### PR TITLE
Dashboard alias resolution + WebSocket startup jitter

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -54,7 +54,9 @@ config :lasso,
   ],
   # Use real HTTP client (Finch) for integration tests
   # (can be overridden in test_helper.exs for unit tests)
-  http_client: Lasso.RPC.Transport.HTTP.Client.Finch
+  http_client: Lasso.RPC.Transport.HTTP.Client.Finch,
+  # Disable WS startup-jitter so tests aren't waiting on rand-uniform delays.
+  ws_startup_jitter_ms: 0
 
 # Configure Phoenix PubSub for testing
 config :lasso, Lasso.PubSub, adapter: Phoenix.PubSub.PG

--- a/lib/lasso/core/transport/websocket/connection.ex
+++ b/lib/lasso/core/transport/websocket/connection.ex
@@ -81,6 +81,12 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   @reconnect_log_threshold 5
   @shared_profile "__shared__"
 
+  # Spread initial WS connection attempts across this window at boot to avoid a
+  # thundering herd of simultaneous handshakes against the same upstream CDN
+  # (Cloudflare in front of most providers will rate-limit a synchronized burst).
+  # Configurable so tests can disable jitter; defaults to 3s in dev/prod.
+  @default_startup_jitter_ms 3_000
+
   # Client API
 
   @doc """
@@ -169,8 +175,21 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
     write_ws_status(state.instance_id, :reconnecting, state.reconnect_attempts)
 
-    # Start the connection process
-    {:ok, state, {:continue, :connect}}
+    # Stagger the initial connection attempt with a random delay so we don't
+    # synchronize with sibling WS connections to the same CDN at boot. When the
+    # jitter window is 0 (e.g. in tests) we connect immediately.
+    case startup_jitter_ms() do
+      0 ->
+        {:ok, state, {:continue, :connect}}
+
+      max ->
+        Process.send_after(self(), :initial_connect, :rand.uniform(max))
+        {:ok, state}
+    end
+  end
+
+  defp startup_jitter_ms do
+    Application.get_env(:lasso, :ws_startup_jitter_ms, @default_startup_jitter_ms)
   end
 
   @doc """
@@ -400,6 +419,8 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   end
 
   @impl true
+  def handle_info(:initial_connect, state), do: handle_continue(:connect, state)
+
   def handle_info({:ws_connected}, state) do
     # NOTE: We intentionally do NOT call signal_recovery here.
     # Recovery is signaled only after the connection proves stable (see {:connection_stable}).

--- a/lib/lasso_web/components/simulator_controls.ex
+++ b/lib/lasso_web/components/simulator_controls.ex
@@ -2,6 +2,7 @@ defmodule LassoWeb.Dashboard.Components.SimulatorControls do
   @moduledoc "LiveView component for dashboard simulator controls."
   use LassoWeb, :live_component
   import LassoWeb.Components.FloatingWindow
+  alias Lasso.Config.ProfileValidator
   alias LassoWeb.Dashboard.Helpers
 
   @impl true
@@ -14,9 +15,9 @@ defmodule LassoWeb.Dashboard.Components.SimulatorControls do
     socket =
       socket
       |> assign(assigns)
-      |> assign_new(:profile_name, fn -> Lasso.Config.ProfileValidator.default_profile() end)
+      |> assign_new(:profile_name, fn -> ProfileValidator.default_profile() end)
       |> assign_new(:rps_limit, fn -> nil end)
-      |> assign_new(:selected_profile, fn -> Lasso.Config.ProfileValidator.default_profile() end)
+      |> assign_new(:selected_profile, fn -> ProfileValidator.default_profile() end)
       |> assign_new(:sim_stats, fn ->
         %{http: %{success: 0, error: 0, avgLatencyMs: 0.0, inflight: 0}, ws: %{open: 0}}
       end)

--- a/lib/lasso_web/dashboard/dashboard.ex
+++ b/lib/lasso_web/dashboard/dashboard.ex
@@ -138,13 +138,26 @@ defmodule LassoWeb.Dashboard do
 
     cond do
       profile = Map.get(params, "profile") ->
-        if profile in profiles, do: profile, else: List.first(profiles)
+        resolve_profile(profile, profiles)
 
       profile = Map.get(session, "selected_profile") ->
-        if profile in profiles, do: profile, else: List.first(profiles)
+        resolve_profile(profile, profiles)
 
       true ->
         List.first(profiles)
+    end
+  end
+
+  # Resolve a requested profile slug to one of the configured profiles, applying
+  # the alias system so legacy slugs like "default" still land on their canonical
+  # target ("public") even after the legacy profile file has been removed.
+  defp resolve_profile(slug, profiles) do
+    canonical = Lasso.Config.ProfileValidator.resolve_alias(slug)
+
+    cond do
+      slug in profiles -> slug
+      canonical in profiles -> canonical
+      true -> List.first(profiles)
     end
   end
 


### PR DESCRIPTION
## Summary

Two follow-up improvements to the recent state-of-OSS audit. Companion to [lasso-cloud#61](https://github.com/jaxernst/lasso-cloud/pull/61).

### 1. Dashboard alias resolution for legacy profile slugs

After [#38](https://github.com/jaxernst/lasso-rpc/pull/38) removed `default.yml`, requests to `/dashboard/default` would silently fall back to `List.first(profiles)` instead of resolving to the canonical `"public"` via the alias system. Bookmarked URLs still work, but UX is unchanged from the user's perspective.

`determine_initial_profile/3` now passes the slug through `ProfileValidator.resolve_alias/1` before the membership check.

Also: clean up `simulator_controls.ex` to use the `ProfileValidator` alias instead of fully-qualifying it at the call site.

### 2. WebSocket startup-jitter

The public profile probes ~30 providers at boot. They were all opening WS connections simultaneously, and most sit behind Cloudflare which rate-limits the synchronized burst — half the initial handshakes return 1015/403, trip circuit breakers, then reconnect on backoff. Visible in cold-boot logs as a wave of "Failed to connect" / "Circuit opened" warnings.

Stagger initial connect calls across a configurable jitter window (`@default_startup_jitter_ms = 3_000`). Reconnects after disconnect already use exponential backoff so this only affects the boot-time burst.

Configurable via `:lasso, :ws_startup_jitter_ms` — set to `0` in `config/test.exs` so the test suite isn't paying rand-uniform delays.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix test --include integration` — **975/975 pass**
- [x] `mix credo --strict` — clean
- [x] Manual: `/dashboard/default` resolves cleanly to public profile data
- [x] Manual: cold boot WS connections now stagger over ~3s instead of all-at-once

## Tradeoff to flag

The jitter means a fresh `mix phx.server` won't have all WS providers connected immediately at boot — first newHeads delivery may take up to 3s longer. In return, fewer flaky failover events and circuit-breaker trips. Set `ws_startup_jitter_ms: 0` to opt out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)