### PR TITLE
Sync profile-isolated routing runtime from lasso-cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Profiles are now loaded exclusively from YAML files in `config/profiles/`; profile slugs are opaque routing IDs, chain aliases resolve to positive integer EIP-155 IDs internally, and `default` remains an alias for `public`
+- Configuration reloads publish a complete new snapshot only after validation; malformed YAML or invalid chain IDs leave the last known-good snapshot active. A cold restart loads profiles from disk before routing begins
+- Dashboard and RPC routes accept both configured chain aliases and decimal chain IDs, while WebSocket startup attempts are jittered to avoid synchronized upstream handshakes
 - Default profile (`config/profiles/default.yml`) removed in favor of the canonical `public` profile; existing `default` slug requests still work via the alias system, eliminating the `Duplicate chain IDs detected across profiles` startup warning
 - `public` profile pruned of broken provider configurations: removed dead WebSocket URLs from LlamaRPC (Ethereum and Base), removed unreachable `arbitrum_meowrpc` (TLS failure), removed `base_sepolia_onfinality` (returns 401 Unauthorized)
 - `.credo.exs` ExSlop checks made conditional, eliminating "Ignoring an undefined check" noise on every credo run

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ curl -sS -X POST 'http://localhost:4000/rpc/ethereum?include_meta=headers' \
 
 Profiles live in `config/profiles/*.yml`. Each profile defines chains, providers, routing policy, and limits. `${ENV_VAR}` substitution is supported (and unresolved placeholders will fail startup).
 
+A profile's YAML `slug` is its routing identity. Treat it as opaque in integrations. Chain routing accepts the configured name (such as `ethereum`) or its decimal EIP-155 ID (such as `1`); Lasso resolves either form to a positive integer internally. The `default` route remains an alias for the included `public` profile.
+
+Reload configuration with `Lasso.Config.ConfigStore.reload/0`. A malformed YAML reload is rejected and the last known-good configuration continues serving requests. On a cold restart, configuration is loaded from the YAML files before routing starts, so ensure required environment variables and profile files are available first.
+
 For the **full configuration reference (all supported options + tuning notes)**, see [`config/profiles/public.yml`](config/profiles/public.yml).
 
 ### Ready to Use: Public Profile

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,7 +16,7 @@ config :lasso, LassoWeb.Endpoint,
 # Options: :fastest, :load_balanced, :latency_weighted
 config :lasso, :provider_selection_strategy, :load_balanced
 
-config :lasso, :profile_aliases, %{"default" => "public", "premium" => "managed"}
+config :lasso, :profile_aliases, %{"default" => "public"}
 
 # Default HTTP client adapter
 config :lasso, :http_client, Lasso.RPC.Transport.HTTP.Client.Finch

--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -21,12 +21,6 @@ defmodule Lasso.Application do
     # TransportRegistry channel cache - enables lockless reads in Selection hot path
     :ets.new(:transport_channel_cache, [:named_table, :public, :set, read_concurrency: true])
 
-    # Profile and chain configuration storage (written by ConfigStore)
-    # Keys: {:profile, slug, :meta}, {:profile, slug, :chains}, {:profile_list}, etc.
-    # Note: :public access is required because ConfigStore GenServer writes to this table
-    # but the table is owned by Application process for stability
-    :ets.new(:lasso_config_store, [:named_table, :public, :set, read_concurrency: true])
-
     # Shared provider instance state (health, circuit, rate limits)
     # Written by ProbeCoordinator, CircuitBreaker, Observability; read by CandidateListing
     :ets.new(:lasso_instance_state, [
@@ -137,11 +131,15 @@ defmodule Lasso.Application do
         # Profile-scoped chain supervisor for (profile, chain) pairs
         Lasso.ProfileChainSupervisor,
 
+        # Stable owners retain ETS snapshots across ConfigStore/Catalog restarts.
+        Lasso.Providers.Catalog.Owner,
+        Lasso.Config.ConfigStore.Owner,
+
         # Start configuration store for centralized config caching
         {Lasso.Config.ConfigStore, get_config_store_opts()},
 
-        # Supervised provider initialization (profiles, catalog, probes, chains)
-        Lasso.ProviderInitializer,
+        # Supervised bootstrap loads profiles and starts shared infrastructure.
+        Lasso.Boot.InfrastructureStarter,
 
         # Start Phoenix endpoint
         LassoWeb.Endpoint,

--- a/lib/lasso/boot/infrastructure_starter.ex
+++ b/lib/lasso/boot/infrastructure_starter.ex
@@ -1,0 +1,321 @@
+defmodule Lasso.Boot.InfrastructureStarter do
+  @moduledoc """
+  Supervised one-shot bootstrap of provider infrastructure.
+
+  Runs profile loading, catalog building, provider validation, and shared
+  infrastructure startup as a supervised step. Failures trigger a retry with
+  exponential backoff; max-retries-exhausted exits with
+  `{:initialization_failed, reason}` so the supervisor restart loop can take
+  over.
+
+  ## Why this is a separate module from `Lasso.Config.ConfigStore`
+
+  `ConfigStore.init/1` must always return `{:ok, state}` so the store can
+  survive degraded backend startup and recover on later reloads. Cold-start
+  validation has different semantics: missing public profiles or unresolved
+  provider URLs should fail the supervised bootstrap step and let the
+  supervisor retry or stop the application.
+
+  The starter calls `ConfigStore.load_all_profiles()`, performs startup
+  validation, then drives the catalog rebuild and supervised process startup
+  through the same paths `inject_profile/1` uses for runtime adds.
+  """
+
+  # Transient: planned shutdown should not trigger a supervisor restart, while
+  # initialization failures still restart through the supervisor.
+  use GenServer, restart: :transient
+  require Logger
+
+  alias Lasso.Config.{ChainConfig, ConfigStore}
+  alias Lasso.Config.ProfileValidator
+  alias Lasso.Providers.{Catalog, InstanceSupervisor, ProbeCoordinator}
+
+  @max_retries 5
+  @base_retry_delay_ms 2_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_opts) do
+    case initialize_with_retries(0) do
+      :ok -> {:ok, %{status: :ready}}
+      {:error, reason} -> {:stop, {:initialization_failed, reason}}
+    end
+  end
+
+  defp initialize_with_retries(attempt) when attempt >= @max_retries do
+    Logger.error("Provider initialization failed after #{@max_retries} attempts")
+    {:error, :max_retries_exceeded}
+  end
+
+  defp initialize_with_retries(attempt) do
+    case do_initialize() do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        delay = @base_retry_delay_ms * Integer.pow(2, attempt)
+
+        Logger.warning(
+          "Provider initialization failed (attempt #{attempt + 1}), retrying in #{delay}ms: #{inspect(reason)}"
+        )
+
+        :timer.sleep(delay)
+        initialize_with_retries(attempt + 1)
+    end
+  end
+
+  defp do_initialize do
+    with {:ok, profile_slugs} <- load_profiles(),
+         :ok <- validate_public_profile(),
+         :ok <- validate_provider_urls(profile_slugs),
+         :ok <- build_catalog(),
+         :ok <- start_shared_infrastructure() do
+      start_all_chains()
+    end
+  end
+
+  defp load_profiles do
+    case ConfigStore.load_all_profiles() do
+      {:ok, profile_slugs} ->
+        Logger.info("Loaded #{length(profile_slugs)} profiles: #{Enum.join(profile_slugs, ", ")}")
+
+        {:ok, profile_slugs}
+
+      {:error, reason} ->
+        Logger.warning("Failed to load profiles: #{inspect(reason)}")
+        {:error, {:load_profiles, reason}}
+    end
+  end
+
+  defp validate_public_profile do
+    case ProfileValidator.validate("public") do
+      {:ok, _} ->
+        Logger.info("Startup validation passed: 'public' profile found")
+        :ok
+
+      {:error, _type, message} ->
+        Logger.error("STARTUP FAILURE: #{message}")
+        Logger.error("The 'public' profile must be configured at startup")
+        Logger.error("Ensure config/profiles/public.yml exists and is valid")
+        {:error, {:public_profile_missing, message}}
+    end
+  end
+
+  defp validate_provider_urls(profile_slugs) do
+    profile_slugs
+    |> Enum.flat_map(&collect_profile_validation_errors/1)
+    |> case do
+      [] ->
+        Logger.info("Startup validation passed: all provider URLs resolved")
+        :ok
+
+      errors ->
+        log_validation_errors(errors)
+        {:error, {:unresolved_env_vars, length(errors)}}
+    end
+  end
+
+  defp build_catalog do
+    Catalog.build_from_config()
+
+    Logger.info("Provider catalog built: #{Catalog.instance_count()} unique instances")
+
+    :ok
+  end
+
+  defp start_shared_infrastructure do
+    instance_ids = Catalog.list_all_instance_ids()
+
+    instance_failures =
+      Enum.reduce(instance_ids, 0, fn instance_id, failures ->
+        case DynamicSupervisor.start_child(
+               Lasso.Providers.InstanceDynamicSupervisor,
+               {InstanceSupervisor, instance_id}
+             ) do
+          {:ok, _} ->
+            failures
+
+          {:error, {:already_started, _}} ->
+            failures
+
+          {:error, reason} ->
+            Logger.warning(
+              "Failed to start InstanceSupervisor for #{instance_id}: #{inspect(reason)}"
+            )
+
+            failures + 1
+        end
+      end)
+
+    cond do
+      instance_ids == [] ->
+        Logger.info("No instances configured - skipping instance supervisor startup")
+        :ok
+
+      instance_failures == length(instance_ids) ->
+        {:error, :all_instance_supervisors_failed}
+
+      true ->
+        Logger.info(
+          "Started #{length(instance_ids) - instance_failures}/#{length(instance_ids)} instance supervisors"
+        )
+
+        start_probe_coordinators_and_block_sync()
+    end
+  end
+
+  defp start_probe_coordinators_and_block_sync do
+    chains =
+      ConfigStore.list_profiles()
+      |> Enum.flat_map(&ConfigStore.list_chains_for_profile/1)
+      |> Enum.uniq()
+
+    probe_failures =
+      Enum.reduce(chains, 0, fn chain, failures ->
+        case DynamicSupervisor.start_child(
+               Lasso.Providers.ProbeSupervisor,
+               {ProbeCoordinator, chain}
+             ) do
+          {:ok, _} ->
+            failures
+
+          {:error, {:already_started, _}} ->
+            failures
+
+          {:error, reason} ->
+            Logger.warning("Failed to start ProbeCoordinator for #{chain}: #{inspect(reason)}")
+            failures + 1
+        end
+      end)
+
+    cond do
+      chains == [] ->
+        :ok
+
+      probe_failures == length(chains) ->
+        {:error, :all_probe_coordinators_failed}
+
+      true ->
+        Logger.info(
+          "Started #{length(chains) - probe_failures}/#{length(chains)} probe coordinators"
+        )
+
+        for chain <- chains do
+          Lasso.BlockSync.Initializer.start_workers_for_chain(chain)
+        end
+
+        Logger.info("Started BlockSync workers for #{length(chains)} chains")
+        :ok
+    end
+  end
+
+  defp start_all_chains do
+    profiles = ConfigStore.list_profiles()
+
+    if Enum.empty?(profiles) do
+      Logger.warning("No profiles loaded - skipping chain startup")
+      :ok
+    else
+      results =
+        Enum.flat_map(profiles, fn profile ->
+          case ConfigStore.get_profile_chains(profile) do
+            {:ok, chains} ->
+              Enum.map(chains, fn {chain_id, chain_config} ->
+                result = start_profile_chain(profile, chain_id, chain_config)
+                {profile, chain_id, result}
+              end)
+
+            {:error, :not_found} ->
+              Logger.warning("Profile #{profile} not found during chain startup")
+              []
+          end
+        end)
+
+      successful_count =
+        results
+        |> Enum.filter(fn {_, _, result} -> match?({:ok, _}, result) end)
+        |> length()
+
+      cond do
+        results == [] ->
+          Logger.info("No chains configured - starting in minimal mode")
+          :ok
+
+        successful_count == 0 ->
+          {:error, :no_chains_started}
+
+        true ->
+          Logger.info("Started #{successful_count}/#{length(results)} chain supervisors")
+          :ok
+      end
+    end
+  end
+
+  defp start_profile_chain(profile, chain_id, chain_config) do
+    case ChainConfig.validate_chain_config(chain_config) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "Chain #{chain_id} validation failed for profile #{profile}: #{inspect(reason)}"
+        )
+    end
+
+    result = Lasso.ProfileChainSupervisor.start_profile_chain(profile, chain_id, chain_config)
+
+    case result do
+      {:ok, _pid} ->
+        Logger.info("Started chain supervisor: #{profile}/#{chain_id}")
+
+      {:error, reason} ->
+        Logger.error(
+          "Failed to start chain supervisor: #{profile}/#{chain_id} - #{inspect(reason)}"
+        )
+    end
+
+    result
+  end
+
+  defp collect_profile_validation_errors(profile) do
+    case ConfigStore.get_profile_chains(profile) do
+      {:ok, chains} ->
+        Enum.flat_map(chains, fn {chain_name, chain_config} ->
+          case ChainConfig.validate_no_unresolved_placeholders(chain_config) do
+            :ok -> []
+            {:error, {:unresolved_env_vars, providers}} -> [{profile, chain_name, providers}]
+          end
+        end)
+
+      _ ->
+        []
+    end
+  end
+
+  defp log_validation_errors(errors) do
+    Logger.error("""
+    STARTUP FAILURE: Unresolved environment variables in provider configuration
+
+    #{format_validation_errors(errors)}
+
+    Please ensure all required environment variables are set in your .env file or system environment.
+    """)
+  end
+
+  defp format_validation_errors(errors) do
+    Enum.map_join(errors, "\n\n", fn {profile, chain, providers} ->
+      "Profile '#{profile}', Chain '#{chain}':\n#{format_provider_issues(providers)}"
+    end)
+  end
+
+  defp format_provider_issues(providers) do
+    Enum.map_join(providers, "\n", fn {provider_id, issues} ->
+      issue_list = Enum.map_join(issues, "\n", fn {type, url} -> "    - #{type}: #{url}" end)
+      "  Provider '#{provider_id}':\n#{issue_list}"
+    end)
+  end
+end

--- a/lib/lasso/chain_supervisor.ex
+++ b/lib/lasso/chain_supervisor.ex
@@ -26,7 +26,7 @@ defmodule Lasso.RPC.ChainSupervisor do
 
   alias Lasso.BlockSync
   alias Lasso.Core.Streaming.{ClientSubscriptionRegistry, UpstreamSubscriptionPool}
-  alias Lasso.Providers.{Catalog, InstanceState}
+  alias Lasso.Providers.{Catalog, InstanceState, ProbeCoordinator}
   alias Lasso.RPC.Transport.WebSocket.Connection, as: WSConnection
   alias Lasso.RPC.TransportRegistry
 
@@ -115,15 +115,23 @@ defmodule Lasso.RPC.ChainSupervisor do
          ) do
       :ok ->
         Catalog.build_from_config()
-        instance_id = Catalog.lookup_instance_id(profile, chain_id, provider_config.id)
 
-        if instance_id do
-          start_instance_supervisor(instance_id)
-          BlockSync.Supervisor.start_worker(chain_id, instance_id)
-          Lasso.Providers.ProbeCoordinator.reload_instances(chain_id)
+        case Catalog.lookup_instance_id(profile, chain_id, provider_config.id) do
+          instance_id when is_binary(instance_id) ->
+            if Map.get(provider_config, :__mock__) == true do
+              :ok
+            else
+              with :ok <- start_instance_supervisor(instance_id),
+                   :ok <- ensure_probe_coordinator(chain_id),
+                   :ok <- start_block_sync_worker(chain_id, instance_id) do
+                ProbeCoordinator.reload_instances(chain_id)
+                :ok
+              end
+            end
+
+          nil ->
+            {:error, :catalog_registration_failed}
         end
-
-        :ok
 
       {:error, reason} = error ->
         Logger.error(
@@ -166,7 +174,11 @@ defmodule Lasso.RPC.ChainSupervisor do
       InstanceState.clear(instance_id)
     end
 
-    Lasso.Providers.ProbeCoordinator.reload_instances(chain_id)
+    if Catalog.list_instances_for_chain(chain_id) == [] do
+      stop_probe_coordinator(chain_id)
+    else
+      ProbeCoordinator.reload_instances(chain_id)
+    end
 
     Logger.info("Successfully removed provider #{provider_id} from chain #{chain_id}")
     :ok
@@ -199,14 +211,51 @@ defmodule Lasso.RPC.ChainSupervisor do
     end
   end
 
+  defp start_block_sync_worker(chain_id, instance_id) do
+    case BlockSync.Supervisor.start_worker(chain_id, instance_id) do
+      {:ok, _pid} -> :ok
+      {:error, reason} -> {:error, {:block_sync_start_failed, reason}}
+    end
+  end
+
+  defp stop_probe_coordinator(chain_id) do
+    case GenServer.whereis(ProbeCoordinator.via_name(chain_id)) do
+      nil ->
+        :ok
+
+      pid ->
+        case DynamicSupervisor.terminate_child(Lasso.Providers.ProbeSupervisor, pid) do
+          :ok -> :ok
+          {:error, :not_found} -> :ok
+        end
+    end
+  end
+
+  defp ensure_probe_coordinator(chain_id) do
+    case DynamicSupervisor.start_child(
+           Lasso.Providers.ProbeSupervisor,
+           {ProbeCoordinator, chain_id}
+         ) do
+      {:ok, _pid} -> :ok
+      {:error, {:already_started, _pid}} -> :ok
+      {:error, reason} -> {:error, {:probe_coordinator_start_failed, reason}}
+    end
+  end
+
   defp start_instance_supervisor(instance_id) do
     case DynamicSupervisor.start_child(
            Lasso.Providers.InstanceDynamicSupervisor,
            {Lasso.Providers.InstanceSupervisor, instance_id}
          ) do
-      {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
-      {:error, reason} -> Logger.warning("Failed to start InstanceSupervisor: #{inspect(reason)}")
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Failed to start InstanceSupervisor: #{inspect(reason)}")
+        {:error, {:instance_supervisor_start_failed, reason}}
     end
   end
 

--- a/lib/lasso/chain_supervisor.ex
+++ b/lib/lasso/chain_supervisor.ex
@@ -2,14 +2,14 @@ defmodule Lasso.RPC.ChainSupervisor do
   @moduledoc """
   Profile-scoped supervisor for RPC provider connections on a single blockchain.
 
-  Manages profile-scoped runtime for a specific (profile, chain) pair.
+  Manages profile-scoped runtime for a specific (profile, chain_id) pair.
   Multiple profiles can use the same chain with independent policy/selection
   and shared provider infrastructure.
 
   ## Architecture
 
   ```
-  ChainSupervisor {profile, chain}
+  ChainSupervisor {profile, chain_id}
   ├── TransportRegistry (Transport Channel Management)
   ├── ClientSubscriptionRegistry
   ├── UpstreamSubscriptionPool
@@ -30,19 +30,21 @@ defmodule Lasso.RPC.ChainSupervisor do
   alias Lasso.RPC.Transport.WebSocket.Connection, as: WSConnection
   alias Lasso.RPC.TransportRegistry
 
-  @spec start_link({String.t(), String.t(), map()}) :: Supervisor.on_start()
-  def start_link({profile, chain_name, chain_config}) do
-    Supervisor.start_link(__MODULE__, {profile, chain_name, chain_config},
-      name: via_name(profile, chain_name)
+  @spec start_link({String.t(), pos_integer(), map()}) :: Supervisor.on_start()
+  def start_link({profile, chain_id, chain_config})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    Supervisor.start_link(__MODULE__, {profile, chain_id, chain_config},
+      name: via_name(profile, chain_id)
     )
   end
 
   @doc """
   Gets the status of all providers for a chain from ETS.
   """
-  @spec get_chain_status(String.t(), String.t()) :: map()
-  def get_chain_status(profile, chain_name) do
-    profile_providers = Catalog.get_profile_providers(profile, chain_name)
+  @spec get_chain_status(String.t(), pos_integer()) :: map()
+  def get_chain_status(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    profile_providers = Catalog.get_profile_providers(profile, chain_id)
 
     providers =
       Enum.map(profile_providers, fn pp ->
@@ -77,10 +79,10 @@ defmodule Lasso.RPC.ChainSupervisor do
 
     healthy_count = Enum.count(providers, &(&1.status == :healthy))
 
-    ws_connections = collect_ws_connection_status(profile, chain_name, providers)
+    ws_connections = collect_ws_connection_status(profile, chain_id, providers)
 
     %{
-      chain_name: chain_name,
+      chain_id: chain_id,
       total_providers: length(providers),
       healthy_providers: healthy_count,
       active_providers: length(providers),
@@ -92,38 +94,40 @@ defmodule Lasso.RPC.ChainSupervisor do
   @doc """
   Gets active provider connections for a chain.
   """
-  @spec get_active_providers(String.t(), String.t()) :: [String.t()]
-  def get_active_providers(profile, chain_name) do
-    Catalog.get_profile_providers(profile, chain_name)
+  @spec get_active_providers(String.t(), pos_integer()) :: [String.t()]
+  def get_active_providers(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    Catalog.get_profile_providers(profile, chain_id)
     |> Enum.map(& &1.provider_id)
   end
 
   @doc """
   Dynamically adds a provider to a running chain supervisor.
   """
-  @spec ensure_provider(String.t(), String.t(), map(), keyword()) :: :ok | {:error, term()}
-  def ensure_provider(profile, chain_name, provider_config, _opts \\ []) do
+  @spec ensure_provider(String.t(), pos_integer(), map(), keyword()) :: :ok | {:error, term()}
+  def ensure_provider(profile, chain_id, provider_config, _opts \\ [])
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
     case TransportRegistry.initialize_provider_channels(
            profile,
-           chain_name,
+           chain_id,
            provider_config.id,
            provider_config
          ) do
       :ok ->
         Catalog.build_from_config()
-        instance_id = Catalog.lookup_instance_id(profile, chain_name, provider_config.id)
+        instance_id = Catalog.lookup_instance_id(profile, chain_id, provider_config.id)
 
         if instance_id do
           start_instance_supervisor(instance_id)
-          BlockSync.Supervisor.start_worker(chain_name, instance_id)
-          Lasso.Providers.ProbeCoordinator.reload_instances(chain_name)
+          BlockSync.Supervisor.start_worker(chain_id, instance_id)
+          Lasso.Providers.ProbeCoordinator.reload_instances(chain_id)
         end
 
         :ok
 
       {:error, reason} = error ->
         Logger.error(
-          "Failed to add provider #{provider_config.id} to #{chain_name}: #{inspect(reason)}"
+          "Failed to add provider #{provider_config.id} to chain #{chain_id}: #{inspect(reason)}"
         )
 
         error
@@ -133,39 +137,50 @@ defmodule Lasso.RPC.ChainSupervisor do
   @doc """
   Removes a provider from a running chain supervisor.
   """
-  @spec remove_provider(String.t(), String.t(), String.t()) :: :ok | {:error, term()}
-  def remove_provider(profile, chain_name, provider_id) do
-    # Resolve instance_id BEFORE rebuilding catalog
-    instance_id = Catalog.lookup_instance_id(profile, chain_name, provider_id)
+  @spec remove_provider(String.t(), pos_integer(), String.t()) :: :ok | {:error, term()}
+  def remove_provider(profile, chain_id, provider_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    remove_provider(
+      profile,
+      chain_id,
+      provider_id,
+      Catalog.lookup_instance_id(profile, chain_id, provider_id)
+    )
+  end
 
-    TransportRegistry.close_channel(profile, chain_name, provider_id, :http)
-    TransportRegistry.close_channel(profile, chain_name, provider_id, :ws)
+  @spec remove_provider(String.t(), pos_integer(), String.t(), String.t() | nil) ::
+          :ok | {:error, term()}
+  def remove_provider(profile, chain_id, provider_id, instance_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    TransportRegistry.close_channel(profile, chain_id, provider_id, :http)
+    TransportRegistry.close_channel(profile, chain_id, provider_id, :ws)
 
+    # The ConfigStore mutation has already completed. Rebuilding now makes the
+    # removed provider unavailable to routing before shared-instance cleanup
+    # decides whether its physical state is still referenced by another profile.
     Catalog.build_from_config()
 
-    if instance_id do
-      remaining_refs = Catalog.get_instance_refs(instance_id)
-
-      if remaining_refs == [] do
-        BlockSync.Supervisor.stop_worker(chain_name, instance_id)
-      end
+    if instance_id && Catalog.get_instance_refs(instance_id) == [] do
+      BlockSync.Supervisor.stop_worker(chain_id, instance_id)
+      stop_instance_supervisor(instance_id)
+      InstanceState.clear(instance_id)
     end
 
-    Lasso.Providers.ProbeCoordinator.reload_instances(chain_name)
+    Lasso.Providers.ProbeCoordinator.reload_instances(chain_id)
 
-    Logger.info("Successfully removed provider #{provider_id} from #{chain_name}")
+    Logger.info("Successfully removed provider #{provider_id} from chain #{chain_id}")
     :ok
   end
 
   # Supervisor callbacks
 
   @impl true
-  def init({profile, chain_name, chain_config}) do
+  def init({profile, chain_id, chain_config}) do
     children = [
-      {TransportRegistry, {profile, chain_name, chain_config}},
-      {ClientSubscriptionRegistry, {profile, chain_name}},
-      {UpstreamSubscriptionPool, {profile, chain_name}},
-      {Lasso.Core.Streaming.StreamSupervisor, {profile, chain_name}}
+      {TransportRegistry, {profile, chain_id, chain_config}},
+      {ClientSubscriptionRegistry, {profile, chain_id}},
+      {UpstreamSubscriptionPool, {profile, chain_id}},
+      {Lasso.Core.Streaming.StreamSupervisor, {profile, chain_id}}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)
@@ -173,8 +188,15 @@ defmodule Lasso.RPC.ChainSupervisor do
 
   # Private functions
 
-  defp via_name(profile, chain_name) do
-    {:via, Registry, {Lasso.Registry, {:chain_supervisor, profile, chain_name}}}
+  defp via_name(profile, chain_id) do
+    {:via, Registry, {Lasso.Registry, {:chain_supervisor, profile, chain_id}}}
+  end
+
+  defp stop_instance_supervisor(instance_id) do
+    case GenServer.whereis(Lasso.Providers.InstanceSupervisor.via_name(instance_id)) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(Lasso.Providers.InstanceDynamicSupervisor, pid)
+    end
   end
 
   defp start_instance_supervisor(instance_id) do
@@ -188,10 +210,10 @@ defmodule Lasso.RPC.ChainSupervisor do
     end
   end
 
-  defp collect_ws_connection_status(profile, chain, providers) when is_list(providers) do
+  defp collect_ws_connection_status(profile, chain_id, providers) when is_list(providers) do
     Enum.map(providers, fn provider ->
       try do
-        instance_id = Catalog.lookup_instance_id(profile, chain, provider.id)
+        instance_id = Catalog.lookup_instance_id(profile, chain_id, provider.id)
         status = if instance_id, do: WSConnection.status(instance_id), else: %{connected: false}
 
         %{

--- a/lib/lasso/config/backend.ex
+++ b/lib/lasso/config/backend.ex
@@ -7,8 +7,7 @@ defmodule Lasso.Config.Backend do
 
   ## Implementations
 
-  - `Lasso.Config.Backend.File` - File-based YAML profiles (OSS default)
-  - Future: `LassoCloud.Config.Backend.Database` - PostgreSQL-backed profiles (SaaS)
+  - `Lasso.Config.Backend.File` - File-based YAML profiles
 
   ## Profile Specification
 
@@ -18,10 +17,21 @@ defmodule Lasso.Config.Backend do
   - `:chains` - Map of chain_name => chain configuration
   """
 
+  @typedoc """
+  File-backed profile scope. OSS profiles are loaded from YAML and use the
+  single `:system` scope.
+  """
+  @type scope :: :system
+
   @type profile_spec :: %{
-          slug: String.t(),
-          name: String.t(),
-          chains: %{String.t() => map()}
+          required(:scope) => scope(),
+          required(:slug) => String.t(),
+          required(:name) => String.t(),
+          required(:chains) => %{String.t() => map()},
+          optional(:rps_limit) => non_neg_integer(),
+          optional(:burst_limit) => non_neg_integer(),
+          optional(:unlisted) => boolean(),
+          optional(:logo) => String.t() | nil
         }
 
   @type state :: term()
@@ -42,13 +52,19 @@ defmodule Lasso.Config.Backend do
 
   Implementations should fail-fast on the first invalid profile to ensure
   configuration errors are caught at deploy time.
+
+  ## Return values
+
+  - `{:ok, profiles}` — full load succeeded.
+  - `{:error, reason}` — fatal: nothing usable was loaded.
   """
-  @callback load_all(state()) :: {:ok, [profile_spec()]} | {:error, term()}
+  @callback load_all(state()) ::
+              {:ok, [profile_spec()]}
+              | {:degraded, [profile_spec()]}
+              | {:error, term()}
 
   @doc """
-  Load a single profile by slug.
-
-  Returns the profile specification or an error if not found.
+  Load a single system profile by its opaque slug.
   """
   @callback load(state(), slug :: String.t()) ::
               {:ok, profile_spec()} | {:error, :not_found | term()}

--- a/lib/lasso/config/backend/file.ex
+++ b/lib/lasso/config/backend/file.ex
@@ -31,7 +31,7 @@ defmodule Lasso.Config.Backend.File do
 
   - Load all `*.yml` files in `profiles_dir`
   - Skip files starting with `.` or `_` (backups, templates)
-  - Profile slug must match filename (e.g., `premium.yml` must have `slug: premium`)
+  - Profile slug must match filename (e.g., `archive.yml` must have `slug: archive`)
   - **Fail-fast**: First invalid file fails entire load
   """
 
@@ -39,7 +39,7 @@ defmodule Lasso.Config.Backend.File do
 
   require Logger
 
-  alias Lasso.Config.ChainConfig
+  alias Lasso.Config.{ChainConfig, ProfileId}
   alias Lasso.RPC.Providers.Capabilities
 
   @type state :: %{
@@ -86,7 +86,7 @@ defmodule Lasso.Config.Backend.File do
   end
 
   @impl true
-  def load(%{profiles_dir: profiles_dir}, slug) do
+  def load(%{profiles_dir: profiles_dir}, slug) when is_binary(slug) do
     path = Path.join(profiles_dir, "#{slug}.yml")
 
     if File.exists?(path) do
@@ -95,6 +95,8 @@ defmodule Lasso.Config.Backend.File do
       {:error, :not_found}
     end
   end
+
+  def load(_state, _slug), do: {:error, :not_found}
 
   @impl true
   def save(%{profiles_dir: profiles_dir}, slug, yaml) do
@@ -196,6 +198,8 @@ defmodule Lasso.Config.Backend.File do
              {:ok, chains} <- parse_chains_data(chains_data) do
           {:ok,
            %{
+             scope: :system,
+             profile_id: ProfileId.for_system(meta["slug"]),
              slug: meta["slug"],
              name: meta["name"],
              logo: meta["logo"],
@@ -220,6 +224,8 @@ defmodule Lasso.Config.Backend.File do
 
       {:ok,
        %{
+         scope: :system,
+         profile_id: ProfileId.for_system(slug),
          slug: slug,
          name: yaml_data["name"] || "Default Profile",
          logo: nil,
@@ -245,7 +251,8 @@ defmodule Lasso.Config.Backend.File do
   defp parse_chain_config(chain_name, chain_data) do
     %ChainConfig{
       chain_id: chain_data["chain_id"],
-      name: chain_data["name"] || chain_name,
+      display_name: chain_data["name"],
+      url_aliases: parse_url_aliases(chain_name, chain_data),
       block_time_ms: chain_data["block_time_ms"],
       providers: parse_providers(chain_data["providers"] || []),
       selection: parse_selection(chain_data["selection"]),
@@ -266,12 +273,21 @@ defmodule Lasso.Config.Backend.File do
         capabilities: parse_capabilities(provider_data["capabilities"]),
         subscribe_new_heads: parse_subscribe_new_heads(provider_data["subscribe_new_heads"]),
         archival: parse_archival(provider_data["archival"]),
-        sharing_mode: parse_sharing_mode(provider_data["sharing_mode"])
+        sharing_mode: parse_sharing_mode(provider_data["sharing_mode"]),
+        api_key: ChainConfig.substitute_env_vars(provider_data["api_key"]),
+        credentials: provider_data["credentials"],
+        headers: provider_data["headers"],
+        auth_headers: provider_data["auth_headers"]
       }
 
       Capabilities.validate!(provider.id, provider.capabilities)
       provider
     end)
+  end
+
+  defp parse_url_aliases(chain_name, chain_data) do
+    configured = chain_data["url_aliases"] || chain_data["aliases"] || []
+    [chain_name | List.wrap(configured)]
   end
 
   defp parse_subscribe_new_heads(nil), do: nil

--- a/lib/lasso/config/backend/file.ex
+++ b/lib/lasso/config/backend/file.ex
@@ -251,7 +251,8 @@ defmodule Lasso.Config.Backend.File do
   defp parse_chain_config(chain_name, chain_data) do
     %ChainConfig{
       chain_id: chain_data["chain_id"],
-      display_name: chain_data["name"],
+      name: chain_data["name"] || chain_name,
+      display_name: chain_data["name"] || chain_name,
       url_aliases: parse_url_aliases(chain_name, chain_data),
       block_time_ms: chain_data["block_time_ms"],
       providers: parse_providers(chain_data["providers"] || []),
@@ -287,7 +288,7 @@ defmodule Lasso.Config.Backend.File do
 
   defp parse_url_aliases(chain_name, chain_data) do
     configured = chain_data["url_aliases"] || chain_data["aliases"] || []
-    [chain_name | List.wrap(configured)]
+    Enum.uniq([chain_name | List.wrap(configured)])
   end
 
   defp parse_subscribe_new_heads(nil), do: nil
@@ -481,8 +482,8 @@ defmodule Lasso.Config.Backend.File do
     Logger.info("Auto-migrating #{legacy_path} to #{profiles_dir}/public.yml")
 
     with {:ok, content} <- File.read(legacy_path),
-         {:ok, yaml_data} <- YamlElixir.read_from_string(content) do
-      profile_yaml = generate_profile_yaml(yaml_data)
+         {:ok, _yaml_data} <- YamlElixir.read_from_string(content) do
+      profile_yaml = generate_profile_yaml(%{"__raw__" => content})
       target_path = Path.join(profiles_dir, "public.yml")
 
       case File.write(target_path, profile_yaml) do
@@ -499,6 +500,21 @@ defmodule Lasso.Config.Backend.File do
         Logger.error("Failed to read legacy config: #{inspect(reason)}")
         {:error, {:migration_read_failed, reason}}
     end
+  end
+
+  defp legacy_profile_frontmatter do
+    """
+    ---
+    name: Public Providers
+    slug: public
+    rps_limit: 100
+    burst_limit: 500
+    ---
+    """
+  end
+
+  defp generate_profile_yaml(%{"__raw__" => content}) when is_binary(content) do
+    legacy_profile_frontmatter() <> content
   end
 
   defp generate_profile_yaml(yaml_data) do

--- a/lib/lasso/config/chain_alias.ex
+++ b/lib/lasso/config/chain_alias.ex
@@ -1,0 +1,42 @@
+defmodule Lasso.Config.ChainAlias do
+  @moduledoc """
+  Resolves chain presentation at configuration and routing boundaries.
+
+  Loaded profile configuration is authoritative for friendly URL aliases and
+  display names. Every positive chain ID also has its decimal representation as
+  a universal fallback, so arbitrary EVM chains require no source-code change.
+  """
+
+  @spec canonical_slug(pos_integer(), [String.t()]) :: String.t()
+  def canonical_slug(chain_id, configured_aliases \\ [])
+
+  def canonical_slug(chain_id, configured_aliases)
+      when is_integer(chain_id) and chain_id > 0 and is_list(configured_aliases) do
+    Enum.find(configured_aliases, &valid_alias?/1) || Integer.to_string(chain_id)
+  end
+
+  @spec aliases(pos_integer()) :: [String.t()]
+  def aliases(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    [Integer.to_string(chain_id)]
+  end
+
+  @spec display_name(non_neg_integer() | nil, String.t() | nil) :: String.t()
+  def display_name(chain_id, label \\ nil)
+
+  def display_name(chain_id, label) when is_binary(label) do
+    case String.trim(label) do
+      "" -> default_display_name(chain_id)
+      trimmed -> trimmed
+    end
+  end
+
+  def display_name(chain_id, nil), do: default_display_name(chain_id)
+
+  defp valid_alias?(alias_name) when is_binary(alias_name), do: String.trim(alias_name) != ""
+  defp valid_alias?(_), do: false
+
+  defp default_display_name(chain_id) when is_integer(chain_id) and chain_id > 0,
+    do: "Chain #{chain_id}"
+
+  defp default_display_name(_), do: "Unknown chain"
+end

--- a/lib/lasso/config/chain_config.ex
+++ b/lib/lasso/config/chain_config.ex
@@ -10,6 +10,7 @@ defmodule Lasso.Config.ChainConfig do
 
   @type t :: %__MODULE__{
           chain_id: pos_integer() | nil,
+          name: String.t() | nil,
           display_name: String.t() | nil,
           url_aliases: [String.t()],
           block_time_ms: non_neg_integer() | nil,
@@ -22,6 +23,7 @@ defmodule Lasso.Config.ChainConfig do
 
   defstruct [
     :chain_id,
+    :name,
     :display_name,
     :block_time_ms,
     :providers,

--- a/lib/lasso/config/chain_config.ex
+++ b/lib/lasso/config/chain_config.ex
@@ -9,8 +9,9 @@ defmodule Lasso.Config.ChainConfig do
   require Logger
 
   @type t :: %__MODULE__{
-          chain_id: non_neg_integer() | nil,
-          name: String.t(),
+          chain_id: pos_integer() | nil,
+          display_name: String.t() | nil,
+          url_aliases: [String.t()],
           block_time_ms: non_neg_integer() | nil,
           providers: [__MODULE__.Provider.t()],
           selection: __MODULE__.Selection.t() | nil,
@@ -21,18 +22,37 @@ defmodule Lasso.Config.ChainConfig do
 
   defstruct [
     :chain_id,
-    :name,
+    :display_name,
     :block_time_ms,
     :providers,
     :selection,
     :monitoring,
     :websocket,
-    :topology
+    :topology,
+    url_aliases: []
   ]
 
   defmodule Provider do
-    @moduledoc "Configuration for an RPC provider."
-    @derive Jason.Encoder
+    @moduledoc """
+    Configuration for an RPC provider.
+
+    URL fields are treated as sensitive — `Inspect` is derived with
+    `:url` and `:ws_url` excluded so they don't leak through
+    `Logger.inspect`, crash dumps, or LiveDashboard.
+    """
+    @derive {Jason.Encoder,
+             only: [
+               :id,
+               :name,
+               :priority,
+               :url,
+               :ws_url,
+               :capabilities,
+               :subscribe_new_heads,
+               :archival,
+               :sharing_mode
+             ]}
+    @derive {Inspect, except: [:url, :ws_url, :api_key, :credentials, :headers, :auth_headers]}
     @type t :: %__MODULE__{
             id: String.t(),
             name: String.t(),
@@ -42,7 +62,11 @@ defmodule Lasso.Config.ChainConfig do
             capabilities: map() | nil,
             subscribe_new_heads: boolean() | nil,
             archival: boolean(),
-            sharing_mode: :auto | :isolated
+            sharing_mode: :auto | :isolated,
+            api_key: String.t() | nil,
+            credentials: term(),
+            headers: map() | [{String.t(), String.t()}] | nil,
+            auth_headers: map() | [{String.t(), String.t()}] | nil
           }
 
     defstruct [
@@ -53,6 +77,10 @@ defmodule Lasso.Config.ChainConfig do
       :ws_url,
       :capabilities,
       :subscribe_new_heads,
+      :api_key,
+      :credentials,
+      :headers,
+      :auth_headers,
       :__mock__,
       archival: true,
       sharing_mode: :auto
@@ -153,7 +181,7 @@ defmodule Lasso.Config.ChainConfig do
             lag_alert_threshold_blocks: non_neg_integer()
           }
 
-    defstruct probe_interval_ms: 15_000,
+    defstruct probe_interval_ms: 12_000,
               lag_alert_threshold_blocks: 3
   end
 

--- a/lib/lasso/config/config_store.ex
+++ b/lib/lasso/config/config_store.ex
@@ -5,16 +5,21 @@ defmodule Lasso.Config.ConfigStore do
 
   ## Multi-Profile Architecture
 
-  Profiles are the top-level isolation boundary. Each profile contains its own
-  set of chains and providers with independent configuration. The ETS table
-  (owned by Application process) uses the following key structure:
+  Profiles are the top-level isolation boundary. Each profile is keyed
+  internally by an opaque `profile_id`. File-backed system profiles use their
+  slug itself (for example, `"public"`). Scope is retained only for Backend
+  compatibility and is always `:system` in OSS.
 
-  - `{:profile, slug, :meta}` -> Profile metadata
-  - `{:profile, slug, :chains}` -> `%{chain_name => ChainConfig.t()}`
-  - `{:profile_list}` -> List of all profile slugs
-  - `{:chain_profiles, chain}` -> List of profiles containing this chain
-  - `{:all_chains}` -> Union of all chain names across all profiles
-  - `{:chain_id_index}` -> `%{chain_id => chain_name}` for cross-profile lookups
+  The ETS table (owned by Application process) uses the following key
+  structure:
+
+  - `{:profile, profile_id, :meta}` -> Profile metadata
+  - `{:profile, profile_id, :chains}` -> `%{chain_id :: pos_integer() => ChainConfig.t()}`
+  - `{:resolve, scope, slug}` -> profile_id (resolution index — same table,
+    same atomic swap, never observed independently)
+  - `{:profile_list}` -> List of all profile_ids
+  - `{:chain_profiles, chain_id}` -> List of profile_ids containing this chain
+  - `{:all_chain_ids}` -> Union of all chain_ids (integers) across all profiles
 
   ## Configuration Backend
 
@@ -28,20 +33,39 @@ defmodule Lasso.Config.ConfigStore do
   alias Lasso.Config.Backend
   alias Lasso.Config.ChainConfig
   alias Lasso.Config.ChainConfig.Provider
+  alias Lasso.Config.ConfigStore.Owner
+  alias Lasso.Config.ProfileMeta
 
-  @config_table :lasso_config_store
+  @persistent_term_key :lasso_config_store_active
   @default_profile Lasso.Config.ProfileValidator.default_profile()
 
-  ## Profile Metadata Type
+  # CONCURRENCY-2: how long the OLD ETS table sticks around after the
+  # persistent_term swap. Any request that captured the old table
+  # reference BEFORE the swap (via `table/0`) and then runs `:ets.lookup`
+  # AFTER the delete fires raises ArgumentError; `safe_lookup/1`
+  # silently rescues to `[]`, which downstream is "chain not found".
+  #
+  # The grace window must comfortably exceed the longest in-flight
+  # `:ets.lookup` chain on the request path. Lookups are O(1), but
+  # the time between `table/0` capture and the actual lookup includes
+  # any work the request does in between (Plug pipeline, JSON-RPC parse,
+  # provider selection iteration). Under load with bursts of reloads,
+  # 2s left a measurable spurious-not-found tail.
+  #
+  # 30s is well past any realistic request lifecycle. The cost is
+  # holding the old ETS table in memory for an extra 28s — bounded
+  # by the reload rate and table size (current scale: ~80 instances
+  # × ~100 profiles, sub-megabyte).
+  @grace_period_ms 30_000
+  @resolve_or_load_timeout_ms 5_000
 
-  @type profile_meta :: %{
-          slug: String.t(),
-          name: String.t(),
-          logo: String.t() | nil,
-          rps_limit: pos_integer(),
-          burst_limit: pos_integer(),
-          unlisted: boolean()
-        }
+  ## Types
+
+  @type profile_id :: String.t()
+  @type scope :: :system
+  @type profile_meta :: ProfileMeta.t()
+
+  defp table, do: :persistent_term.get(@persistent_term_key)
 
   ## Public API - Profile Operations
 
@@ -61,103 +85,288 @@ defmodule Lasso.Config.ConfigStore do
   Loads all profiles from the configured backend.
 
   This should be called AFTER the supervision tree is started to avoid
-  circular dependencies. Returns the list of loaded profile slugs.
+  circular dependencies. Returns the list of loaded profile_ids.
   """
-  @spec load_all_profiles() :: {:ok, [String.t()]} | {:error, term()}
+  @spec load_all_profiles() :: {:ok, [profile_id()]} | {:error, term()}
   def load_all_profiles do
     GenServer.call(__MODULE__, :load_all_profiles, :infinity)
   end
 
   @doc """
-  Lists all loaded profile slugs.
+  Lists all loaded profile_ids.
+
+  For file-backed profiles `profile_id == slug`. Use
+  `list_profile_summaries/1` for display data.
   """
-  @spec list_profiles() :: [String.t()]
+  @spec list_profiles() :: [profile_id()]
   def list_profiles do
-    case :ets.lookup(@config_table, {:profile_list}) do
+    case safe_lookup({:profile_list}) do
       [{{:profile_list}, profiles}] -> profiles
-      [] -> []
+      _ -> []
     end
   end
 
   @doc """
-  Gets profile metadata by slug.
+  Resolves `(scope, slug)` to an opaque `profile_id`.
+
+  This is the single resolution boundary: callers that hold a
+  user-facing slug pair it with the request's scope here, then thread
+  the returned `profile_id` through the rest of the system.
   """
-  @spec get_profile(String.t()) :: {:ok, profile_meta()} | {:error, :not_found}
-  def get_profile(slug) do
-    case :ets.lookup(@config_table, {:profile, slug, :meta}) do
-      [{{:profile, ^slug, :meta}, meta}] -> {:ok, meta}
-      [] -> {:error, :not_found}
+  @spec resolve(scope(), String.t()) :: {:ok, profile_id()} | {:error, :not_found}
+  def resolve(:system, slug) when is_binary(slug) do
+    case safe_lookup({:resolve, :system, slug}) do
+      [{{:resolve, :system, ^slug}, profile_id}] -> {:ok, profile_id}
+      _ -> {:error, :not_found}
     end
   end
 
   @doc """
-  Gets chain configuration for a specific profile and chain.
+  Resolves a slug for an OSS request. The optional first argument is retained
+  as a compatibility façade and is ignored because YAML profiles have one
+  system scope.
   """
-  @spec get_chain(String.t(), String.t()) :: {:ok, ChainConfig.t()} | {:error, :not_found}
-  def get_chain(profile, chain_name) when is_binary(profile) and is_binary(chain_name) do
-    case :ets.lookup(@config_table, {:profile, profile, :chains}) do
-      [{{:profile, ^profile, :chains}, chains}] ->
-        case Map.get(chains, chain_name) do
+  @spec resolve_for_request(term(), String.t()) :: {:ok, profile_id()} | {:error, :not_found}
+  def resolve_for_request(_context, slug) when is_binary(slug), do: resolve(:system, slug)
+
+  @doc """
+  Resolves `(scope, slug)` and loads it from the configured backend on a miss.
+
+  `ConfigStore` is the runtime cache; the configured backend is authoritative
+  for profiles that are not yet present in the local ETS table. This helper is
+  intentionally scope-based so callers do not need to know how the file
+  backend is configured.
+  """
+  @spec resolve_or_load(scope(), String.t()) ::
+          {:ok, profile_id(), profile_meta()}
+          | {:error, :not_found | {:load_failed, term()} | {:inject_failed, term()}}
+  def resolve_or_load(:system, slug) when is_binary(slug) do
+    case resolve_with_meta(:system, slug) do
+      {:ok, _profile_id, _meta} = ok ->
+        ok
+
+      {:error, :not_found} ->
+        timeout =
+          Application.get_env(
+            :lasso,
+            :config_store_resolve_or_load_timeout_ms,
+            @resolve_or_load_timeout_ms
+          )
+
+        try do
+          GenServer.call(__MODULE__, {:resolve_or_load, :system, slug}, timeout)
+        catch
+          :exit, {:timeout, _} -> {:error, {:load_failed, :timeout}}
+          :exit, reason -> {:error, {:load_failed, reason}}
+        end
+    end
+  end
+
+  @doc """
+  Gets profile metadata by `profile_id`.
+  """
+  @spec get_profile(profile_id()) :: {:ok, profile_meta()} | {:error, :not_found}
+  def get_profile(profile_id) do
+    case safe_lookup({:profile, profile_id, :meta}) do
+      [{{:profile, ^profile_id, :meta}, meta}] -> {:ok, meta}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Gets chain configuration for a specific `profile_id` and chain.
+
+  Accepts either a `pos_integer()` chain_id (primary path) or a binary
+  identifier (resolved via `lookup_chain_id_in_profile/2` for the
+  rehydrate/migration window only).
+  """
+  @spec get_chain(profile_id(), pos_integer() | String.t()) ::
+          {:ok, ChainConfig.t()} | {:error, :not_found}
+  def get_chain(profile_id, chain_id)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    case safe_lookup({:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] ->
+        case Map.get(chains, chain_id) do
           nil -> {:error, :not_found}
           chain_config -> {:ok, chain_config}
         end
 
-      [] ->
+      _ ->
         {:error, :not_found}
     end
   end
 
-  @doc """
-  Lists all chains for a specific profile.
-  """
-  @spec list_chains_for_profile(String.t()) :: [String.t()]
-  def list_chains_for_profile(profile) do
-    case :ets.lookup(@config_table, {:profile, profile, :chains}) do
-      [{{:profile, ^profile, :chains}, chains}] -> Map.keys(chains)
-      [] -> []
+  def get_chain(profile_id, chain_identifier)
+      when is_binary(profile_id) and is_binary(chain_identifier) do
+    case lookup_chain_id_in_profile(profile_id, chain_identifier) do
+      {:ok, chain_id} -> get_chain(profile_id, chain_id)
+      :not_found -> {:error, :not_found}
     end
   end
 
   @doc """
-  Lists all chain names (union across all profiles).
+  Resolves a chain slug or decimal string to a `chain_id` for a profile.
+
+  Parses exact decimal chain IDs before matching aliases from the loaded profile
+  configuration. Returns `{:ok, chain_id}` or `:not_found`.
   """
-  @spec list_chains() :: [String.t()]
-  def list_chains do
-    case :ets.lookup(@config_table, {:all_chains}) do
-      [{{:all_chains}, chains}] -> chains
-      [] -> []
+  @spec lookup_chain_id_in_profile(profile_id(), String.t()) ::
+          {:ok, pos_integer()} | :not_found
+  def lookup_chain_id_in_profile(profile_id, chain_identifier)
+      when is_binary(profile_id) and is_binary(chain_identifier) do
+    case safe_lookup({:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] ->
+        resolve_chain_identifier(chains, chain_identifier)
+
+      _ ->
+        :not_found
     end
   end
 
   @doc """
-  Lists profiles that contain a specific chain.
+  Returns true when the profile contains a chain with the given `chain_id`.
   """
-  @spec list_profiles_for_chain(String.t()) :: [String.t()]
-  def list_profiles_for_chain(chain_name) do
-    case :ets.lookup(@config_table, {:chain_profiles, chain_name}) do
-      [{{:chain_profiles, ^chain_name}, profiles}] -> profiles
-      [] -> []
+  @spec profile_has_chain?(profile_id(), pos_integer()) :: boolean()
+  def profile_has_chain?(profile_id, chain_id)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    case safe_lookup({:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] -> Map.has_key?(chains, chain_id)
+      _ -> false
+    end
+  end
+
+  defp resolve_chain_identifier(chains, identifier) do
+    case Integer.parse(identifier) do
+      {id, ""} when is_map_key(chains, id) ->
+        {:ok, id}
+
+      _ ->
+        case Enum.find(chains, fn {_chain_id, cc} ->
+               identifier in Map.get(cc, :url_aliases, [])
+             end) do
+          {chain_id, _cc} -> {:ok, chain_id}
+          nil -> :not_found
+        end
     end
   end
 
   @doc """
-  Gets all chains for a profile as a map.
+  Lists all profile IDs in the file-backed `:system` scope.
   """
-  @spec get_profile_chains(String.t()) ::
-          {:ok, %{String.t() => ChainConfig.t()}} | {:error, :not_found}
-  def get_profile_chains(profile) do
-    case :ets.lookup(@config_table, {:profile, profile, :chains}) do
-      [{{:profile, ^profile, :chains}, chains}] -> {:ok, chains}
-      [] -> {:error, :not_found}
+  @spec list_profile_ids_for_scope(scope()) :: [profile_id()]
+  def list_profile_ids_for_scope(:system) do
+    scope = :system
+
+    case table() do
+      nil ->
+        []
+
+      t ->
+        try do
+          :ets.match(t, {{:resolve, scope, :"$1"}, :"$2"})
+          |> Enum.map(fn [_slug, profile_id] -> profile_id end)
+        rescue
+          ArgumentError -> []
+        end
     end
   end
 
   @doc """
-  Gets all chains for the default profile as a map.
+  Returns display-ready profile summaries for the given scope.
+
+  Each summary carries `profile_id` (machine identity) plus the
+  user-facing `slug`, `name`, `logo`, and `unlisted` fields — sufficient
+  for dashboards and selectors without forcing them to translate
+  `profile_id` back to a slug.
+  """
+  @spec list_profile_summaries(scope()) :: [
+          %{
+            profile_id: profile_id(),
+            slug: String.t(),
+            name: String.t(),
+            logo: String.t() | nil,
+            unlisted: boolean()
+          }
+        ]
+  def list_profile_summaries(:system) do
+    scope = :system
+
+    scope
+    |> list_profile_ids_for_scope()
+    |> Enum.flat_map(fn profile_id ->
+      case get_profile(profile_id) do
+        {:ok, meta} ->
+          [
+            %{
+              profile_id: profile_id,
+              slug: meta.slug,
+              name: meta.name,
+              logo: meta.logo,
+              unlisted: meta.unlisted
+            }
+          ]
+
+        {:error, :not_found} ->
+          []
+      end
+    end)
+  end
+
+  @doc """
+  Lists all chain_ids for a specific `profile_id`.
+  """
+  @spec list_chains_for_profile(profile_id()) :: [pos_integer()]
+  def list_chains_for_profile(profile_id) do
+    case safe_lookup({:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] -> Map.keys(chains)
+      _ -> []
+    end
+  end
+
+  @doc """
+  Lists all chain_ids (union across all profiles).
+  """
+  @spec list_chain_ids() :: [pos_integer()]
+  def list_chain_ids do
+    case safe_lookup({:all_chain_ids}) do
+      [{{:all_chain_ids}, chain_ids}] -> chain_ids
+      _ -> []
+    end
+  end
+
+  @doc "Compatibility alias for callers that predate integer chain runtime keys."
+  @spec list_chains() :: [pos_integer()]
+  def list_chains, do: list_chain_ids()
+
+  @doc """
+  Lists profile_ids that contain a specific chain.
+  """
+  @spec list_profiles_for_chain(pos_integer()) :: [profile_id()]
+  def list_profiles_for_chain(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    case safe_lookup({:chain_profiles, chain_id}) do
+      [{{:chain_profiles, ^chain_id}, profiles}] -> profiles
+      _ -> []
+    end
+  end
+
+  @doc """
+  Gets all chains for a `profile_id` as a map keyed by `chain_id`.
+  """
+  @spec get_profile_chains(profile_id()) ::
+          {:ok, %{pos_integer() => ChainConfig.t()}} | {:error, :not_found}
+  def get_profile_chains(profile_id) do
+    case safe_lookup({:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] -> {:ok, chains}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  @doc """
+  Gets all chains for the default profile as a map keyed by `chain_id`.
 
   Used for cross-profile operations like chain ID lookups.
   """
-  @spec get_all_chains() :: %{String.t() => ChainConfig.t()}
+  @spec get_all_chains() :: %{pos_integer() => ChainConfig.t()}
   def get_all_chains do
     case get_profile_chains(@default_profile) do
       {:ok, chains} -> chains
@@ -166,13 +375,13 @@ defmodule Lasso.Config.ConfigStore do
   end
 
   @doc """
-  Gets provider configuration for a specific profile, chain, and provider.
+  Gets provider configuration for a specific `profile_id`, chain, and provider.
   """
-  @spec get_provider(String.t(), String.t(), String.t()) ::
+  @spec get_provider(profile_id(), pos_integer(), String.t()) ::
           {:ok, Provider.t()} | {:error, :not_found}
-  def get_provider(profile, chain_name, provider_id)
-      when is_binary(profile) and is_binary(chain_name) and is_binary(provider_id) do
-    with {:ok, chain_config} <- get_chain(profile, chain_name) do
+  def get_provider(profile_id, chain_id, provider_id)
+      when is_binary(profile_id) and is_integer(chain_id) and is_binary(provider_id) do
+    with {:ok, chain_config} <- get_chain(profile_id, chain_id) do
       case Enum.find(chain_config.providers, &(&1.id == provider_id)) do
         nil -> {:error, :not_found}
         provider -> {:ok, provider}
@@ -181,92 +390,108 @@ defmodule Lasso.Config.ConfigStore do
   end
 
   @doc """
-  Gets all providers for a specific profile and chain.
+  Gets all providers for a specific `profile_id` and chain.
   """
-  @spec get_providers(String.t(), String.t()) :: {:ok, [Provider.t()]} | {:error, :not_found}
-  def get_providers(profile, chain_name) when is_binary(profile) and is_binary(chain_name) do
-    case get_chain(profile, chain_name) do
+  @spec get_providers(profile_id(), pos_integer()) :: {:ok, [Provider.t()]} | {:error, :not_found}
+  def get_providers(profile_id, chain_id)
+      when is_binary(profile_id) and is_integer(chain_id) do
+    case get_chain(profile_id, chain_id) do
       {:ok, chain_config} -> {:ok, chain_config.providers}
       error -> error
     end
   end
 
+  def get_providers(profile_id, chain_identifier)
+      when is_binary(profile_id) and is_binary(chain_identifier) do
+    case lookup_chain_id_in_profile(profile_id, chain_identifier) do
+      {:ok, chain_id} -> get_providers(profile_id, chain_id)
+      :not_found -> {:error, :not_found}
+    end
+  end
+
   @doc """
-  Gets all provider IDs for a profile and chain.
+  Gets all provider IDs for a `profile_id` and chain.
   """
-  @spec get_provider_ids(String.t(), String.t()) :: [String.t()]
-  def get_provider_ids(profile, chain_name) do
-    case get_chain(profile, chain_name) do
+  @spec get_provider_ids(profile_id(), pos_integer()) :: [String.t()]
+  def get_provider_ids(profile_id, chain_id) when is_integer(chain_id) do
+    case get_chain(profile_id, chain_id) do
       {:ok, chain_config} -> Enum.map(chain_config.providers, & &1.id)
       {:error, :not_found} -> []
     end
   end
 
-  @doc """
-  Find the canonical chain name for a numeric chain ID.
-
-  Returns the chain name from the chain_id index without loading the full config.
-  The index prefers "public" profile when multiple profiles define the same chain_id.
-
-  ## Examples
-
-      find_chain_name_by_id(1)  # Returns {:ok, "ethereum"} if chain_id 1 maps to ethereum
-
-  Note: This does NOT return chain configuration, only the name mapping.
-  Callers should verify the chain exists in their target profile separately.
-  """
-  @spec find_chain_name_by_id(integer()) :: {:ok, String.t()} | {:error, :not_found}
-  def find_chain_name_by_id(chain_id) when is_integer(chain_id) do
-    case :ets.lookup(@config_table, {:chain_id_index}) do
-      [{{:chain_id_index}, id_index}] ->
-        case Map.get(id_index, chain_id) do
-          nil -> {:error, :not_found}
-          chain_name -> {:ok, chain_name}
-        end
-
-      [] ->
-        {:error, :not_found}
-    end
-  end
-
-  ## Public API - Chain ID Lookups
-
   ## Public API - Runtime Registration (for tests)
 
   @doc """
-  Registers a chain configuration in-memory for a profile (runtime only, not persisted).
+  Registers a chain configuration in-memory for a `profile_id` (runtime only, not persisted).
   """
-  @spec register_chain_runtime(String.t(), String.t(), map()) :: :ok | {:error, term()}
-  def register_chain_runtime(profile, chain_name, chain_attrs)
-      when is_binary(profile) and is_binary(chain_name) do
-    GenServer.call(__MODULE__, {:register_chain_runtime, profile, chain_name, chain_attrs})
+  @spec register_chain_runtime(profile_id(), pos_integer(), map()) :: :ok | {:error, term()}
+  def register_chain_runtime(profile_id, chain_id, chain_attrs)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(__MODULE__, {:register_chain_runtime, profile_id, chain_id, chain_attrs})
+  end
+
+  def register_chain_runtime(profile_id, _legacy_alias, %{chain_id: chain_id} = chain_attrs)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    register_chain_runtime(profile_id, chain_id, chain_attrs)
   end
 
   @doc """
-  Unregisters a chain from in-memory configuration for a profile (runtime only).
+  Unregisters a chain from in-memory configuration for a `profile_id` (runtime only).
   """
-  @spec unregister_chain_runtime(String.t(), String.t()) :: :ok | {:error, term()}
-  def unregister_chain_runtime(profile, chain_name)
-      when is_binary(profile) and is_binary(chain_name) do
-    GenServer.call(__MODULE__, {:unregister_chain_runtime, profile, chain_name})
+  @spec unregister_chain_runtime(profile_id(), pos_integer()) :: :ok | {:error, term()}
+  def unregister_chain_runtime(profile_id, chain_id)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(__MODULE__, {:unregister_chain_runtime, profile_id, chain_id})
+  end
+
+  def unregister_chain_runtime(profile_id, legacy_alias)
+      when is_binary(profile_id) and is_binary(legacy_alias) do
+    case lookup_chain_id_in_profile(profile_id, legacy_alias) do
+      {:ok, chain_id} -> unregister_chain_runtime(profile_id, chain_id)
+      :not_found -> {:error, :chain_not_found}
+    end
   end
 
   @doc """
-  Registers a provider configuration in-memory for a profile (runtime only).
+  Registers a provider configuration in-memory for a `profile_id` (runtime only).
   """
-  @spec register_provider_runtime(String.t(), String.t(), map()) :: :ok | {:error, term()}
-  def register_provider_runtime(profile, chain_name, provider_attrs)
-      when is_binary(profile) and is_binary(chain_name) do
-    GenServer.call(__MODULE__, {:register_provider_runtime, profile, chain_name, provider_attrs})
+  @spec register_provider_runtime(profile_id(), pos_integer(), map()) :: :ok | {:error, term()}
+  def register_provider_runtime(profile_id, chain_id, provider_attrs)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(
+      __MODULE__,
+      {:register_provider_runtime, profile_id, chain_id, provider_attrs}
+    )
+  end
+
+  def register_provider_runtime(profile_id, legacy_alias, provider_attrs)
+      when is_binary(profile_id) and is_binary(legacy_alias) do
+    case lookup_chain_id_in_profile(profile_id, legacy_alias) do
+      {:ok, chain_id} -> register_provider_runtime(profile_id, chain_id, provider_attrs)
+      :not_found -> {:error, :chain_not_found}
+    end
   end
 
   @doc """
-  Unregisters a provider from in-memory configuration for a profile (runtime only).
+  Unregisters a provider from in-memory configuration for a `profile_id` (runtime only).
   """
-  @spec unregister_provider_runtime(String.t(), String.t(), String.t()) :: :ok | {:error, term()}
-  def unregister_provider_runtime(profile, chain_name, provider_id)
-      when is_binary(profile) and is_binary(chain_name) and is_binary(provider_id) do
-    GenServer.call(__MODULE__, {:unregister_provider_runtime, profile, chain_name, provider_id})
+  @spec unregister_provider_runtime(profile_id(), pos_integer(), String.t()) ::
+          :ok | {:error, term()}
+  def unregister_provider_runtime(profile_id, chain_id, provider_id)
+      when is_binary(profile_id) and is_integer(chain_id) and is_binary(provider_id) do
+    GenServer.call(
+      __MODULE__,
+      {:unregister_provider_runtime, profile_id, chain_id, provider_id}
+    )
+  end
+
+  def unregister_provider_runtime(profile_id, legacy_alias, provider_id)
+      when is_binary(profile_id) and is_binary(legacy_alias) and is_binary(provider_id) do
+    case lookup_chain_id_in_profile(profile_id, legacy_alias) do
+      {:ok, chain_id} -> unregister_provider_runtime(profile_id, chain_id, provider_id)
+      :not_found -> {:error, :chain_not_found}
+    end
   end
 
   @doc """
@@ -275,6 +500,45 @@ defmodule Lasso.Config.ConfigStore do
   @spec reload() :: :ok | {:error, term()}
   def reload do
     GenServer.call(__MODULE__, :reload, :infinity)
+  end
+
+  @doc """
+  Injects a single profile into ConfigStore with full infrastructure setup.
+
+  Writes to ETS, rebuilds Catalog, starts InstanceSupervisors and
+  ProbeCoordinators for the new profile. Used for immediate activation
+  after a runtime configuration update.
+  """
+  @spec inject_profile(map()) :: :ok | {:error, term()}
+  def inject_profile(profile_spec) do
+    GenServer.call(__MODULE__, {:inject_profile, profile_spec}, :infinity)
+  end
+
+  @doc """
+  Updates an existing profile in ConfigStore with targeted ETS update.
+
+  Overwrites profile data, rebuilds indices for changed chains, and
+  reconciles shared infrastructure (Catalog, InstanceSupervisors,
+  ProbeCoordinators, BlockSync workers).
+  """
+  @spec update_profile(map()) :: :ok | {:error, term()}
+  def update_profile(profile_spec) do
+    GenServer.call(__MODULE__, {:update_profile, profile_spec}, :infinity)
+  end
+
+  @doc """
+  Removes a profile from ConfigStore and tears down its infrastructure.
+
+  Rebuilds Catalog before deleting ConfigStore entries so the routing
+  layer stops seeing the profile's providers before the profile itself
+  disappears from resolution.
+
+  Takes `profile_id`. Callers that hold a slug must call `resolve/2`
+  first.
+  """
+  @spec remove_profile(profile_id()) :: :ok | {:error, term()}
+  def remove_profile(profile_id) when is_binary(profile_id) do
+    GenServer.call(__MODULE__, {:remove_profile, profile_id}, :infinity)
   end
 
   @doc """
@@ -289,18 +553,21 @@ defmodule Lasso.Config.ConfigStore do
 
   @impl true
   def init(opts) do
-    # ETS table is owned by Application - we just use it
-    # Note: We don't load profiles here to avoid circular dependencies
-    # Profile loading happens via load_all_profiles/0 after supervision tree starts
-
-    # Parse options - support both legacy path and new config
+    # Profile loading happens after init; this process only tracks retry state.
     {backend_module, backend_config} = parse_backend_opts(opts)
 
     state = %{
       backend_module: backend_module,
       backend_config: backend_config,
       backend_state: nil,
-      last_loaded: nil
+      last_loaded: nil,
+      retry_interval_ms:
+        retry_opt(opts, :retry_interval_ms, :config_store_retry_interval_ms, 30_000),
+      retry_timer: nil,
+      retry_task_ref: nil,
+      retry_task_snapshot: nil,
+      db_degraded: false,
+      last_good_specs: snapshot_profile_specs()
     }
 
     {:ok, state}
@@ -310,50 +577,95 @@ defmodule Lasso.Config.ConfigStore do
   def handle_call(:load_all_profiles, _from, state) do
     case do_load_all_profiles(state) do
       {:ok, profiles, new_state} ->
-        {:reply, {:ok, profiles}, new_state}
+        {:reply, {:ok, profiles}, %{new_state | db_degraded: false}}
+
+      {:degraded, profiles, new_state} ->
+        Logger.warning("Initial configuration load was degraded; scheduling retry")
+
+        {:reply, {:ok, profiles}, schedule_retry(%{new_state | db_degraded: true})}
 
       {:error, reason} ->
-        {:reply, {:error, reason}, state}
+        # Keep retrying boot-time load errors.
+        Logger.error("Initial load failed: #{inspect(reason)}; scheduling retry")
+        {:reply, {:error, reason}, schedule_retry(%{state | db_degraded: true})}
     end
   end
 
   @impl true
   def handle_call(:reload, _from, state) do
-    case do_load_all_profiles(state) do
-      {:ok, _profiles, new_state} ->
+    # Capture prior chain state so removed chains are reconciled correctly.
+    old_pairs = collect_profile_chain_pairs()
+    old_chain_ids = list_chain_ids()
+    old_endpoints = snapshot_all_chain_endpoints()
+
+    case do_load_all_profiles(state, preserve_current_ets_on_degraded?: true) do
+      {:ok, profiles, new_state} ->
         Logger.info("Configuration reloaded successfully")
-        rebuild_shared_infrastructure()
-        {:reply, :ok, new_state}
+        rebuild_shared_infrastructure(old_chain_ids)
+        sync_chain_supervisors(old_pairs)
+        reconcile_transport_channels_all(old_endpoints)
+        Enum.each(profiles, &broadcast_profile_updated/1)
+        {:reply, :ok, %{new_state | db_degraded: false}}
+
+      {:degraded, _profiles, new_state} ->
+        # Keep serving the last good snapshot and retry in the background.
+        Logger.warning("Skipping degraded reload; preserving cached profiles")
+
+        {:reply, {:error, :degraded}, schedule_retry(%{new_state | db_degraded: true})}
 
       {:error, reason} ->
         Logger.error("Failed to reload configuration: #{inspect(reason)}")
-        {:reply, {:error, reason}, state}
+        {:reply, {:error, reason}, schedule_retry(%{state | db_degraded: true})}
     end
   end
 
   @impl true
-  def handle_call({:register_chain_runtime, profile, chain_name, chain_attrs}, _from, state) do
-    # Use GenServer serialization to make check-then-act atomic
-    case get_chain(profile, chain_name) do
+  def handle_call({:inject_profile, profile_spec}, _from, state) do
+    reply = do_inject_profile(profile_spec)
+    {:reply, reply, refresh_last_good_specs(state, reply)}
+  end
+
+  @impl true
+  def handle_call({:resolve_or_load, scope, slug}, _from, state) do
+    {reply, new_state} = do_resolve_or_load(scope, slug, state)
+    {:reply, reply, new_state}
+  end
+
+  @impl true
+  def handle_call({:update_profile, profile_spec}, _from, state) do
+    reply = do_update_profile(profile_spec)
+    {:reply, reply, refresh_last_good_specs(state, reply)}
+  end
+
+  @impl true
+  def handle_call({:remove_profile, profile_id}, _from, state) do
+    reply = do_remove_profile(profile_id)
+    {:reply, reply, refresh_last_good_specs(state, reply)}
+  end
+
+  @impl true
+  def handle_call({:register_chain_runtime, profile_id, chain_id, chain_attrs}, _from, state) do
+    case get_chain(profile_id, chain_id) do
       {:ok, _existing} ->
         {:reply, {:error, :already_exists}, state}
 
       {:error, :not_found} ->
-        chain_config = normalize_chain_config(chain_name, chain_attrs)
-        add_chain_to_profile(profile, chain_name, chain_config)
-        update_chain_id_index(chain_name, chain_config)
-        Logger.debug("Registered chain #{chain_name} in profile #{profile} (runtime)")
-        {:reply, :ok, state}
+        ensure_profile_in_list(profile_id)
+        chain_config = normalize_chain_config(chain_id, chain_attrs)
+        add_chain_to_profile(profile_id, chain_id, chain_config)
+        Logger.debug("Registered chain #{chain_id} in profile #{profile_id} (runtime)")
+        {:reply, :ok, refresh_last_good_specs(state, :ok)}
     end
   end
 
   @impl true
-  def handle_call({:unregister_chain_runtime, profile, chain_name}, _from, state) do
-    case get_chain(profile, chain_name) do
+  def handle_call({:unregister_chain_runtime, profile_id, chain_id}, _from, state) do
+    case get_chain(profile_id, chain_id) do
       {:ok, _chain_config} ->
-        remove_chain_from_profile(profile, chain_name)
-        Logger.debug("Unregistered chain #{chain_name} from profile #{profile} (runtime)")
-        {:reply, :ok, state}
+        remove_chain_from_profile(profile_id, chain_id)
+        maybe_remove_profile_from_list(profile_id)
+        Logger.debug("Unregistered chain #{chain_id} from profile #{profile_id} (runtime)")
+        {:reply, :ok, refresh_last_good_specs(state, :ok)}
 
       {:error, :not_found} ->
         {:reply, {:error, :chain_not_found}, state}
@@ -361,18 +673,22 @@ defmodule Lasso.Config.ConfigStore do
   end
 
   @impl true
-  def handle_call({:register_provider_runtime, profile, chain_name, provider_attrs}, _from, state) do
-    with {:ok, chain_config} <- get_chain(profile, chain_name),
+  def handle_call(
+        {:register_provider_runtime, profile_id, chain_id, provider_attrs},
+        _from,
+        state
+      ) do
+    with {:ok, chain_config} <- get_chain(profile_id, chain_id),
          provider_config <- normalize_provider_config(provider_attrs),
          :ok <- validate_provider_not_exists(chain_config, provider_config.id) do
       updated_chain = add_provider_to_chain(chain_config, provider_config)
-      update_chain_in_profile(profile, chain_name, updated_chain)
+      update_chain_in_profile(profile_id, chain_id, updated_chain)
 
       Logger.debug(
-        "Registered provider #{provider_config.id} for #{chain_name} in profile #{profile} (runtime)"
+        "Registered provider #{provider_config.id} for chain #{chain_id} in profile #{profile_id} (runtime)"
       )
 
-      {:reply, :ok, state}
+      {:reply, :ok, refresh_last_good_specs(state, :ok)}
     else
       {:error, :not_found} -> {:reply, {:error, :chain_not_found}, state}
       {:error, :already_exists} -> {:reply, {:error, :already_exists}, state}
@@ -380,16 +696,20 @@ defmodule Lasso.Config.ConfigStore do
   end
 
   @impl true
-  def handle_call({:unregister_provider_runtime, profile, chain_name, provider_id}, _from, state) do
-    with {:ok, chain_config} <- get_chain(profile, chain_name),
+  def handle_call(
+        {:unregister_provider_runtime, profile_id, chain_id, provider_id},
+        _from,
+        state
+      ) do
+    with {:ok, chain_config} <- get_chain(profile_id, chain_id),
          {:ok, updated_chain} <- remove_provider_from_chain(chain_config, provider_id) do
-      update_chain_in_profile(profile, chain_name, updated_chain)
+      update_chain_in_profile(profile_id, chain_id, updated_chain)
 
       Logger.debug(
-        "Unregistered provider #{provider_id} from #{chain_name} in profile #{profile} (runtime)"
+        "Unregistered provider #{provider_id} from chain #{chain_id} in profile #{profile_id} (runtime)"
       )
 
-      {:reply, :ok, state}
+      {:reply, :ok, refresh_last_good_specs(state, :ok)}
     else
       {:error, :not_found} -> {:reply, {:error, :chain_not_found}, state}
       {:error, :provider_not_found} -> {:reply, {:error, :provider_not_found}, state}
@@ -399,16 +719,16 @@ defmodule Lasso.Config.ConfigStore do
   @impl true
   def handle_call(:status, _from, state) do
     profiles = list_profiles()
-    chains = list_chains()
+    chain_ids = list_chain_ids()
 
     total_providers =
       profiles
-      |> Enum.flat_map(fn profile ->
-        list_chains_for_profile(profile)
-        |> Enum.map(fn chain -> {profile, chain} end)
+      |> Enum.flat_map(fn profile_id ->
+        list_chains_for_profile(profile_id)
+        |> Enum.map(fn chain_id -> {profile_id, chain_id} end)
       end)
-      |> Enum.map(fn {profile, chain} ->
-        case get_chain(profile, chain) do
+      |> Enum.map(fn {profile_id, chain_id} ->
+        case get_chain(profile_id, chain_id) do
           {:ok, config} -> length(config.providers)
           _ -> 0
         end
@@ -417,7 +737,7 @@ defmodule Lasso.Config.ConfigStore do
 
     status = %{
       profiles_loaded: length(profiles),
-      chains_loaded: length(chains),
+      chains_loaded: length(chain_ids),
       total_providers: total_providers,
       last_loaded: state.last_loaded,
       backend: state.backend_module
@@ -426,7 +746,411 @@ defmodule Lasso.Config.ConfigStore do
     {:reply, status, state}
   end
 
+  # Old ETS tables published via persistent_term are deleted from inside
+  # the GenServer — `:ets.delete/1` requires the calling process to be
+  # the table owner, which only this process is.
+  @impl true
+  def handle_info({:config_store_owner_restarted, _owner}, state) do
+    case state.last_good_specs do
+      specs when is_list(specs) ->
+        populate_ets(specs)
+        Logger.info("ConfigStore republished its last good snapshot after Owner restart")
+
+      nil ->
+        Logger.warning(
+          "ConfigStore Owner restarted before a configuration snapshot was available"
+        )
+    end
+
+    {:noreply, state}
+  rescue
+    e ->
+      Logger.error("ConfigStore could not republish snapshot after Owner restart: #{inspect(e)}")
+      {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:delete_old_table, table}, state) do
+    try do
+      :ets.delete(table)
+    rescue
+      ArgumentError -> :ok
+    end
+
+    {:noreply, state}
+  end
+
+  # Degraded-mode recovery runs backend load in a Task so the GenServer mailbox
+  # stays responsive. Snapshot bounds removals to avoid evicting profiles that
+  # were injected while the Task was running.
+  @impl true
+  def handle_info(:retry_eager_load, state) do
+    state = %{state | retry_timer: nil}
+
+    if state.retry_task_ref do
+      # A prior retry task is still in flight; defer.
+      Logger.debug("ConfigStore retry: prior retry task still running, re-scheduling")
+      {:noreply, schedule_retry(state)}
+    else
+      case ensure_backend_initialized(state) do
+        {:ok, backend_state} ->
+          backend_module = state.backend_module
+
+          task =
+            Task.Supervisor.async_nolink(Lasso.TaskSupervisor, fn ->
+              backend_module.load_all(backend_state)
+            end)
+
+          snapshot = current_file_profile_ids()
+
+          {:noreply,
+           %{
+             state
+             | backend_state: backend_state,
+               retry_task_ref: task.ref,
+               retry_task_snapshot: snapshot
+           }}
+
+        {:error, reason} ->
+          Logger.warning("ConfigStore retry: backend init failed, will retry: #{inspect(reason)}")
+          {:noreply, schedule_retry(%{state | db_degraded: true})}
+      end
+    end
+  end
+
+  # Apply retry-task results as deltas against current ETS state.
+  @impl true
+  def handle_info({ref, result}, state) when ref == state.retry_task_ref do
+    Process.demonitor(ref, [:flush])
+    snapshot = state.retry_task_snapshot
+    state = %{state | retry_task_ref: nil, retry_task_snapshot: nil}
+
+    case result do
+      {:ok, specs} ->
+        Logger.info("ConfigStore: retry succeeded, exiting degraded mode")
+        apply_retry_deltas(specs, snapshot)
+        {:noreply, %{state | db_degraded: false, last_loaded: DateTime.utc_now()}}
+
+      {:degraded, _specs} ->
+        Logger.debug("ConfigStore: retry still degraded, will retry")
+        {:noreply, schedule_retry(state)}
+
+      {:error, reason} ->
+        Logger.warning("ConfigStore retry: backend error, will retry: #{inspect(reason)}")
+        {:noreply, schedule_retry(state)}
+    end
+  end
+
+  # Retry task crashed before completing; re-arm timer.
+  @impl true
+  def handle_info({:DOWN, ref, :process, _pid, reason}, state)
+      when ref == state.retry_task_ref do
+    Logger.warning("ConfigStore retry task crashed: #{inspect(reason)}")
+    {:noreply, schedule_retry(%{state | retry_task_ref: nil, retry_task_snapshot: nil})}
+  end
+
   ## Private Functions
+
+  # Inject a profile end-to-end.
+  defp do_resolve_or_load(scope, slug, state) do
+    case resolve_with_meta(scope, slug) do
+      {:ok, _profile_id, _meta} = ok ->
+        {ok, state}
+
+      {:error, :not_found} ->
+        case ensure_backend_initialized(state) do
+          {:ok, backend_state} ->
+            state = %{state | backend_state: backend_state}
+
+            reply =
+              case safe_backend_load(state.backend_module, backend_state, scope, slug) do
+                {:ok, profile_spec} ->
+                  case do_inject_profile(profile_spec) do
+                    :ok -> resolve_with_meta(scope, slug)
+                    {:error, reason} -> {:error, {:inject_failed, normalize_failure(reason)}}
+                  end
+
+                {:error, :not_found} ->
+                  {:error, :not_found}
+
+                {:error, {:load_failed, reason}} ->
+                  {:error, {:load_failed, reason}}
+
+                {:error, reason} ->
+                  {:error, {:load_failed, normalize_failure(reason)}}
+              end
+
+            {reply, state}
+
+          {:error, reason} ->
+            {{:error, {:load_failed, reason}}, state}
+        end
+    end
+  end
+
+  defp safe_backend_load(backend_module, backend_state, _scope, slug) do
+    backend_module.load(backend_state, slug)
+  rescue
+    e -> {:error, {:load_failed, normalize_failure(e)}}
+  catch
+    kind, reason -> {:error, {:load_failed, {kind, normalize_failure(reason)}}}
+  end
+
+  defp normalize_failure(reason) when is_atom(reason), do: reason
+  defp normalize_failure(reason) when is_binary(reason), do: reason
+
+  defp normalize_failure(%{__struct__: module} = reason) do
+    if is_exception(reason) do
+      {module, Exception.message(reason)}
+    else
+      inspect(reason)
+    end
+  end
+
+  defp normalize_failure(reason), do: inspect(reason)
+
+  defp do_inject_profile(profile_spec) do
+    with :ok <- validate_profile_spec(profile_spec) do
+      do_inject_profile_validated(profile_spec)
+    end
+  end
+
+  defp do_inject_profile_validated(profile_spec) do
+    profile_id = profile_spec.profile_id
+
+    Logger.info(
+      "Injecting profile into ConfigStore",
+      Lasso.Logging.profile_metadata(profile_spec)
+    )
+
+    store_profile(profile_spec)
+
+    update_indices_for_inject(profile_spec)
+
+    # Inject path uses post-mutation chain_ids.
+    rebuild_shared_infrastructure(list_chain_ids())
+
+    start_profile_chain_supervisors(profile_id)
+
+    notify_inject()
+    broadcast_profile_updated(profile_id)
+
+    :ok
+  rescue
+    e ->
+      Logger.error("Failed to inject profile: #{inspect(e)}")
+      {:error, e}
+  end
+
+  defp do_update_profile(profile_spec) do
+    with :ok <- validate_profile_spec(profile_spec) do
+      do_update_profile_validated(profile_spec)
+    end
+  end
+
+  defp do_update_profile_validated(profile_spec) do
+    profile_id = profile_spec.profile_id
+
+    case get_profile(profile_id) do
+      {:error, :not_found} ->
+        {:error, :profile_not_found}
+
+      {:ok, old_meta} ->
+        Logger.info(
+          "Updating profile in ConfigStore",
+          Lasso.Logging.profile_metadata(profile_spec)
+        )
+
+        old_pairs = collect_profile_chain_pairs()
+        old_chain_ids = list_chain_ids()
+        old_profile_chains = list_chains_for_profile(profile_id)
+        old_chain_configs = snapshot_profile_chain_configs(profile_id, old_profile_chains)
+
+        store_profile(profile_spec)
+        delete_stale_resolve_entry(old_meta, profile_spec)
+        rebuild_indices_for_profile(profile_id, old_profile_chains, profile_spec)
+        rebuild_shared_infrastructure(old_chain_ids)
+        sync_chain_supervisors(old_pairs)
+        reconcile_transport_channels(profile_id, old_chain_configs, profile_spec)
+        notify_inject()
+        broadcast_profile_updated(profile_id)
+
+        :ok
+    end
+  rescue
+    e ->
+      Logger.error("Failed to update profile: #{inspect(e)}")
+      {:error, e}
+  end
+
+  defp do_remove_profile(profile_id) do
+    case get_profile(profile_id) do
+      {:error, :not_found} ->
+        {:error, :profile_not_found}
+
+      {:ok, meta} ->
+        Logger.info(
+          "Removing profile from ConfigStore",
+          Lasso.Logging.profile_metadata(meta)
+        )
+
+        old_pairs = collect_profile_chain_pairs()
+        old_chain_ids = list_chain_ids()
+
+        publish_profile_removal(profile_id, meta)
+
+        rebuild_shared_infrastructure(old_chain_ids)
+        sync_chain_supervisors(old_pairs)
+        notify_inject()
+        broadcast_profile_updated(profile_id)
+
+        :ok
+    end
+  rescue
+    e ->
+      Logger.error("Failed to remove profile: #{inspect(e)}")
+      {:error, e}
+  end
+
+  # Schedule eager-load retry and spread retries across nodes with jitter.
+  defp schedule_retry(%{retry_timer: prior, retry_interval_ms: ms} = state) do
+    if prior, do: Process.cancel_timer(prior)
+    delay = ms + jitter(ms)
+    timer = Process.send_after(self(), :retry_eager_load, delay)
+    %{state | retry_timer: timer}
+  end
+
+  defp jitter(ms) do
+    span = max(div(ms, 7), 1)
+    :rand.uniform(2 * span) - span
+  end
+
+  # Apply a completed retry as deltas. Snapshot bounds removals so runtime
+  # updates made while the backend read was running are preserved.
+  defp apply_retry_deltas(loaded_specs, spawn_snapshot) do
+    spawn_snapshot = spawn_snapshot || MapSet.new()
+    loaded_by_id = Map.new(loaded_specs, &{&1.profile_id, &1})
+    loaded_ids = MapSet.new(Map.keys(loaded_by_id))
+
+    current_ids = current_file_profile_ids()
+
+    to_remove =
+      spawn_snapshot
+      |> MapSet.intersection(current_ids)
+      |> MapSet.difference(loaded_ids)
+
+    old_pairs = collect_profile_chain_pairs()
+    old_chain_ids = list_chain_ids()
+
+    changed_profile_ids =
+      Enum.flat_map(loaded_specs, fn spec ->
+        result =
+          if MapSet.member?(current_ids, spec.profile_id) do
+            do_update_profile_without_rebuild(spec)
+          else
+            do_inject_profile_without_rebuild(spec)
+          end
+
+        case result do
+          :ok -> [spec.profile_id]
+          _ -> []
+        end
+      end)
+
+    removed_profile_ids =
+      Enum.flat_map(to_remove, fn profile_id ->
+        case do_remove_profile_without_rebuild(profile_id) do
+          :ok -> [profile_id]
+          _ -> []
+        end
+      end)
+
+    changed_ids = changed_profile_ids ++ removed_profile_ids
+
+    if changed_ids != [] do
+      rebuild_shared_infrastructure(old_chain_ids)
+      sync_chain_supervisors(old_pairs)
+      notify_inject()
+      Enum.each(changed_ids, &broadcast_profile_updated/1)
+    end
+
+    :ok
+  end
+
+  defp do_inject_profile_without_rebuild(profile_spec) do
+    Logger.info(
+      "Injecting profile into ConfigStore",
+      Lasso.Logging.profile_metadata(profile_spec)
+    )
+
+    store_profile(profile_spec)
+    update_indices_for_inject(profile_spec)
+
+    :ok
+  rescue
+    e ->
+      Logger.error("Failed to inject profile: #{inspect(e)}")
+      {:error, e}
+  end
+
+  defp do_update_profile_without_rebuild(profile_spec) do
+    profile_id = profile_spec.profile_id
+
+    case get_profile(profile_id) do
+      {:error, :not_found} ->
+        {:error, :profile_not_found}
+
+      {:ok, old_meta} ->
+        Logger.info(
+          "Updating profile in ConfigStore",
+          Lasso.Logging.profile_metadata(profile_spec)
+        )
+
+        old_profile_chains = list_chains_for_profile(profile_id)
+
+        store_profile(profile_spec)
+        delete_stale_resolve_entry(old_meta, profile_spec)
+        rebuild_indices_for_profile(profile_id, old_profile_chains, profile_spec)
+
+        :ok
+    end
+  rescue
+    e ->
+      Logger.error("Failed to update profile: #{inspect(e)}")
+      {:error, e}
+  end
+
+  defp do_remove_profile_without_rebuild(profile_id) do
+    case get_profile(profile_id) do
+      {:error, :not_found} ->
+        {:error, :profile_not_found}
+
+      {:ok, meta} ->
+        Logger.info(
+          "Removing profile from ConfigStore",
+          Lasso.Logging.profile_metadata(meta)
+        )
+
+        publish_profile_removal(profile_id, meta)
+
+        :ok
+    end
+  rescue
+    e ->
+      Logger.error("Failed to remove profile: #{inspect(e)}")
+      {:error, e}
+  end
+
+  # Set of file-backed profile IDs currently in ETS.
+  defp current_file_profile_ids, do: list_profiles() |> MapSet.new()
+
+  # Resolution order: keyword option -> app env -> default.
+  defp retry_opt(opts, key, app_key, default) do
+    case Keyword.fetch(opts, key) do
+      {:ok, value} -> value
+      :error -> Application.get_env(:lasso, app_key, default)
+    end
+  end
 
   defp parse_backend_opts(opts) when is_binary(opts) do
     # Legacy: single path string means use file backend
@@ -447,47 +1171,265 @@ defmodule Lasso.Config.ConfigStore do
     {Backend.backend_module(), Backend.backend_config()}
   end
 
-  defp do_load_all_profiles(state) do
-    backend_module = state.backend_module
-    backend_config = state.backend_config
+  defp do_load_all_profiles(state, opts \\ []) do
+    preserve_current_ets_on_degraded? =
+      Keyword.get(opts, :preserve_current_ets_on_degraded?, false)
 
-    with {:ok, backend_state} <- backend_module.init(backend_config),
-         {:ok, profile_specs} <- backend_module.load_all(backend_state) do
-      # Clear existing profile data
-      clear_profile_data()
+    with {:ok, backend_state} <- ensure_backend_initialized(state) do
+      case safe_backend_load_all(state.backend_module, backend_state) do
+        {:ok, specs} ->
+          finalize_validated_load(specs, state, backend_state, :ok)
 
-      # Store each profile
-      profile_slugs =
-        Enum.map(profile_specs, fn spec ->
-          store_profile(spec)
-          spec.slug
-        end)
+        {:degraded, _specs} when preserve_current_ets_on_degraded? ->
+          {:degraded, list_profiles(), %{state | backend_state: backend_state}}
 
-      # Build indices
-      build_indices(profile_specs)
+        {:degraded, specs} ->
+          finalize_validated_load(specs, state, backend_state, :degraded)
 
-      new_state = %{
-        state
-        | backend_state: backend_state,
-          last_loaded: DateTime.utc_now()
-      }
-
-      Logger.info("Loaded #{length(profile_slugs)} profiles: #{Enum.join(profile_slugs, ", ")}")
-      {:ok, profile_slugs, new_state}
+        {:error, _} = error ->
+          error
+      end
     end
   end
 
-  defp clear_profile_data do
-    # Clear profile-related keys
-    :ets.match_delete(@config_table, {{:profile, :_, :_}, :_})
-    :ets.delete(@config_table, {:profile_list})
-    :ets.delete(@config_table, {:all_chains})
-    :ets.delete(@config_table, {:chain_id_index})
-    :ets.match_delete(@config_table, {{:chain_profiles, :_}, :_})
+  defp finalize_validated_load(profile_specs, state, backend_state, result) do
+    case validate_profile_specs(profile_specs) do
+      :ok ->
+        {profile_ids, new_state} = finalize_load(profile_specs, state, backend_state)
+        {result, profile_ids, new_state}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
-  defp store_profile(spec) do
-    meta = %{
+  defp finalize_load(profile_specs, state, backend_state) do
+    populate_ets(profile_specs)
+
+    new_state = %{
+      state
+      | backend_state: backend_state,
+        last_loaded: DateTime.utc_now(),
+        last_good_specs: profile_specs
+    }
+
+    profile_ids = Enum.map(profile_specs, & &1.profile_id)
+    Logger.info("Loaded #{length(profile_ids)} profiles: #{Enum.join(profile_ids, ", ")}")
+
+    {profile_ids, new_state}
+  end
+
+  defp validate_profile_specs(profile_specs) when is_list(profile_specs) do
+    with :ok <- validate_unique_profile_ids(profile_specs) do
+      Enum.reduce_while(profile_specs, :ok, fn spec, :ok ->
+        case validate_profile_spec(spec) do
+          :ok -> {:cont, :ok}
+          {:error, _} = error -> {:halt, error}
+        end
+      end)
+    end
+  end
+
+  defp validate_profile_specs(_), do: {:error, :invalid_profile_specs}
+
+  defp validate_unique_profile_ids(profile_specs) do
+    ids = Enum.map(profile_specs, &Map.get(&1, :profile_id))
+
+    if Enum.all?(ids, &is_binary/1) and length(ids) == length(Enum.uniq(ids)) do
+      :ok
+    else
+      {:error, :invalid_or_duplicate_profile_id}
+    end
+  end
+
+  defp validate_profile_spec(%{
+         scope: :system,
+         profile_id: profile_id,
+         slug: slug,
+         chains: chains
+       })
+       when is_binary(profile_id) and is_binary(slug) and is_map(chains) do
+    ids = Enum.map(chains, fn {_name, chain} -> Map.get(chain, :chain_id) end)
+
+    cond do
+      not Enum.all?(ids, &(is_integer(&1) and &1 > 0)) ->
+        {:error, :invalid_chain_id}
+
+      length(ids) != length(Enum.uniq(ids)) ->
+        {:error, :duplicate_chain_id}
+
+      true ->
+        validate_chain_aliases(chains, MapSet.new(ids))
+    end
+  end
+
+  defp validate_profile_spec(_), do: {:error, :invalid_profile_spec}
+
+  defp validate_chain_aliases(chains, chain_ids) do
+    aliases =
+      for {chain_name, chain} <- chains,
+          alias_name <- Map.get(chain, :url_aliases, [chain_name]),
+          do: {Map.get(chain, :chain_id), alias_name}
+
+    with :ok <- validate_alias_values(aliases),
+         :ok <- validate_unique_aliases(aliases) do
+      validate_decimal_alias_collisions(aliases, chain_ids)
+    end
+  end
+
+  defp validate_alias_values(aliases) do
+    case Enum.find(aliases, fn {_chain_id, alias_name} ->
+           not (is_binary(alias_name) and String.trim(alias_name) != "")
+         end) do
+      nil -> :ok
+      {chain_id, alias_name} -> {:error, {:invalid_chain_alias, chain_id, alias_name}}
+    end
+  end
+
+  defp validate_unique_aliases(aliases) do
+    case aliases
+         |> Enum.group_by(fn {_chain_id, alias_name} -> alias_name end)
+         |> Enum.find(fn {_alias_name, values} -> length(values) > 1 end) do
+      nil -> :ok
+      {alias_name, _values} -> {:error, {:duplicate_chain_alias, alias_name}}
+    end
+  end
+
+  defp validate_decimal_alias_collisions(aliases, chain_ids) do
+    case Enum.find(aliases, fn {chain_id, alias_name} ->
+           case Integer.parse(alias_name) do
+             {decimal_id, ""} -> decimal_id != chain_id and MapSet.member?(chain_ids, decimal_id)
+             _ -> false
+           end
+         end) do
+      nil ->
+        :ok
+
+      {chain_id, alias_name} ->
+        {:error, {:chain_alias_collides_with_chain_id, chain_id, alias_name}}
+    end
+  end
+
+  defp safe_backend_load_all(backend_module, backend_state) do
+    backend_module.load_all(backend_state)
+  rescue
+    e -> {:error, {:load_failed, normalize_failure(e)}}
+  catch
+    kind, reason -> {:error, {:load_failed, {kind, normalize_failure(reason)}}}
+  end
+
+  defp ensure_backend_initialized(%{backend_state: nil} = state) do
+    state.backend_module.init(state.backend_config)
+  end
+
+  defp ensure_backend_initialized(%{backend_state: backend_state}) do
+    {:ok, backend_state}
+  end
+
+  defp populate_ets(profile_specs) do
+    new_table =
+      :ets.new(:lasso_config_store, [
+        :public,
+        :set,
+        {:heir, Process.whereis(Owner), :config_store},
+        read_concurrency: true
+      ])
+
+    Enum.each(profile_specs, fn spec ->
+      store_profile(spec, new_table)
+    end)
+
+    build_indices(profile_specs, new_table)
+
+    old_table = :persistent_term.get(@persistent_term_key, nil)
+    :persistent_term.put(@persistent_term_key, new_table)
+
+    if old_table do
+      Owner.schedule_delete(old_table, @grace_period_ms)
+    end
+  end
+
+  defp safe_lookup(key) do
+    :ets.lookup(table(), key)
+  rescue
+    ArgumentError -> []
+  end
+
+  defp snapshot_profile_specs do
+    for profile_id <- list_profiles(),
+        {:ok, meta} = get_profile(profile_id),
+        {:ok, chains} = get_profile_chains(profile_id),
+        into: [] do
+      %{
+        scope: :system,
+        profile_id: meta.profile_id,
+        slug: meta.slug,
+        name: meta.name,
+        logo: meta.logo,
+        rps_limit: meta.rps_limit,
+        burst_limit: meta.burst_limit,
+        unlisted: meta.unlisted,
+        chains:
+          Map.new(chains, fn {chain_id, chain} ->
+            {chain.display_name || Integer.to_string(chain_id), chain}
+          end)
+      }
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp refresh_last_good_specs(state, :ok),
+    do: %{state | last_good_specs: snapshot_profile_specs()}
+
+  defp refresh_last_good_specs(state, _reply), do: state
+
+  defp resolve_with_meta(scope, slug) do
+    with {:ok, profile_id} <- resolve(scope, slug),
+         {:ok, meta} <- get_profile(profile_id) do
+      {:ok, profile_id, meta}
+    end
+  end
+
+  defp store_profile(spec), do: publish_profile_upsert(spec)
+
+  defp publish_profile_upsert(spec) do
+    old_table = table()
+
+    new_table =
+      :ets.new(:lasso_config_store, [
+        :public,
+        :set,
+        {:heir, Process.whereis(Owner), :config_store},
+        read_concurrency: true
+      ])
+
+    old_table
+    |> :ets.tab2list()
+    |> Enum.reject(fn
+      {{:profile, profile_id, :meta}, _} -> profile_id == spec.profile_id
+      {{:profile, profile_id, :chains}, _} -> profile_id == spec.profile_id
+      {{:resolve, _scope, _slug}, profile_id} -> profile_id == spec.profile_id
+      {{:profile_list}, _} -> true
+      {{:chain_profiles, _chain_id}, _} -> true
+      {{:all_chain_ids}, _} -> true
+      _ -> false
+    end)
+    |> then(&:ets.insert(new_table, &1))
+
+    store_profile(spec, new_table)
+    rebuild_indices_from_table(new_table)
+
+    :persistent_term.put(@persistent_term_key, new_table)
+    Owner.schedule_delete(old_table, @grace_period_ms)
+
+    :ok
+  end
+
+  defp store_profile(spec, t) do
+    meta = %ProfileMeta{
+      profile_id: spec.profile_id,
+      scope: spec.scope,
       slug: spec.slug,
       name: spec.name,
       logo: Map.get(spec, :logo),
@@ -496,229 +1438,238 @@ defmodule Lasso.Config.ConfigStore do
       unlisted: Map.get(spec, :unlisted, false)
     }
 
-    :ets.insert(@config_table, {{:profile, spec.slug, :meta}, meta})
-    :ets.insert(@config_table, {{:profile, spec.slug, :chains}, spec.chains})
+    # Profile validation runs before every publication, so this conversion
+    # cannot silently drop an invalid chain or overwrite a duplicate ID.
+    :ok = validate_profile_spec(spec)
+
+    integer_chains = Map.new(spec.chains, fn {_chain_name, cc} -> {cc.chain_id, cc} end)
+
+    # The three rows for one profile are inserted as a single :ets.insert/2
+    # call with a list — :ets.insert/2 is atomic on a :set table, so a
+    # concurrent reader cannot observe meta+chains without the resolution
+    # index entry (the partial-snapshot case the redesign forbids).
+    # Resolution index lives in the same table as the profile data so an
+    # atomic-swap reload (populate_ets) never exposes one without the other.
+    :ets.insert(t, [
+      {{:profile, spec.profile_id, :meta}, meta},
+      {{:profile, spec.profile_id, :chains}, integer_chains},
+      {{:resolve, spec.scope, spec.slug}, spec.profile_id}
+    ])
   end
 
-  defp build_indices(profile_specs) do
-    # Build profile list
-    profile_slugs = Enum.map(profile_specs, & &1.slug)
-    :ets.insert(@config_table, {{:profile_list}, profile_slugs})
+  # When `update_profile` reshapes a profile under a new scope or slug,
+  # `store_profile/2` writes the new `{:resolve, scope, slug}` entry but
+  # leaves the prior one pointing at the same `profile_id`. That stale
+  # entry would let `resolve(old_scope, old_slug)` keep returning the
+  # profile after rename. Drop it.
+  defp publish_profile_removal(profile_id, %ProfileMeta{} = meta) do
+    old_table = table()
 
-    # Build chain -> profiles index and all_chains list
-    chain_profiles_map =
-      profile_specs
-      |> Enum.flat_map(fn spec ->
-        Enum.map(Map.keys(spec.chains), fn chain -> {chain, spec.slug} end)
+    new_table =
+      :ets.new(:lasso_config_store, [
+        :public,
+        :set,
+        {:heir, Process.whereis(Owner), :config_store},
+        read_concurrency: true
+      ])
+
+    retained_rows =
+      old_table
+      |> :ets.tab2list()
+      |> Enum.reject(fn
+        {{:profile, ^profile_id, :meta}, _} -> true
+        {{:profile, ^profile_id, :chains}, _} -> true
+        {{:resolve, scope, slug}, ^profile_id} -> scope == meta.scope and slug == meta.slug
+        {{:profile_list}, _} -> true
+        {{:chain_profiles, _chain_id}, _} -> true
+        {{:all_chain_ids}, _} -> true
+        _ -> false
       end)
-      |> Enum.group_by(fn {chain, _} -> chain end, fn {_, profile} -> profile end)
 
-    all_chains = Map.keys(chain_profiles_map)
-    :ets.insert(@config_table, {{:all_chains}, all_chains})
+    :ets.insert(new_table, retained_rows)
+    rebuild_indices_from_table(new_table)
 
-    Enum.each(chain_profiles_map, fn {chain, profiles} ->
-      :ets.insert(@config_table, {{:chain_profiles, chain}, profiles})
-    end)
+    :persistent_term.put(@persistent_term_key, new_table)
+    Owner.schedule_delete(old_table, @grace_period_ms)
 
-    # Build chain_id index (for cross-profile lookups by numeric chain ID)
-    # Collect all {chain_id, {profile_slug, chain_name}} tuples
-    chain_id_list =
-      profile_specs
-      |> Enum.flat_map(fn spec ->
-        Enum.flat_map(spec.chains, fn {chain_name, chain_config} ->
-          if chain_config.chain_id do
-            [{chain_config.chain_id, {spec.slug, chain_name}}]
-          else
-            []
-          end
+    :ok
+  end
+
+  defp rebuild_indices_from_table(t) do
+    profile_ids =
+      t
+      |> :ets.match({{:profile, :"$1", :meta}, :"$2"})
+      |> Enum.map(fn [profile_id, _meta] -> profile_id end)
+
+    :ets.insert(t, {{:profile_list}, profile_ids})
+
+    chain_profiles_map =
+      t
+      |> :ets.match({{:profile, :"$1", :chains}, :"$2"})
+      |> Enum.reduce(%{}, fn [profile_id, chains], acc ->
+        Enum.reduce(Map.keys(chains), acc, fn chain_id, inner_acc ->
+          Map.update(inner_acc, chain_id, [profile_id], &[profile_id | &1])
         end)
       end)
 
-    # Check for duplicates and warn
-    duplicates =
-      chain_id_list
-      |> Enum.group_by(fn {chain_id, _} -> chain_id end)
-      |> Enum.filter(fn {_, matches} -> length(matches) > 1 end)
+    all_chain_ids = Map.keys(chain_profiles_map)
+    :ets.insert(t, {{:all_chain_ids}, all_chain_ids})
 
-    if duplicates != [] do
-      Logger.warning("Duplicate chain IDs detected across profiles",
-        duplicates:
-          Enum.map(duplicates, fn {chain_id, matches} ->
-            {chain_id, Enum.map(matches, fn {_, {profile, chain}} -> {profile, chain} end)}
-          end)
-      )
-    end
-
-    # Build index with resolution strategy: prefer default profile, otherwise first match
-    chain_id_index =
-      chain_id_list
-      |> Enum.group_by(fn {chain_id, _} -> chain_id end)
-      |> Enum.map(fn {chain_id, matches} ->
-        # Prefer default profile if present, otherwise use first match
-        resolved =
-          case Enum.find(matches, fn {_, {profile, _}} -> profile == @default_profile end) do
-            {_, {_profile, chain_name}} ->
-              chain_name
-
-            nil ->
-              {_, {_profile, chain_name}} = List.first(matches)
-              chain_name
-          end
-
-        {chain_id, resolved}
-      end)
-      |> Map.new()
-
-    :ets.insert(@config_table, {{:chain_id_index}, chain_id_index})
+    Enum.each(chain_profiles_map, fn {chain_id, profile_ids} ->
+      :ets.insert(t, {{:chain_profiles, chain_id}, Enum.uniq(profile_ids)})
+    end)
   end
 
-  defp add_chain_to_profile(profile, chain_name, chain_config) do
+  defp delete_stale_resolve_entry(%ProfileMeta{}, _new_spec), do: :ok
+
+  defp build_indices(profile_specs, t) do
+    profile_ids = Enum.map(profile_specs, & &1.profile_id)
+    :ets.insert(t, {{:profile_list}, profile_ids})
+
+    # Chains are already integer-keyed after store_profile converts them.
+    # Read back the integer-keyed chains from ETS to build the indices.
+    chain_profiles_map =
+      profile_ids
+      |> Enum.flat_map(fn profile_id ->
+        case :ets.lookup(t, {:profile, profile_id, :chains}) do
+          [{{:profile, ^profile_id, :chains}, chains}] ->
+            Enum.map(Map.keys(chains), fn chain_id -> {chain_id, profile_id} end)
+
+          _ ->
+            []
+        end
+      end)
+      |> Enum.group_by(fn {chain_id, _} -> chain_id end, fn {_, pid} -> pid end)
+
+    all_chain_ids = Map.keys(chain_profiles_map)
+    :ets.insert(t, {{:all_chain_ids}, all_chain_ids})
+
+    Enum.each(chain_profiles_map, fn {chain_id, pids} ->
+      :ets.insert(t, {{:chain_profiles, chain_id}, pids})
+    end)
+  end
+
+  defp ensure_profile_in_list(profile_id) do
+    current = list_profiles()
+
+    rows =
+      if match?({:error, :not_found}, get_profile(profile_id)) do
+        meta = %ProfileMeta{
+          profile_id: profile_id,
+          scope: :system,
+          slug: profile_id,
+          name: profile_id,
+          rps_limit: 100,
+          burst_limit: 500,
+          unlisted: false
+        }
+
+        [
+          {{:profile, profile_id, :meta}, meta},
+          {{:resolve, :system, profile_id}, profile_id}
+        ]
+      else
+        []
+      end
+
+    rows =
+      if profile_id in current do
+        rows
+      else
+        [{{:profile_list}, [profile_id | current]} | rows]
+      end
+
+    if rows != [], do: :ets.insert(table(), rows)
+  end
+
+  defp maybe_remove_profile_from_list(profile_id) do
+    remaining_chains = list_chains_for_profile(profile_id)
+
+    if remaining_chains == [] do
+      current = list_profiles()
+      :ets.insert(table(), {{:profile_list}, List.delete(current, profile_id)})
+    end
+  end
+
+  defp add_chain_to_profile(profile_id, chain_id, chain_config) do
     chains =
-      case :ets.lookup(@config_table, {:profile, profile, :chains}) do
-        [{{:profile, ^profile, :chains}, existing}] -> existing
+      case :ets.lookup(table(), {:profile, profile_id, :chains}) do
+        [{{:profile, ^profile_id, :chains}, existing}] -> existing
         [] -> %{}
       end
 
-    updated_chains = Map.put(chains, chain_name, chain_config)
-    :ets.insert(@config_table, {{:profile, profile, :chains}, updated_chains})
+    updated_chains = Map.put(chains, chain_id, chain_config)
+    :ets.insert(table(), {{:profile, profile_id, :chains}, updated_chains})
 
-    # Update indices atomically
-    update_indices_for_chain_add(profile, chain_name, chain_config)
+    update_indices_for_chain_add(profile_id, chain_id)
   end
 
-  defp remove_chain_from_profile(profile, chain_name) do
-    case :ets.lookup(@config_table, {:profile, profile, :chains}) do
-      [{{:profile, ^profile, :chains}, chains}] ->
-        chain_config = Map.get(chains, chain_name)
-        updated_chains = Map.delete(chains, chain_name)
-        :ets.insert(@config_table, {{:profile, profile, :chains}, updated_chains})
-
-        # Update indices atomically after chain is removed
-        if chain_config do
-          update_indices_for_chain_remove(profile, chain_name, chain_config)
-        end
+  defp remove_chain_from_profile(profile_id, chain_id) do
+    case :ets.lookup(table(), {:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] ->
+        updated_chains = Map.delete(chains, chain_id)
+        :ets.insert(table(), {{:profile, profile_id, :chains}, updated_chains})
+        update_indices_for_chain_remove(profile_id, chain_id)
 
       [] ->
         :ok
     end
   end
 
-  defp update_chain_in_profile(profile, chain_name, chain_config) do
-    case :ets.lookup(@config_table, {:profile, profile, :chains}) do
-      [{{:profile, ^profile, :chains}, chains}] ->
-        updated_chains = Map.put(chains, chain_name, chain_config)
-        :ets.insert(@config_table, {{:profile, profile, :chains}, updated_chains})
+  defp update_chain_in_profile(profile_id, chain_id, chain_config) do
+    case :ets.lookup(table(), {:profile, profile_id, :chains}) do
+      [{{:profile, ^profile_id, :chains}, chains}] ->
+        updated_chains = Map.put(chains, chain_id, chain_config)
+        :ets.insert(table(), {{:profile, profile_id, :chains}, updated_chains})
 
       [] ->
         :ok
     end
   end
 
-  defp update_chain_profiles_index(chain_name, profile) do
+  defp update_chain_profiles_index(chain_id, profile_id) do
     current =
-      case :ets.lookup(@config_table, {:chain_profiles, chain_name}) do
-        [{{:chain_profiles, ^chain_name}, profiles}] -> profiles
+      case :ets.lookup(table(), {:chain_profiles, chain_id}) do
+        [{{:chain_profiles, ^chain_id}, profiles}] -> profiles
         [] -> []
       end
 
-    if profile not in current do
-      :ets.insert(@config_table, {{:chain_profiles, chain_name}, [profile | current]})
+    if profile_id not in current do
+      :ets.insert(table(), {{:chain_profiles, chain_id}, [profile_id | current]})
     end
   end
 
-  defp update_all_chains_index(chain_name) do
+  defp update_all_chain_ids_index(chain_id) do
     current =
-      case :ets.lookup(@config_table, {:all_chains}) do
-        [{{:all_chains}, chains}] -> chains
+      case :ets.lookup(table(), {:all_chain_ids}) do
+        [{{:all_chain_ids}, ids}] -> ids
         [] -> []
       end
 
-    if chain_name not in current do
-      :ets.insert(@config_table, {{:all_chains}, [chain_name | current]})
+    if chain_id not in current do
+      :ets.insert(table(), {{:all_chain_ids}, [chain_id | current]})
     end
   end
 
-  defp update_chain_id_index(_chain_name, chain_config) do
-    rebuild_chain_id_entry(chain_config.chain_id)
+  defp update_indices_for_chain_add(profile_id, chain_id) do
+    update_chain_profiles_index(chain_id, profile_id)
+    update_all_chain_ids_index(chain_id)
   end
 
-  # Rebuild a single chain_id entry by scanning profiles and preferring default profile if present.
-  defp rebuild_chain_id_entry(nil), do: :ok
-
-  defp rebuild_chain_id_entry(chain_id) do
-    matches =
-      :ets.match(@config_table, {{:profile, :"$1", :chains}, :"$2"})
-      |> Enum.flat_map(fn [profile, chains] ->
-        Enum.flat_map(chains, fn {chain_name, cc} ->
-          if cc.chain_id == chain_id, do: [{profile, chain_name}], else: []
-        end)
-      end)
-
-    case matches do
-      [] ->
-        case :ets.lookup(@config_table, {:chain_id_index}) do
-          [{{:chain_id_index}, index}] ->
-            :ets.insert(@config_table, {{:chain_id_index}, Map.delete(index, chain_id)})
-
-          [] ->
-            :ok
-        end
-
-      list ->
-        preferred =
-          Enum.find(list, fn {profile, _} -> profile == @default_profile end) ||
-            hd(list)
-
-        {_profile, chain_name} = preferred
-
-        current =
-          case :ets.lookup(@config_table, {:chain_id_index}) do
-            [{{:chain_id_index}, index}] -> index
-            [] -> %{}
-          end
-
-        :ets.insert(@config_table, {{:chain_id_index}, Map.put(current, chain_id, chain_name)})
-    end
+  defp update_indices_for_chain_remove(profile_id, chain_id) do
+    remove_profile_from_chain_profiles(chain_id, profile_id)
+    maybe_remove_chain_from_all_chain_ids(chain_id)
   end
 
-  # Atomic index updates for chain addition
-  defp update_indices_for_chain_add(profile, chain_name, chain_config) do
-    # Update chain_profiles index (add profile to chain's profile list)
-    update_chain_profiles_index(chain_name, profile)
-
-    # Update all_chains index (add chain if not present)
-    update_all_chains_index(chain_name)
-
-    # Update chain_id index if chain has a numeric ID
-    if chain_config.chain_id do
-      update_chain_id_index(chain_name, chain_config)
-    end
-  end
-
-  # Atomic index updates for chain removal
-  defp update_indices_for_chain_remove(profile, chain_name, chain_config) do
-    # Remove profile from chain_profiles index
-    remove_profile_from_chain_profiles(chain_name, profile)
-
-    # Remove chain from all_chains index if no profiles remain
-    maybe_remove_chain_from_all_chains(chain_name)
-
-    # Remove from chain_id index if applicable
-    if chain_config.chain_id do
-      remove_from_chain_id_index(chain_config.chain_id, chain_name)
-    end
-  end
-
-  # Remove profile from chain_profiles index
-  defp remove_profile_from_chain_profiles(chain_name, profile) do
-    case :ets.lookup(@config_table, {:chain_profiles, chain_name}) do
-      [{{:chain_profiles, ^chain_name}, profiles}] ->
-        updated = List.delete(profiles, profile)
+  defp remove_profile_from_chain_profiles(chain_id, profile_id) do
+    case :ets.lookup(table(), {:chain_profiles, chain_id}) do
+      [{{:chain_profiles, ^chain_id}, profiles}] ->
+        updated = List.delete(profiles, profile_id)
 
         if updated == [] do
-          :ets.delete(@config_table, {:chain_profiles, chain_name})
+          :ets.delete(table(), {:chain_profiles, chain_id})
         else
-          :ets.insert(@config_table, {{:chain_profiles, chain_name}, updated})
+          :ets.insert(table(), {{:chain_profiles, chain_id}, updated})
         end
 
       [] ->
@@ -726,20 +1677,15 @@ defmodule Lasso.Config.ConfigStore do
     end
   end
 
-  # Remove chain from all_chains index if no profiles remain
-  defp maybe_remove_chain_from_all_chains(chain_name) do
-    # Check if any profile still has this chain
+  defp maybe_remove_chain_from_all_chain_ids(chain_id) do
     has_chain =
-      :ets.match(@config_table, {{:profile, :"$1", :chains}, :"$2"})
-      |> Enum.any?(fn [_, chains] ->
-        Map.has_key?(chains, chain_name)
-      end)
+      :ets.match(table(), {{:profile, :"$1", :chains}, :"$2"})
+      |> Enum.any?(fn [_, chains] -> Map.has_key?(chains, chain_id) end)
 
     if not has_chain do
-      case :ets.lookup(@config_table, {:all_chains}) do
-        [{{:all_chains}, chains}] ->
-          updated = List.delete(chains, chain_name)
-          :ets.insert(@config_table, {{:all_chains}, updated})
+      case :ets.lookup(table(), {:all_chain_ids}) do
+        [{{:all_chain_ids}, ids}] ->
+          :ets.insert(table(), {{:all_chain_ids}, List.delete(ids, chain_id)})
 
         [] ->
           :ok
@@ -747,43 +1693,56 @@ defmodule Lasso.Config.ConfigStore do
     end
   end
 
-  # Remove entry from chain_id_index if it points to this chain
-  defp remove_from_chain_id_index(chain_id, chain_name) do
-    case :ets.lookup(@config_table, {:chain_id_index}) do
-      [{{:chain_id_index}, index}] ->
-        case Map.get(index, chain_id) do
-          ^chain_name ->
-            # Only remove if this chain_id was pointing to this chain_name
-            updated = Map.delete(index, chain_id)
-            :ets.insert(@config_table, {{:chain_id_index}, updated})
+  # Profile publication rebuilds all indices in the unpublished snapshot.
+  defp update_indices_for_inject(_spec), do: :ok
 
-          _ ->
-            # chain_id points to a different chain, don't remove
-            :ok
-        end
-
-      [] ->
-        :ok
+  defp notify_inject do
+    case Application.get_env(:lasso, :profile_inject_listener) do
+      nil -> :ok
+      mod -> mod.record_inject()
     end
+  end
+
+  defp broadcast_profile_updated(profile_id) do
+    Phoenix.PubSub.broadcast(
+      Lasso.PubSub,
+      Lasso.Topics.config_profile_updated(profile_id),
+      {:profile_config_updated, profile_id}
+    )
+  rescue
+    _ -> :ok
   end
 
   # Normalization helpers
 
-  defp normalize_chain_config(chain_name, attrs) when is_map(attrs) do
+  defp normalize_chain_config(chain_id, attrs) when is_integer(chain_id) and is_map(attrs) do
     websocket_attrs = Map.get(attrs, :websocket) || Map.get(attrs, "websocket") || %{}
     selection_attrs = Map.get(attrs, :selection) || Map.get(attrs, "selection")
     monitoring_attrs = Map.get(attrs, :monitoring) || Map.get(attrs, "monitoring") || %{}
     providers_attrs = Map.get(attrs, :providers) || Map.get(attrs, "providers") || []
 
     %ChainConfig{
-      chain_id: Map.get(attrs, :chain_id) || Map.get(attrs, "chain_id"),
-      name: Map.get(attrs, :name) || Map.get(attrs, "name") || chain_name,
+      chain_id: chain_id,
+      display_name:
+        Map.get(attrs, :display_name) || Map.get(attrs, "display_name") ||
+          Map.get(attrs, :name) || Map.get(attrs, "name"),
+      url_aliases:
+        attrs
+        |> Map.get(:url_aliases, Map.get(attrs, "url_aliases"))
+        |> normalize_url_aliases(Map.get(attrs, :name) || Map.get(attrs, "name")),
       providers: Enum.map(providers_attrs, &normalize_provider_config/1),
       websocket: normalize_websocket_config(websocket_attrs),
       selection: normalize_selection_config(selection_attrs),
       monitoring: normalize_monitoring_config(monitoring_attrs)
     }
   end
+
+  defp normalize_url_aliases(aliases, _fallback) when is_list(aliases) do
+    Enum.filter(aliases, &(is_binary(&1) and String.trim(&1) != ""))
+  end
+
+  defp normalize_url_aliases(_aliases, fallback) when is_binary(fallback), do: [fallback]
+  defp normalize_url_aliases(_aliases, _fallback), do: []
 
   defp normalize_websocket_config(attrs) when is_map(attrs) do
     failover_attrs = Map.get(attrs, :failover) || Map.get(attrs, "failover") || %{}
@@ -848,21 +1807,190 @@ defmodule Lasso.Config.ConfigStore do
       priority: Map.get(attrs, :priority) || Map.get(attrs, "priority") || 100,
       capabilities: Map.get(attrs, :capabilities) || Map.get(attrs, "capabilities"),
       archival: archival,
+      subscribe_new_heads:
+        Map.get(attrs, :subscribe_new_heads, Map.get(attrs, "subscribe_new_heads")),
       sharing_mode: sharing_mode,
+      api_key: Map.get(attrs, :api_key) || Map.get(attrs, "api_key"),
+      credentials: Map.get(attrs, :credentials) || Map.get(attrs, "credentials"),
+      headers: Map.get(attrs, :headers) || Map.get(attrs, "headers"),
+      auth_headers: Map.get(attrs, :auth_headers) || Map.get(attrs, "auth_headers"),
       __mock__: Map.get(attrs, :__mock__)
     }
   end
 
-  defp rebuild_shared_infrastructure do
+  defp start_profile_chain_supervisors(profile_id) do
+    chain_ids = list_chains_for_profile(profile_id)
+
+    for chain_id <- chain_ids do
+      case get_chain(profile_id, chain_id) do
+        {:ok, chain_config} ->
+          Lasso.ProfileChainSupervisor.start_profile_chain(
+            profile_id,
+            chain_id,
+            chain_config
+          )
+
+        _ ->
+          :ok
+      end
+    end
+  rescue
+    e ->
+      Logger.warning("Failed to start chain supervisors for #{profile_id}: #{inspect(e)}")
+  end
+
+  defp collect_profile_chain_pairs do
+    for profile_id <- list_profiles(),
+        chain_id <- list_chains_for_profile(profile_id),
+        do: {profile_id, chain_id}
+  end
+
+  defp sync_chain_supervisors(old_pairs) do
+    new_pairs = collect_profile_chain_pairs()
+
+    for {profile_id, chain_id} <- new_pairs -- old_pairs do
+      case get_chain(profile_id, chain_id) do
+        {:ok, config} ->
+          Lasso.ProfileChainSupervisor.start_profile_chain(profile_id, chain_id, config)
+
+        _ ->
+          :ok
+      end
+    end
+
+    for {profile_id, chain_id} <- old_pairs -- new_pairs do
+      Lasso.ProfileChainSupervisor.stop_profile_chain(profile_id, chain_id)
+    end
+  rescue
+    e ->
+      Logger.warning("Failed to sync chain supervisors on reload: #{inspect(e)}")
+  end
+
+  defp snapshot_profile_chain_configs(profile_id, chain_ids) do
+    Map.new(chain_ids, fn chain_id ->
+      {chain_id, chain_provider_endpoints(profile_id, chain_id)}
+    end)
+  end
+
+  defp reconcile_transport_channels(profile_id, old_chain_configs, profile_spec) do
+    new_chain_ids = Map.keys(profile_spec.chains || %{})
+    chain_ids = MapSet.union(MapSet.new(Map.keys(old_chain_configs)), MapSet.new(new_chain_ids))
+
+    Enum.each(chain_ids, fn chain_id ->
+      old_providers = Map.get(old_chain_configs, chain_id, %{})
+      new_providers = chain_provider_endpoints(profile_id, chain_id)
+      reset_changed_provider_channels(profile_id, chain_id, old_providers, new_providers)
+    end)
+  end
+
+  # Reconciles transport channels for every (profile, chain) after a cluster
+  # reload. Remote nodes apply config changes via reload/0 rather than
+  # update_profile/1, so without this they keep serving from channels that
+  # cache a now-stale endpoint URL.
+  defp reconcile_transport_channels_all(old_endpoints) do
+    new_pairs = collect_profile_chain_pairs()
+
+    pairs =
+      MapSet.union(MapSet.new(Map.keys(old_endpoints)), MapSet.new(new_pairs))
+
+    Enum.each(pairs, fn {profile_id, chain_id} ->
+      old_providers = Map.get(old_endpoints, {profile_id, chain_id}, %{})
+      new_providers = chain_provider_endpoints(profile_id, chain_id)
+      reset_changed_provider_channels(profile_id, chain_id, old_providers, new_providers)
+    end)
+  end
+
+  # Closes transport channels for providers whose endpoint changed or that were
+  # removed. Channels are keyed by provider_id and cache the URL captured at
+  # creation, so an endpoint change under the same id leaves a stale channel
+  # until it is explicitly closed. HTTP channels are recreated lazily from fresh
+  # config on the next request; WS channels are recreated on the next
+  # ws_connected event once the rebuilt instance reconnects. Only the affected
+  # provider is touched, so unrelated traffic and live subscriptions on the same
+  # chain keep running.
+  defp reset_changed_provider_channels(profile_id, chain_id, old_providers, new_providers) do
+    removed_provider_ids = Map.keys(old_providers) -- Map.keys(new_providers)
+
+    changed_provider_ids =
+      Enum.flat_map(new_providers, fn {provider_id, new_endpoints} ->
+        case Map.fetch(old_providers, provider_id) do
+          {:ok, old_endpoints} when old_endpoints != new_endpoints -> [provider_id]
+          _ -> []
+        end
+      end)
+
+    Enum.uniq(removed_provider_ids ++ changed_provider_ids)
+    |> Enum.each(fn provider_id ->
+      Lasso.RPC.TransportRegistry.close_channel_sync(profile_id, chain_id, provider_id, :http)
+      Lasso.RPC.TransportRegistry.close_channel_sync(profile_id, chain_id, provider_id, :ws)
+    end)
+  end
+
+  defp snapshot_all_chain_endpoints do
+    Enum.reduce(collect_profile_chain_pairs(), %{}, fn {profile_id, chain_id}, acc ->
+      Map.put(acc, {profile_id, chain_id}, chain_provider_endpoints(profile_id, chain_id))
+    end)
+  end
+
+  defp chain_provider_endpoints(profile_id, chain_id) do
+    case get_chain(profile_id, chain_id) do
+      {:ok, %{providers: providers}} when is_list(providers) ->
+        Map.new(providers, fn provider ->
+          {provider.id, %{url: provider.url, ws_url: provider.ws_url}}
+        end)
+
+      _ ->
+        %{}
+    end
+  end
+
+  defp validate_provider_not_exists(chain_config, provider_id) do
+    if Enum.any?(chain_config.providers, &(&1.id == provider_id)) do
+      {:error, :already_exists}
+    else
+      :ok
+    end
+  end
+
+  defp add_provider_to_chain(chain_config, provider_config) do
+    %{chain_config | providers: chain_config.providers ++ [provider_config]}
+  end
+
+  defp remove_provider_from_chain(chain_config, provider_id) do
+    updated_providers = Enum.reject(chain_config.providers, &(&1.id == provider_id))
+
+    if length(updated_providers) == length(chain_config.providers) do
+      {:error, :provider_not_found}
+    else
+      {:ok, %{chain_config | providers: updated_providers}}
+    end
+  end
+
+  # `publish_profile_upsert/1` atomically publishes the complete rebuilt index.
+  defp rebuild_indices_for_profile(_profile_id, _old_chain_ids, _profile_spec), do: :ok
+
+  # Reconciles Catalog + InstanceSupervisors + ProbeCoordinators + BlockSync
+  # workers against current ConfigStore state.
+  #
+  # `old_chains` is the chain set captured BEFORE any mutations the caller
+  # has made. Chains present in `old_chains` but absent from the new state
+  # get their ProbeCoordinators torn down via `old_chains -- new_chains`.
+  #
+  # Caller contract:
+  #   - Inject path (no chains removed): pass `list_chains()` (post-mutation
+  #     list — equivalent to the pre-mutation set plus the just-added chains).
+  #   - Update / remove / reload paths: pass the chain list captured BEFORE
+  #     the mutation so removed chains tear down cleanly.
+  defp rebuild_shared_infrastructure(old_chain_ids) do
     alias Lasso.Providers.{Catalog, InstanceSupervisor, ProbeCoordinator}
 
     old_instances = Catalog.list_all_instance_ids()
-    old_chains = list_chains()
+    old_instance_chain_ids = snapshot_instance_chain_ids(old_instances)
 
     Catalog.build_from_config()
 
     new_instances = Catalog.list_all_instance_ids()
-    new_chains = list_chains()
+    new_chain_ids = list_chain_ids()
 
     for instance_id <- new_instances do
       case DynamicSupervisor.start_child(
@@ -885,61 +2013,99 @@ defmodule Lasso.Config.ConfigStore do
       end
     end
 
-    # Terminate InstanceSupervisors for removed instances
-    removed_instances = old_instances -- new_instances
-
-    for instance_id <- removed_instances do
+    for instance_id <- old_instances -- new_instances do
       case GenServer.whereis(InstanceSupervisor.via_name(instance_id)) do
         nil -> :ok
         pid -> DynamicSupervisor.terminate_child(Lasso.Providers.InstanceDynamicSupervisor, pid)
       end
+
+      Lasso.Providers.InstanceState.clear(instance_id)
     end
 
-    # Start/reload ProbeCoordinators for current chains
-    for chain <- new_chains do
+    for chain_id <- new_chain_ids do
       case DynamicSupervisor.start_child(
              Lasso.Providers.ProbeSupervisor,
-             {ProbeCoordinator, chain}
+             {ProbeCoordinator, chain_id}
            ) do
         {:ok, _} -> :ok
-        {:error, {:already_started, _}} -> ProbeCoordinator.reload_instances(chain)
+        {:error, {:already_started, _}} -> ProbeCoordinator.reload_instances(chain_id)
         _ -> :ok
       end
     end
 
-    # Terminate ProbeCoordinators for removed chains
-    removed_chains = old_chains -- new_chains
-
-    for chain <- removed_chains do
-      case GenServer.whereis(ProbeCoordinator.via_name(chain)) do
+    for chain_id <- old_chain_ids -- new_chain_ids do
+      case GenServer.whereis(ProbeCoordinator.via_name(chain_id)) do
         nil -> :ok
         pid -> DynamicSupervisor.terminate_child(Lasso.Providers.ProbeSupervisor, pid)
       end
+
+      Lasso.Providers.RestartCounter.clear({:probe_coord, chain_id})
     end
+
+    reconcile_block_sync_workers(old_instances, old_instance_chain_ids)
   rescue
     e ->
-      Logger.warning("Failed to rebuild shared infrastructure on config reload: #{inspect(e)}")
+      Logger.warning("Failed to rebuild shared infrastructure: #{inspect(e)}")
   end
 
-  defp validate_provider_not_exists(chain_config, provider_id) do
-    if Enum.any?(chain_config.providers, &(&1.id == provider_id)) do
-      {:error, :already_exists}
-    else
-      :ok
+  defp snapshot_instance_chain_ids(instance_ids) do
+    alias Lasso.Providers.Catalog
+
+    Map.new(instance_ids, fn id ->
+      case Catalog.get_instance(id) do
+        {:ok, %{chain_id: chain_id}} -> {id, chain_id}
+        _ -> {id, nil}
+      end
+    end)
+  end
+
+  defp reconcile_block_sync_workers(old_instances, old_instance_chain_ids) do
+    alias Lasso.Providers.Catalog
+
+    new_instances = Catalog.list_all_instance_ids()
+    added = new_instances -- old_instances
+    removed = old_instances -- new_instances
+    retained = new_instances -- added
+
+    # Reap dropped instances before spawning new ones to enforce the
+    # probe-intensity contract: no window where two workers for the same
+    # provider URL run concurrently (auth rotation scenario).
+    for instance_id <- removed do
+      case Map.get(old_instance_chain_ids, instance_id) do
+        nil -> :ok
+        chain_id -> Lasso.BlockSync.Supervisor.stop_worker(chain_id, instance_id)
+      end
+
+      Lasso.Providers.RestartCounter.clear({:block_sync, instance_id})
+    end
+
+    for instance_id <- added do
+      case Catalog.get_instance(instance_id) do
+        {:ok, %{chain_id: chain_id}} ->
+          Lasso.BlockSync.Supervisor.start_worker(chain_id, instance_id)
+
+        _ ->
+          :ok
+      end
+    end
+
+    # Single signal: retained instances whose ref set or config may have
+    # changed pick up the new config via :instance_config_updated. Added
+    # workers load fresh config in handle_continue; removed are gone.
+    broadcast_instance_config_changes(retained)
+
+    if added != [] or removed != [] do
+      Logger.info("Reconciled BlockSync workers: +#{length(added)} -#{length(removed)}")
     end
   end
 
-  defp add_provider_to_chain(chain_config, provider_config) do
-    %{chain_config | providers: chain_config.providers ++ [provider_config]}
-  end
-
-  defp remove_provider_from_chain(chain_config, provider_id) do
-    updated_providers = Enum.reject(chain_config.providers, &(&1.id == provider_id))
-
-    if length(updated_providers) == length(chain_config.providers) do
-      {:error, :provider_not_found}
-    else
-      {:ok, %{chain_config | providers: updated_providers}}
+  defp broadcast_instance_config_changes(instance_ids) do
+    for instance_id <- instance_ids do
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.instance_config_updated(instance_id),
+        :instance_config_updated
+      )
     end
   end
 end

--- a/lib/lasso/config/config_store.ex
+++ b/lib/lasso/config/config_store.ex
@@ -31,7 +31,7 @@ defmodule Lasso.Config.ConfigStore do
   require Logger
 
   alias Lasso.Config.Backend
-  alias Lasso.Config.ChainConfig
+  alias Lasso.Config.{ChainAlias, ChainConfig}
   alias Lasso.Config.ChainConfig.Provider
   alias Lasso.Config.ConfigStore.Owner
   alias Lasso.Config.ProfileMeta
@@ -222,6 +222,33 @@ defmodule Lasso.Config.ConfigStore do
         :not_found
     end
   end
+
+  @doc """
+  Returns a configured URL alias for a numeric chain ID.
+
+  The public profile is preferred for compatibility with the legacy global
+  chain-ID index. Other loaded profiles are consulted when the chain is not in
+  public.
+  """
+  @spec find_chain_name_by_id(integer()) :: {:ok, String.t()} | {:error, :not_found}
+  def find_chain_name_by_id(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    profiles = list_profiles()
+
+    profiles =
+      if "public" in profiles, do: ["public" | List.delete(profiles, "public")], else: profiles
+
+    Enum.find_value(profiles, {:error, :not_found}, fn profile_id ->
+      case get_chain(profile_id, chain_id) do
+        {:ok, chain_config} ->
+          {:ok, ChainAlias.canonical_slug(chain_id, chain_config.url_aliases)}
+
+        {:error, :not_found} ->
+          false
+      end
+    end)
+  end
+
+  def find_chain_name_by_id(_chain_id), do: {:error, :not_found}
 
   @doc """
   Returns true when the profile contains a chain with the given `chain_id`.
@@ -431,8 +458,11 @@ defmodule Lasso.Config.ConfigStore do
     GenServer.call(__MODULE__, {:register_chain_runtime, profile_id, chain_id, chain_attrs})
   end
 
-  def register_chain_runtime(profile_id, _legacy_alias, %{chain_id: chain_id} = chain_attrs)
-      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+  def register_chain_runtime(profile_id, legacy_alias, %{chain_id: chain_id} = chain_attrs)
+      when is_binary(profile_id) and is_binary(legacy_alias) and is_integer(chain_id) and
+             chain_id > 0 do
+    aliases = Map.get(chain_attrs, :url_aliases, [])
+    chain_attrs = Map.put(chain_attrs, :url_aliases, Enum.uniq([legacy_alias | aliases]))
     register_chain_runtime(profile_id, chain_id, chain_attrs)
   end
 
@@ -567,6 +597,7 @@ defmodule Lasso.Config.ConfigStore do
       retry_task_ref: nil,
       retry_task_snapshot: nil,
       db_degraded: false,
+      runtime_dirty_profiles: MapSet.new(),
       last_good_specs: snapshot_profile_specs()
     }
 
@@ -577,7 +608,8 @@ defmodule Lasso.Config.ConfigStore do
   def handle_call(:load_all_profiles, _from, state) do
     case do_load_all_profiles(state) do
       {:ok, profiles, new_state} ->
-        {:reply, {:ok, profiles}, %{new_state | db_degraded: false}}
+        {:reply, {:ok, profiles},
+         %{new_state | db_degraded: false, runtime_dirty_profiles: MapSet.new()}}
 
       {:degraded, profiles, new_state} ->
         Logger.warning("Initial configuration load was degraded; scheduling retry")
@@ -605,7 +637,7 @@ defmodule Lasso.Config.ConfigStore do
         sync_chain_supervisors(old_pairs)
         reconcile_transport_channels_all(old_endpoints)
         Enum.each(profiles, &broadcast_profile_updated/1)
-        {:reply, :ok, %{new_state | db_degraded: false}}
+        {:reply, :ok, %{new_state | db_degraded: false, runtime_dirty_profiles: MapSet.new()}}
 
       {:degraded, _profiles, new_state} ->
         # Keep serving the last good snapshot and retry in the background.
@@ -622,7 +654,7 @@ defmodule Lasso.Config.ConfigStore do
   @impl true
   def handle_call({:inject_profile, profile_spec}, _from, state) do
     reply = do_inject_profile(profile_spec)
-    {:reply, reply, refresh_last_good_specs(state, reply)}
+    {:reply, reply, mark_runtime_dirty(state, profile_spec.profile_id, reply)}
   end
 
   @impl true
@@ -634,13 +666,13 @@ defmodule Lasso.Config.ConfigStore do
   @impl true
   def handle_call({:update_profile, profile_spec}, _from, state) do
     reply = do_update_profile(profile_spec)
-    {:reply, reply, refresh_last_good_specs(state, reply)}
+    {:reply, reply, mark_runtime_dirty(state, profile_spec.profile_id, reply)}
   end
 
   @impl true
   def handle_call({:remove_profile, profile_id}, _from, state) do
     reply = do_remove_profile(profile_id)
-    {:reply, reply, refresh_last_good_specs(state, reply)}
+    {:reply, reply, mark_runtime_dirty(state, profile_id, reply)}
   end
 
   @impl true
@@ -654,7 +686,7 @@ defmodule Lasso.Config.ConfigStore do
         chain_config = normalize_chain_config(chain_id, chain_attrs)
         add_chain_to_profile(profile_id, chain_id, chain_config)
         Logger.debug("Registered chain #{chain_id} in profile #{profile_id} (runtime)")
-        {:reply, :ok, refresh_last_good_specs(state, :ok)}
+        {:reply, :ok, mark_runtime_dirty(state, profile_id, :ok)}
     end
   end
 
@@ -665,7 +697,7 @@ defmodule Lasso.Config.ConfigStore do
         remove_chain_from_profile(profile_id, chain_id)
         maybe_remove_profile_from_list(profile_id)
         Logger.debug("Unregistered chain #{chain_id} from profile #{profile_id} (runtime)")
-        {:reply, :ok, refresh_last_good_specs(state, :ok)}
+        {:reply, :ok, mark_runtime_dirty(state, profile_id, :ok)}
 
       {:error, :not_found} ->
         {:reply, {:error, :chain_not_found}, state}
@@ -688,7 +720,7 @@ defmodule Lasso.Config.ConfigStore do
         "Registered provider #{provider_config.id} for chain #{chain_id} in profile #{profile_id} (runtime)"
       )
 
-      {:reply, :ok, refresh_last_good_specs(state, :ok)}
+      {:reply, :ok, mark_runtime_dirty(state, profile_id, :ok)}
     else
       {:error, :not_found} -> {:reply, {:error, :chain_not_found}, state}
       {:error, :already_exists} -> {:reply, {:error, :already_exists}, state}
@@ -709,7 +741,7 @@ defmodule Lasso.Config.ConfigStore do
         "Unregistered provider #{provider_id} from chain #{chain_id} in profile #{profile_id} (runtime)"
       )
 
-      {:reply, :ok, refresh_last_good_specs(state, :ok)}
+      {:reply, :ok, mark_runtime_dirty(state, profile_id, :ok)}
     else
       {:error, :not_found} -> {:reply, {:error, :chain_not_found}, state}
       {:error, :provider_not_found} -> {:reply, {:error, :provider_not_found}, state}
@@ -801,7 +833,7 @@ defmodule Lasso.Config.ConfigStore do
               backend_module.load_all(backend_state)
             end)
 
-          snapshot = current_file_profile_ids()
+          snapshot = current_profile_fingerprints()
 
           {:noreply,
            %{
@@ -828,7 +860,7 @@ defmodule Lasso.Config.ConfigStore do
     case result do
       {:ok, specs} ->
         Logger.info("ConfigStore: retry succeeded, exiting degraded mode")
-        apply_retry_deltas(specs, snapshot)
+        apply_retry_deltas(specs, snapshot, state.runtime_dirty_profiles)
         {:noreply, %{state | db_degraded: false, last_loaded: DateTime.utc_now()}}
 
       {:degraded, _specs} ->
@@ -1027,28 +1059,45 @@ defmodule Lasso.Config.ConfigStore do
 
   # Apply a completed retry as deltas. Snapshot bounds removals so runtime
   # updates made while the backend read was running are preserved.
-  defp apply_retry_deltas(loaded_specs, spawn_snapshot) do
-    spawn_snapshot = spawn_snapshot || MapSet.new()
+  defp apply_retry_deltas(loaded_specs, spawn_snapshot, runtime_dirty_profiles) do
+    spawn_snapshot = spawn_snapshot || %{}
+    spawn_ids = MapSet.new(Map.keys(spawn_snapshot))
     loaded_by_id = Map.new(loaded_specs, &{&1.profile_id, &1})
     loaded_ids = MapSet.new(Map.keys(loaded_by_id))
 
     current_ids = current_file_profile_ids()
+    current_fingerprints = current_profile_fingerprints()
 
     to_remove =
-      spawn_snapshot
+      spawn_ids
       |> MapSet.intersection(current_ids)
       |> MapSet.difference(loaded_ids)
+      |> Enum.filter(fn profile_id ->
+        not MapSet.member?(runtime_dirty_profiles, profile_id) and
+          Map.get(current_fingerprints, profile_id) == Map.get(spawn_snapshot, profile_id)
+      end)
 
     old_pairs = collect_profile_chain_pairs()
     old_chain_ids = list_chain_ids()
 
     changed_profile_ids =
       Enum.flat_map(loaded_specs, fn spec ->
+        current_fingerprint = Map.get(current_fingerprints, spec.profile_id)
+        spawn_fingerprint = Map.get(spawn_snapshot, spec.profile_id)
+
         result =
-          if MapSet.member?(current_ids, spec.profile_id) do
-            do_update_profile_without_rebuild(spec)
-          else
-            do_inject_profile_without_rebuild(spec)
+          cond do
+            MapSet.member?(runtime_dirty_profiles, spec.profile_id) ->
+              :runtime_dirty
+
+            not MapSet.member?(current_ids, spec.profile_id) ->
+              do_inject_profile_without_rebuild(spec)
+
+            current_fingerprint == spawn_fingerprint ->
+              do_update_profile_without_rebuild(spec)
+
+            true ->
+              :unchanged_since_retry_started
           end
 
         case result do
@@ -1144,7 +1193,21 @@ defmodule Lasso.Config.ConfigStore do
   # Set of file-backed profile IDs currently in ETS.
   defp current_file_profile_ids, do: list_profiles() |> MapSet.new()
 
+  defp current_profile_fingerprints do
+    case snapshot_profile_specs() do
+      specs when is_list(specs) ->
+        Map.new(specs, fn spec -> {spec.profile_id, :erlang.phash2(spec)} end)
+
+      _ ->
+        %{}
+    end
+  end
+
   # Resolution order: keyword option -> app env -> default.
+  defp retry_opt(opts, _key, app_key, default) when is_binary(opts) do
+    Application.get_env(:lasso, app_key, default)
+  end
+
   defp retry_opt(opts, key, app_key, default) do
     case Keyword.fetch(opts, key) do
       {:ok, value} -> value
@@ -1379,10 +1442,17 @@ defmodule Lasso.Config.ConfigStore do
     ArgumentError -> nil
   end
 
+  defp mark_runtime_dirty(state, profile_id, reply) do
+    if reply == :ok do
+      state = refresh_last_good_specs(state, :ok)
+      %{state | runtime_dirty_profiles: MapSet.put(state.runtime_dirty_profiles, profile_id)}
+    else
+      state
+    end
+  end
+
   defp refresh_last_good_specs(state, :ok),
     do: %{state | last_good_specs: snapshot_profile_specs()}
-
-  defp refresh_last_good_specs(state, _reply), do: state
 
   defp resolve_with_meta(scope, slug) do
     with {:ok, profile_id} <- resolve(scope, slug),
@@ -1721,15 +1791,18 @@ defmodule Lasso.Config.ConfigStore do
     monitoring_attrs = Map.get(attrs, :monitoring) || Map.get(attrs, "monitoring") || %{}
     providers_attrs = Map.get(attrs, :providers) || Map.get(attrs, "providers") || []
 
+    display_name =
+      Map.get(attrs, :display_name) || Map.get(attrs, "display_name") ||
+        Map.get(attrs, :name) || Map.get(attrs, "name")
+
     %ChainConfig{
       chain_id: chain_id,
-      display_name:
-        Map.get(attrs, :display_name) || Map.get(attrs, "display_name") ||
-          Map.get(attrs, :name) || Map.get(attrs, "name"),
+      name: display_name,
+      display_name: display_name,
       url_aliases:
         attrs
         |> Map.get(:url_aliases, Map.get(attrs, "url_aliases"))
-        |> normalize_url_aliases(Map.get(attrs, :name) || Map.get(attrs, "name")),
+        |> normalize_url_aliases(),
       providers: Enum.map(providers_attrs, &normalize_provider_config/1),
       websocket: normalize_websocket_config(websocket_attrs),
       selection: normalize_selection_config(selection_attrs),
@@ -1737,12 +1810,11 @@ defmodule Lasso.Config.ConfigStore do
     }
   end
 
-  defp normalize_url_aliases(aliases, _fallback) when is_list(aliases) do
+  defp normalize_url_aliases(aliases) when is_list(aliases) do
     Enum.filter(aliases, &(is_binary(&1) and String.trim(&1) != ""))
   end
 
-  defp normalize_url_aliases(_aliases, fallback) when is_binary(fallback), do: [fallback]
-  defp normalize_url_aliases(_aliases, _fallback), do: []
+  defp normalize_url_aliases(_aliases), do: []
 
   defp normalize_websocket_config(attrs) when is_map(attrs) do
     failover_attrs = Map.get(attrs, :failover) || Map.get(attrs, "failover") || %{}

--- a/lib/lasso/config/config_store/owner.ex
+++ b/lib/lasso/config/config_store/owner.ex
@@ -1,0 +1,46 @@
+defmodule Lasso.Config.ConfigStore.Owner do
+  @moduledoc false
+
+  use GenServer
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_opts \\ []), do: GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+
+  @spec schedule_delete(:ets.tid(), non_neg_integer()) :: :ok
+  def schedule_delete(table, delay_ms) do
+    GenServer.cast(__MODULE__, {:schedule_delete, table, delay_ms})
+  end
+
+  @impl true
+  def init(state), do: {:ok, state, {:continue, :notify_config_store}}
+
+  @impl true
+  def handle_continue(:notify_config_store, state) do
+    if pid = Process.whereis(Lasso.Config.ConfigStore) do
+      send(pid, {:config_store_owner_restarted, self()})
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:schedule_delete, table, delay_ms}, state) do
+    Process.send_after(self(), {:delete, table}, delay_ms)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_info({:"ETS-TRANSFER", _table, _from, :config_store}, state), do: {:noreply, state}
+
+  def handle_info({:delete, table}, state) do
+    case :ets.info(table, :owner) do
+      owner when owner == self() -> :ets.delete(table)
+      owner when is_pid(owner) -> send(owner, {:delete_old_table, table})
+      _ -> :ok
+    end
+
+    {:noreply, state}
+  rescue
+    ArgumentError -> {:noreply, state}
+  end
+end

--- a/lib/lasso/config/method_constraints.ex
+++ b/lib/lasso/config/method_constraints.ex
@@ -2,8 +2,8 @@ defmodule Lasso.Config.MethodConstraints do
   @moduledoc """
   Public facade for method constraints (ws-only, disallowed, transports).
 
-  Delegates to TransportPolicy for now to preserve backward compatibility,
-  allowing future renaming without widespread churn.
+  Delegates to TransportPolicy to preserve the existing public interface
+  while keeping transport policy definitions in one place.
   """
 
   alias Lasso.Config.TransportPolicy

--- a/lib/lasso/config/monitoring_defaults.ex
+++ b/lib/lasso/config/monitoring_defaults.ex
@@ -1,0 +1,68 @@
+defmodule Lasso.Config.MonitoringDefaults do
+  @moduledoc """
+  Block-time-aware default derivations for probe and monitoring intervals.
+
+  Single source of truth for the two interval formulas used by:
+  - `ConfigBackendDB` (defaults at config-load time)
+  - `ConfigGenerator` (defaults at provider-config generation time)
+  - `ProbeCoordinator` (Phase 3b — per-instance effective interval)
+  - `BlockSync.Worker` (Phase 3b — per-instance effective interval)
+  - `EditChainPanel` (Phase 3c — UI input ceiling clamp)
+
+  ## Formulas
+
+  Both formulas share the same structural pattern: `max(block_time * factor, floor)`.
+
+  `default_probe_interval_ms/1`:
+    factor = 2 (poll twice per expected block), floor = 5_000ms.
+    - Mainnet (12 000ms) → 24 000ms (two polls per 12s block)
+    - Base/Optimism (2 000ms) → 5 000ms (floor, not 4 000ms — avoids F1
+      recurrence on chains with slight timing jitter)
+    - Arbitrum (250ms) → 5 000ms (floor — 40 blocks of allowed staleness)
+
+  `probe_interval_ceiling_ms/1`:
+    factor = 10 (10 blocks of allowed staleness), floor = 10_000ms.
+    - Mainnet (12 000ms) → 120 000ms (10 × 12s)
+    - Arbitrum (250ms) → 10 000ms (floor — 40 blocks; prevents a sub-second
+      ceiling from thrashing the probe loop on pathologically fast chains)
+
+  ## Unknown chains
+
+  When `block_time_ms` is `nil` or not a positive integer, both functions
+  fall through to wide fallbacks (12 000ms default, 60 000ms ceiling). These
+  apply only until the chain's block time is known — either from
+  `ChainRegistry` or from the discovery block-time sampling introduced in
+  Phase 3a.
+  """
+
+  @doc """
+  Derives the default probe interval from the chain's block time.
+
+  Returns `max(block_time_ms * 2, 5_000)` for known block times;
+  falls back to `12_000` when block time is unknown.
+  """
+  @spec default_probe_interval_ms(block_time_ms :: pos_integer() | nil) :: pos_integer()
+  def default_probe_interval_ms(block_time_ms)
+      when is_integer(block_time_ms) and block_time_ms > 0 do
+    max(block_time_ms * 2, 5_000)
+  end
+
+  def default_probe_interval_ms(_), do: 12_000
+
+  @doc """
+  Derives the maximum allowed probe interval (ceiling) from the chain's block time.
+
+  Returns `max(block_time_ms * 10, 10_000)` for known block times;
+  falls back to `60_000` when block time is unknown.
+
+  Used by Phase 3c's `EditChainPanel` to clamp the user-supplied
+  `probe_interval_ms` input: `[3_000, probe_interval_ceiling_ms(block_time_ms)]`.
+  """
+  @spec probe_interval_ceiling_ms(block_time_ms :: pos_integer() | nil) :: pos_integer()
+  def probe_interval_ceiling_ms(block_time_ms)
+      when is_integer(block_time_ms) and block_time_ms > 0 do
+    max(block_time_ms * 10, 10_000)
+  end
+
+  def probe_interval_ceiling_ms(_), do: 60_000
+end

--- a/lib/lasso/config/profile_id.ex
+++ b/lib/lasso/config/profile_id.ex
@@ -1,0 +1,20 @@
+defmodule Lasso.Config.ProfileId do
+  @moduledoc """
+  Opaque routing key for a file-backed profile.
+
+  System profile IDs are their YAML slugs. Callers should treat the value as
+  opaque even though the current file backend makes the two equal.
+  """
+
+  @typedoc "Opaque routing key."
+  @type t :: String.t()
+
+  @spec for_system(String.t()) :: t()
+  def for_system(slug) when is_binary(slug), do: slug
+
+  @spec system?(String.t()) :: boolean()
+  def system?(slug) when is_binary(slug) do
+    canonical = Lasso.Config.ProfileValidator.resolve_alias(slug)
+    match?({:ok, _profile_id}, Lasso.Config.ConfigStore.resolve(:system, canonical))
+  end
+end

--- a/lib/lasso/config/profile_meta.ex
+++ b/lib/lasso/config/profile_meta.ex
@@ -1,0 +1,44 @@
+defmodule Lasso.Config.ProfileMeta do
+  @moduledoc """
+  Profile metadata stored in `Lasso.Config.ConfigStore`.
+
+  Carries the opaque routing identity and YAML slug for a system profile,
+  plus display fields (`name`, `logo`, `unlisted`) and request limits
+  (`rps_limit`, `burst_limit`).
+
+  Use the field accessors (`meta.name`, `meta.rps_limit`, etc.). For
+  optional fields use `Map.get/3` rather than bracket access — structs
+  do not implement `Access`.
+  """
+
+  @enforce_keys [
+    :profile_id,
+    :scope,
+    :slug,
+    :name,
+    :rps_limit,
+    :burst_limit,
+    :unlisted
+  ]
+  defstruct [
+    :profile_id,
+    :scope,
+    :slug,
+    :name,
+    :logo,
+    :rps_limit,
+    :burst_limit,
+    :unlisted
+  ]
+
+  @type t :: %__MODULE__{
+          profile_id: String.t(),
+          scope: :system,
+          slug: String.t(),
+          name: String.t(),
+          logo: String.t() | nil,
+          rps_limit: pos_integer(),
+          burst_limit: pos_integer(),
+          unlisted: boolean()
+        }
+end

--- a/lib/lasso/config/profile_validator.ex
+++ b/lib/lasso/config/profile_validator.ex
@@ -34,7 +34,6 @@ defmodule Lasso.Config.ProfileValidator do
       {:ok, profile} = ProfileValidator.validate_with_default(maybe_nil_profile)
   """
 
-  require Logger
   alias Lasso.Config.ConfigStore
 
   @default_profile "public"
@@ -53,6 +52,7 @@ defmodule Lasso.Config.ProfileValidator do
           :profile_nil
           | :profile_invalid_type
           | :profile_empty
+          | :profile_invalid_format
           | :profile_not_found
 
   @type validation_result ::
@@ -80,33 +80,44 @@ defmodule Lasso.Config.ProfileValidator do
       {:error, :profile_not_found, "Profile 'nonexistent' not found"}
   """
   @spec validate(term()) :: validation_result()
-  def validate(nil) do
+  def validate(profile) do
+    case validate_format(profile) do
+      {:ok, canonical} -> validate_existence(canonical, profile)
+      {:error, _, _} = err -> err
+    end
+  end
+
+  @doc """
+  Format-only validation: checks `nil`, type, and emptiness, then returns
+  the alias-resolved canonical slug. It does not verify existence in
+  `ConfigStore`.
+  """
+  @spec validate_format(term()) :: validation_result()
+  def validate_format(nil) do
     {:error, :profile_nil, "Profile parameter is required"}
   end
 
-  def validate(profile) when not is_binary(profile) do
+  def validate_format(profile) when not is_binary(profile) do
     {:error, :profile_invalid_type, "Profile must be a string, got: #{inspect(profile)}"}
   end
 
-  def validate(profile) when is_binary(profile) do
+  def validate_format(profile) when is_binary(profile) do
     trimmed = String.trim(profile)
 
     if trimmed == "" do
       {:error, :profile_empty, "Profile cannot be empty"}
     else
-      canonical = resolve_alias(trimmed)
+      {:ok, resolve_alias(trimmed)}
+    end
+  end
 
-      case ConfigStore.get_profile(canonical) do
-        {:ok, _meta} ->
-          {:ok, canonical}
+  defp validate_existence(canonical, original) do
+    case ConfigStore.resolve(:system, canonical) do
+      {:ok, _profile_id} ->
+        {:ok, canonical}
 
-        {:error, :not_found} ->
-          {:error, :profile_not_found, "Profile '#{trimmed}' not found"}
-
-        {:error, reason} ->
-          Logger.warning("Profile validation failed for '#{canonical}': #{inspect(reason)}")
-          {:error, :profile_not_found, "Profile '#{canonical}' not found"}
-      end
+      {:error, :not_found} ->
+        {:error, :profile_not_found, "Profile '#{original}' not found"}
     end
   end
 
@@ -203,10 +214,11 @@ defmodule Lasso.Config.ProfileValidator do
       iex> ProfileValidator.error_to_http_status(:profile_not_found)
       404
   """
-  @spec error_to_http_status(validation_error()) :: integer()
+  @spec error_to_http_status(validation_error() | atom()) :: integer()
   def error_to_http_status(:profile_nil), do: 400
   def error_to_http_status(:profile_invalid_type), do: 400
   def error_to_http_status(:profile_empty), do: 400
+  def error_to_http_status(:profile_invalid_format), do: 400
   def error_to_http_status(:profile_not_found), do: 404
 
   @doc """
@@ -223,10 +235,11 @@ defmodule Lasso.Config.ProfileValidator do
       iex> ProfileValidator.error_to_jsonrpc_code(:profile_not_found)
       -32000
   """
-  @spec error_to_jsonrpc_code(validation_error()) :: integer()
+  @spec error_to_jsonrpc_code(validation_error() | atom()) :: integer()
   def error_to_jsonrpc_code(:profile_nil), do: -32_602
   def error_to_jsonrpc_code(:profile_invalid_type), do: -32_602
   def error_to_jsonrpc_code(:profile_empty), do: -32_602
+  def error_to_jsonrpc_code(:profile_invalid_format), do: -32_602
   def error_to_jsonrpc_code(:profile_not_found), do: -32_000
 
   @doc """
@@ -234,8 +247,7 @@ defmodule Lasso.Config.ProfileValidator do
   canonical name.
 
   The alias map is read from `config :lasso, :profile_aliases` and defaults
-  to `%{}`. Lasso Cloud configures this to handle the `default`→`public` and
-  `premium`→`managed` rename; OSS deployments are unaffected.
+  to `%{}`. OSS retains `default` as a compatibility alias for `public`.
   """
   @spec resolve_alias(String.t()) :: String.t()
   def resolve_alias(slug) when is_binary(slug) do

--- a/lib/lasso/config/runtime_config.ex
+++ b/lib/lasso/config/runtime_config.ex
@@ -26,9 +26,10 @@ defmodule Lasso.Config.RuntimeConfig do
   @doc """
   Gets chain configuration with sensible defaults.
   """
-  @spec get_chain_config(String.t(), String.t()) :: {:ok, chain_config()} | {:error, term()}
-  def get_chain_config(profile, chain_name) do
-    case ConfigStore.get_chain(profile, chain_name) do
+  @spec get_chain_config(String.t(), pos_integer() | String.t()) ::
+          {:ok, chain_config()} | {:error, term()}
+  def get_chain_config(profile, chain_id) do
+    case ConfigStore.get_chain(profile, chain_id) do
       {:ok, config} ->
         {:ok, normalize_chain_config(config)}
 
@@ -40,10 +41,10 @@ defmodule Lasso.Config.RuntimeConfig do
   @doc """
   Gets provider configuration with validation.
   """
-  @spec get_provider_config(String.t(), String.t(), String.t()) ::
+  @spec get_provider_config(String.t(), pos_integer(), String.t()) ::
           {:ok, provider_config()} | {:error, term()}
-  def get_provider_config(profile, chain_name, provider_id) do
-    case ConfigStore.get_provider(profile, chain_name, provider_id) do
+  def get_provider_config(profile, chain_id, provider_id) do
+    case ConfigStore.get_provider(profile, chain_id, provider_id) do
       {:ok, config} ->
         {:ok, normalize_provider_config(config)}
 
@@ -55,10 +56,10 @@ defmodule Lasso.Config.RuntimeConfig do
   @doc """
   Gets all providers for a chain in priority order.
   """
-  @spec get_chain_providers(String.t(), String.t()) ::
+  @spec get_chain_providers(String.t(), pos_integer()) ::
           {:ok, [provider_config()]} | {:error, term()}
-  def get_chain_providers(profile, chain_name) do
-    case ConfigStore.get_providers(profile, chain_name) do
+  def get_chain_providers(profile, chain_id) do
+    case ConfigStore.get_providers(profile, chain_id) do
       {:ok, providers} ->
         normalized =
           providers
@@ -119,12 +120,12 @@ defmodule Lasso.Config.RuntimeConfig do
   @doc """
   Creates a scoped configuration for a specific module/process.
   """
-  @spec create_scoped_config(String.t(), String.t(), keyword()) :: map()
-  def create_scoped_config(profile, chain_name, opts \\ []) do
-    with {:ok, chain_config} <- get_chain_config(profile, chain_name),
-         {:ok, providers} <- get_chain_providers(profile, chain_name) do
+  @spec create_scoped_config(String.t(), pos_integer(), keyword()) :: map()
+  def create_scoped_config(profile, chain_id, opts \\ []) do
+    with {:ok, chain_config} <- get_chain_config(profile, chain_id),
+         {:ok, providers} <- get_chain_providers(profile, chain_id) do
       %{
-        chain: chain_name,
+        chain: chain_id,
         chain_config: chain_config,
         providers: providers,
         metrics_backend: get_metrics_backend(),

--- a/lib/lasso/core/benchmarking/benchmark_store.ex
+++ b/lib/lasso/core/benchmarking/benchmark_store.ex
@@ -16,7 +16,7 @@ defmodule Lasso.Benchmarking.BenchmarkStore do
   require Logger
 
   @type profile :: String.t()
-  @type chain_name :: String.t()
+  @type chain_name :: pos_integer()
   @type provider_id :: String.t()
   @type method :: String.t()
   @type result :: :success | :error | :timeout | :network_error | :rate_limit | atom()

--- a/lib/lasso/core/benchmarking/benchmark_store_adapter.ex
+++ b/lib/lasso/core/benchmarking/benchmark_store_adapter.ex
@@ -72,7 +72,7 @@ defmodule Lasso.RPC.Metrics.BenchmarkStore do
 
   @impl true
   def record_request(profile, chain, provider_id, method, duration_ms, result, opts) do
-    transport = Keyword.get(opts, :transport, :http)
+    transport = Keyword.get(opts, :transport) || :http
 
     method_key = "#{method}@#{transport}"
 

--- a/lib/lasso/core/benchmarking/metrics.ex
+++ b/lib/lasso/core/benchmarking/metrics.ex
@@ -11,7 +11,7 @@ defmodule Lasso.Core.Benchmarking.Metrics do
   """
 
   @type profile :: String.t()
-  @type chain :: String.t()
+  @type chain :: pos_integer()
   @type provider_id :: String.t()
   @type method :: String.t()
   @type result :: :success | :error

--- a/lib/lasso/core/block_cache.ex
+++ b/lib/lasso/core/block_cache.ex
@@ -19,7 +19,7 @@ defmodule Lasso.Core.BlockCache do
       heights = BlockCache.get_all_provider_heights("ethereum")
 
       # Subscribe to real-time updates for a profile
-      Phoenix.PubSub.subscribe(Lasso.PubSub, BlockCache.pubsub_topic("public"))
+      Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.block_cache_updates("public"))
 
   ## Data Format
 
@@ -39,13 +39,12 @@ defmodule Lasso.Core.BlockCache do
   require Logger
 
   @table_name :lasso_block_cache
-  @pubsub_topic_base "block_cache:updates"
 
   # Data freshness window (15 seconds)
   @freshness_window_ms 15_000
 
   # Types
-  @type chain :: String.t()
+  @type chain :: pos_integer()
   @type provider_id :: String.t()
   @type block_data :: %{
           number: non_neg_integer(),
@@ -71,12 +70,6 @@ defmodule Lasso.Core.BlockCache do
   """
   @spec table_name() :: atom()
   def table_name, do: @table_name
-
-  @doc """
-  Get the PubSub topic for subscribing to block updates for a specific profile.
-  """
-  @spec pubsub_topic(String.t()) :: String.t()
-  def pubsub_topic(profile), do: "#{@pubsub_topic_base}:#{profile}"
 
   @doc """
   Store a new block from a provider's newHeads subscription.
@@ -245,7 +238,7 @@ defmodule Lasso.Core.BlockCache do
         end
 
         # Broadcast update to profile-scoped topic
-        Phoenix.PubSub.broadcast(Lasso.PubSub, pubsub_topic(profile), %{
+        Phoenix.PubSub.broadcast(Lasso.PubSub, Lasso.Topics.block_cache_updates(profile), %{
           type: :block_update,
           chain: chain,
           provider_id: provider_id,

--- a/lib/lasso/core/block_sync/initializer.ex
+++ b/lib/lasso/core/block_sync/initializer.ex
@@ -10,9 +10,9 @@ defmodule Lasso.BlockSync.Initializer do
   alias Lasso.BlockSync.Supervisor, as: BlockSyncSupervisor
   alias Lasso.Providers.Catalog
 
-  @spec start_workers_for_chain(String.t()) :: :ok
-  def start_workers_for_chain(chain) do
-    instance_ids = Catalog.list_instances_for_chain(chain)
-    BlockSyncSupervisor.start_all_workers(chain, instance_ids)
+  @spec start_workers_for_chain(pos_integer()) :: :ok
+  def start_workers_for_chain(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    instance_ids = Catalog.list_instances_for_chain(chain_id)
+    BlockSyncSupervisor.start_all_workers(chain_id, instance_ids)
   end
 end

--- a/lib/lasso/core/block_sync/registry.ex
+++ b/lib/lasso/core/block_sync/registry.ex
@@ -9,8 +9,8 @@ defmodule Lasso.BlockSync.Registry do
   ## ETS Schema
 
   Keys are tuples for efficient lookups:
-  - `{:height, chain, provider_id}` => `{height, timestamp_ms, source, metadata}`
-  - `{:block_time, chain}` => `%BlockTimeMeasurement{}`
+  - `{:height, chain_id, provider_id}` => `{height, timestamp_ms, source, metadata}`
+  - `{:block_time, chain_id}` => `%BlockTimeMeasurement{}`
 
   ## Freshness
 
@@ -34,20 +34,20 @@ defmodule Lasso.BlockSync.Registry do
   Store a block height from a provider.
 
   ## Parameters
-  - `chain` - Chain identifier (e.g., "ethereum")
+  - `chain_id` - Chain identifier (EIP-155 integer, e.g. 1 for Ethereum mainnet)
   - `provider_id` - Provider identifier
   - `height` - Block height (integer)
   - `source` - `:ws` or `:http`
   - `metadata` - Optional map with additional data (hash, timestamp, latency_ms)
   """
-  @spec put_height(String.t(), String.t(), integer(), :ws | :http, map()) :: :ok
-  def put_height(chain, provider_id, height, source, metadata \\ %{})
-      when is_binary(chain) and is_binary(provider_id) and is_integer(height) do
+  @spec put_height(pos_integer(), String.t(), integer(), :ws | :http, map()) :: :ok
+  def put_height(chain_id, provider_id, height, source, metadata \\ %{})
+      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) and
+             is_integer(height) do
     timestamp = System.system_time(:millisecond)
-    :ets.insert(@table, {{:height, chain, provider_id}, {height, timestamp, source, metadata}})
+    :ets.insert(@table, {{:height, chain_id, provider_id}, {height, timestamp, source, metadata}})
 
-    # Update block time measurement (tracks max height seen across all providers)
-    update_block_time(chain, height)
+    update_block_time(chain_id, height)
 
     :ok
   end
@@ -57,10 +57,11 @@ defmodule Lasso.BlockSync.Registry do
 
   Returns `{:ok, {height, timestamp, source, metadata}}` or `{:error, :not_found}`.
   """
-  @spec get_height(String.t(), String.t()) ::
+  @spec get_height(pos_integer(), String.t()) ::
           {:ok, {integer(), integer(), :ws | :http, map()}} | {:error, :not_found}
-  def get_height(chain, provider_id) when is_binary(chain) and is_binary(provider_id) do
-    case :ets.lookup(@table, {:height, chain, provider_id}) do
+  def get_height(chain_id, provider_id)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) do
+    case :ets.lookup(@table, {:height, chain_id, provider_id}) do
       [{_key, value}] -> {:ok, value}
       [] -> {:error, :not_found}
     end
@@ -75,43 +76,29 @@ defmodule Lasso.BlockSync.Registry do
 
   Only considers heights from the last `freshness_ms` milliseconds.
 
-  ## Parameters
-  - `chain` - Chain identifier
-  - `freshness_ms` - Maximum age of data to consider (default: 30 seconds)
-
   Returns `{:ok, height}` or `{:error, :no_data}`.
   """
-  @spec get_consensus_height(String.t(), non_neg_integer()) ::
+  @spec get_consensus_height(pos_integer(), non_neg_integer()) ::
           {:ok, integer()} | {:error, :no_data}
-  def get_consensus_height(chain, freshness_ms \\ @default_freshness_ms)
-      when is_binary(chain) do
-    calculate_consensus(chain, nil, freshness_ms)
+  def get_consensus_height(chain_id, freshness_ms \\ @default_freshness_ms)
+      when is_integer(chain_id) and chain_id > 0 do
+    calculate_consensus(chain_id, nil, freshness_ms)
   end
 
   @doc """
   Get consensus height filtered by specific providers.
 
-  ## Parameters
-  - `chain` - Chain identifier
-  - `provider_ids` - List of provider IDs to consider. If nil or empty, uses all providers.
-  - `freshness_ms` - Maximum age of data to consider (default: 30 seconds)
-
   Returns `{:ok, height}` or `{:error, :no_data}`.
   """
-  @spec get_consensus_height_filtered(String.t(), [String.t()] | nil, non_neg_integer()) ::
+  @spec get_consensus_height_filtered(pos_integer(), [String.t()] | nil, non_neg_integer()) ::
           {:ok, integer()} | {:error, :no_data}
-  def get_consensus_height_filtered(chain, provider_ids, freshness_ms \\ @default_freshness_ms)
-      when is_binary(chain) do
-    calculate_consensus(chain, provider_ids, freshness_ms)
+  def get_consensus_height_filtered(chain_id, provider_ids, freshness_ms \\ @default_freshness_ms)
+      when is_integer(chain_id) and chain_id > 0 do
+    calculate_consensus(chain_id, provider_ids, freshness_ms)
   end
 
   @doc """
   Calculate provider's lag compared to consensus height.
-
-  ## Parameters
-  - `chain` - Chain identifier
-  - `provider_id` - Provider to check lag for
-  - `freshness_ms` - Maximum age of data to consider (default: 30 seconds)
 
   Returns:
   - `{:ok, lag}` where lag is `provider_height - consensus_height`
@@ -119,14 +106,14 @@ defmodule Lasso.BlockSync.Registry do
   - `{:error, :no_provider_data}` if provider has no height data
   - `{:error, :no_consensus}` if no consensus can be calculated
   """
-  @spec get_provider_lag(String.t(), String.t(), non_neg_integer()) ::
+  @spec get_provider_lag(pos_integer(), String.t(), non_neg_integer()) ::
           {:ok, integer()} | {:error, :no_provider_data | :no_consensus | :stale_data}
-  def get_provider_lag(chain, provider_id, freshness_ms \\ @default_freshness_ms)
-      when is_binary(chain) and is_binary(provider_id) do
-    with {:ok, {height, timestamp, _source, _meta}} <- get_height(chain, provider_id),
+  def get_provider_lag(chain_id, provider_id, freshness_ms \\ @default_freshness_ms)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) do
+    with {:ok, {height, timestamp, _source, _meta}} <- get_height(chain_id, provider_id),
          age = System.system_time(:millisecond) - timestamp,
          true <- age <= freshness_ms,
-         {:ok, consensus} <- get_consensus_height(chain, freshness_ms) do
+         {:ok, consensus} <- get_consensus_height(chain_id, freshness_ms) do
       {:ok, height - consensus}
     else
       false -> {:error, :stale_data}
@@ -140,10 +127,12 @@ defmodule Lasso.BlockSync.Registry do
 
   Returns a map of `provider_id => {height, timestamp, source, metadata}`.
   """
-  @spec get_all_heights(String.t()) :: %{String.t() => {integer(), integer(), :ws | :http, map()}}
-  def get_all_heights(chain) when is_binary(chain) do
+  @spec get_all_heights(pos_integer()) :: %{
+          String.t() => {integer(), integer(), :ws | :http, map()}
+        }
+  def get_all_heights(chain_id) when is_integer(chain_id) and chain_id > 0 do
     match_spec = [
-      {{{:height, chain, :"$1"}, :"$2"}, [], [{{:"$1", :"$2"}}]}
+      {{{:height, chain_id, :"$1"}, :"$2"}, [], [{{:"$1", :"$2"}}]}
     ]
 
     :ets.select(@table, match_spec)
@@ -155,14 +144,13 @@ defmodule Lasso.BlockSync.Registry do
 
   Returns a map of provider_id => %{height: ..., source: ..., lag: ..., ...}
   """
-  @spec get_chain_status(String.t()) :: %{String.t() => map()}
-  def get_chain_status(chain) when is_binary(chain) do
-    heights = get_all_heights(chain)
+  @spec get_chain_status(pos_integer()) :: %{String.t() => map()}
+  def get_chain_status(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    heights = get_all_heights(chain_id)
     now = System.system_time(:millisecond)
 
-    # Get consensus for lag calculation
     consensus =
-      case get_consensus_height(chain) do
+      case get_consensus_height(chain_id) do
         {:ok, h} -> h
         _ -> nil
       end
@@ -187,10 +175,10 @@ defmodule Lasso.BlockSync.Registry do
   @doc """
   Clear all data for a chain. Useful for testing.
   """
-  @spec clear_chain(String.t()) :: :ok
-  def clear_chain(chain) when is_binary(chain) do
-    :ets.match_delete(@table, {{:height, chain, :_}, :_})
-    :ets.delete(@table, {:block_time, chain})
+  @spec clear_chain(pos_integer()) :: :ok
+  def clear_chain(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    :ets.match_delete(@table, {{:height, chain_id, :_}, :_})
+    :ets.delete(@table, {:block_time, chain_id})
     :ok
   end
 
@@ -202,10 +190,10 @@ defmodule Lasso.BlockSync.Registry do
   Returns the measured block time if enough samples have been collected,
   otherwise returns nil.
   """
-  @spec get_block_time_ms(String.t()) :: non_neg_integer() | nil
-  def get_block_time_ms(chain) when is_binary(chain) do
-    case :ets.lookup(@table, {:block_time, chain}) do
-      [{{:block_time, ^chain}, measurement}] ->
+  @spec get_block_time_ms(pos_integer()) :: non_neg_integer() | nil
+  def get_block_time_ms(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    case :ets.lookup(@table, {:block_time, chain_id}) do
+      [{{:block_time, ^chain_id}, measurement}] ->
         BlockTimeMeasurement.get_block_time_ms(measurement, nil)
 
       [] ->
@@ -219,27 +207,27 @@ defmodule Lasso.BlockSync.Registry do
   Should be called whenever the consensus height changes to track
   inter-block timing.
   """
-  @spec update_block_time(String.t(), non_neg_integer()) :: :ok
-  def update_block_time(chain, height) when is_binary(chain) and is_integer(height) do
+  @spec update_block_time(pos_integer(), non_neg_integer()) :: :ok
+  def update_block_time(chain_id, height)
+      when is_integer(chain_id) and chain_id > 0 and is_integer(height) do
     measurement =
-      case :ets.lookup(@table, {:block_time, chain}) do
-        [{{:block_time, ^chain}, m}] -> m
+      case :ets.lookup(@table, {:block_time, chain_id}) do
+        [{{:block_time, ^chain_id}, m}] -> m
         [] -> %BlockTimeMeasurement{}
       end
 
     updated = BlockTimeMeasurement.record(measurement, height)
-    :ets.insert(@table, {{:block_time, chain}, updated})
+    :ets.insert(@table, {{:block_time, chain_id}, updated})
     :ok
   end
 
   ## Private Functions
 
-  defp calculate_consensus(chain, provider_ids, freshness_ms) do
+  defp calculate_consensus(chain_id, provider_ids, freshness_ms) do
     now = System.system_time(:millisecond)
     cutoff = now - freshness_ms
 
-    # Find all fresh heights for this chain
-    heights = get_all_heights(chain)
+    heights = get_all_heights(chain_id)
 
     # Filter by provider_ids if specified
     heights_filtered =

--- a/lib/lasso/core/block_sync/strategies/http_strategy.ex
+++ b/lib/lasso/core/block_sync/strategies/http_strategy.ex
@@ -34,10 +34,11 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
 
   defstruct [
     :instance_id,
-    :chain,
+    :chain_id,
     :parent,
     :poll_interval_ms,
     :timer_ref,
+    :poll_generation,
     :consecutive_failures,
     :last_height,
     :last_poll_time
@@ -45,10 +46,11 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
 
   @type t :: %__MODULE__{
           instance_id: String.t(),
-          chain: String.t(),
+          chain_id: pos_integer(),
           parent: pid(),
           poll_interval_ms: non_neg_integer(),
           timer_ref: reference() | nil,
+          poll_generation: reference() | nil,
           consecutive_failures: non_neg_integer(),
           last_height: non_neg_integer() | nil,
           last_poll_time: integer() | nil
@@ -57,19 +59,20 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
   ## Strategy Callbacks
 
   @impl true
-  def start(chain, instance_id, opts) do
+  def start(chain_id, instance_id, opts) do
     parent = Keyword.get(opts, :parent, self())
     poll_interval = Keyword.get(opts, :poll_interval_ms, @default_poll_interval_ms)
 
     state = %__MODULE__{
       instance_id: instance_id,
-      chain: chain,
+      chain_id: chain_id,
       parent: parent,
       poll_interval_ms: poll_interval,
       consecutive_failures: 0,
       last_height: nil,
       last_poll_time: nil,
-      timer_ref: nil
+      timer_ref: nil,
+      poll_generation: nil
     }
 
     state = schedule_poll(state, 0)
@@ -103,11 +106,13 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
   end
 
   @impl true
-  def handle_message(:poll, state) do
+  def handle_message({:poll, generation}, %__MODULE__{poll_generation: generation} = state) do
     new_state = execute_poll(state)
     new_state = schedule_poll(new_state, new_state.poll_interval_ms)
     {:ok, new_state}
   end
+
+  def handle_message({:poll, _stale_generation}, %__MODULE__{} = state), do: {:ok, state}
 
   def handle_message(_other, state) do
     {:ok, state}
@@ -121,20 +126,29 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
   @spec set_poll_interval(t(), pos_integer()) :: t()
   def set_poll_interval(%__MODULE__{} = state, interval_ms)
       when is_integer(interval_ms) and interval_ms > 0 do
-    %{state | poll_interval_ms: interval_ms}
+    if state.timer_ref, do: Process.cancel_timer(state.timer_ref)
+    schedule_poll(%{state | poll_interval_ms: interval_ms}, interval_ms)
   end
 
   ## Private Functions
 
   defp schedule_poll(state, delay_ms) do
-    ref = Process.send_after(state.parent, {:http_strategy, :poll, state.instance_id}, delay_ms)
-    %{state | timer_ref: ref}
+    generation = make_ref()
+
+    ref =
+      Process.send_after(
+        state.parent,
+        {:http_strategy, :poll, state.instance_id, generation},
+        delay_ms
+      )
+
+    %{state | timer_ref: ref, poll_generation: generation}
   end
 
   defp execute_poll(%__MODULE__{} = state) do
     start_time = System.monotonic_time(:millisecond)
 
-    result = do_poll(state.instance_id, state.chain)
+    result = do_poll(state.instance_id, state.chain_id)
     latency_ms = System.monotonic_time(:millisecond) - start_time
 
     case result do
@@ -165,7 +179,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
 
         if failures == @max_consecutive_failures do
           Logger.warning("HTTP polling degraded",
-            chain: state.chain,
+            chain_id: state.chain_id,
             instance_id: state.instance_id,
             consecutive_failures: failures,
             error: inspect(reason)
@@ -205,10 +219,10 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
     )
   end
 
-  defp do_poll(instance_id, chain) do
+  defp do_poll(instance_id, chain_id) do
     cb_id = {instance_id, :http}
 
-    case CircuitBreaker.call(cb_id, fn -> do_poll_request(instance_id, chain) end) do
+    case CircuitBreaker.call(cb_id, fn -> do_poll_request(instance_id, chain_id) end) do
       {:executed, {:ok, height}} ->
         {:ok, height}
 
@@ -232,8 +246,8 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
     end
   end
 
-  defp do_poll_request(instance_id, chain) do
-    case resolve_channel(instance_id, chain) do
+  defp do_poll_request(instance_id, chain_id) do
+    case resolve_channel(instance_id, chain_id) do
       {:ok, channel} ->
         rpc_request = %{
           "jsonrpc" => "2.0",
@@ -265,7 +279,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
   rescue
     e ->
       Logger.error("HTTP polling crashed",
-        chain: chain,
+        chain_id: chain_id,
         instance_id: instance_id,
         error: Exception.format(:error, e, __STACKTRACE__)
       )
@@ -273,13 +287,13 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
       {:error, {:exception, Exception.message(e)}}
   end
 
-  defp resolve_channel(instance_id, chain) do
+  defp resolve_channel(instance_id, chain_id) do
     case Catalog.get_instance_refs(instance_id) do
       [ref_profile | _] ->
-        provider_id = Catalog.reverse_lookup_provider_id(ref_profile, chain, instance_id)
+        provider_id = Catalog.reverse_lookup_provider_id(ref_profile, chain_id, instance_id)
 
         if provider_id do
-          TransportRegistry.get_channel(ref_profile, chain, provider_id, :http)
+          TransportRegistry.get_channel(ref_profile, chain_id, provider_id, :http)
         else
           {:error, :no_provider_id}
         end

--- a/lib/lasso/core/block_sync/strategies/ws_strategy.ex
+++ b/lib/lasso/core/block_sync/strategies/ws_strategy.ex
@@ -28,7 +28,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
 
   defstruct [
     :instance_id,
-    :chain,
+    :chain_id,
     :parent,
     :staleness_threshold_ms,
     :staleness_timer_ref,
@@ -40,7 +40,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
 
   @type t :: %__MODULE__{
           instance_id: String.t(),
-          chain: String.t(),
+          chain_id: pos_integer(),
           parent: pid(),
           staleness_threshold_ms: non_neg_integer(),
           staleness_timer_ref: reference() | nil,
@@ -53,7 +53,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
   ## Strategy Callbacks
 
   @impl true
-  def start(chain, instance_id, opts) do
+  def start(chain_id, instance_id, opts) do
     parent = Keyword.get(opts, :parent, self())
 
     staleness_threshold =
@@ -61,7 +61,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
 
     state = %__MODULE__{
       instance_id: instance_id,
-      chain: chain,
+      chain_id: chain_id,
       parent: parent,
       staleness_threshold_ms: staleness_threshold,
       staleness_timer_ref: nil,
@@ -134,7 +134,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
   @spec handle_invalidation(t(), term()) :: t()
   def handle_invalidation(%__MODULE__{} = state, reason) do
     Logger.debug("WS subscription invalidated",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id,
       reason: inspect(reason)
     )
@@ -165,7 +165,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
     case InstanceSubscriptionManager.ensure_subscription(state.instance_id, {:newHeads}) do
       {:ok, status} ->
         Logger.debug("WS newHeads subscription registered",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: state.instance_id,
           status: status
         )
@@ -175,7 +175,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
 
       {:error, reason} ->
         Logger.debug("WS subscription failed",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: state.instance_id,
           reason: inspect(reason)
         )
@@ -204,7 +204,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
     cond do
       first_block ->
         Logger.debug("WS subscription active (first block received)",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: state.instance_id,
           height: height
         )
@@ -213,7 +213,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
 
       state.status == :stale ->
         Logger.debug("WS subscription recovered from stale",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: state.instance_id,
           height: height
         )
@@ -269,7 +269,7 @@ defmodule Lasso.BlockSync.Strategies.WsStrategy do
 
   defp mark_stale(state) do
     Logger.warning("WS subscription stale (no events)",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id,
       threshold_ms: state.staleness_threshold_ms
     )

--- a/lib/lasso/core/block_sync/supervisor.ex
+++ b/lib/lasso/core/block_sync/supervisor.ex
@@ -2,7 +2,7 @@ defmodule Lasso.BlockSync.Supervisor do
   @moduledoc """
   Singleton interface to the BlockSync DynamicSupervisor.
 
-  Manages one Worker per (chain, instance_id) pair. Workers are started
+  Manages one Worker per (chain_id, instance_id) pair. Workers are started
   during `start_shared_infrastructure` and can be added/removed at runtime.
   """
 
@@ -12,9 +12,10 @@ defmodule Lasso.BlockSync.Supervisor do
 
   @dynamic_supervisor Lasso.BlockSync.DynamicSupervisor
 
-  @spec start_worker(String.t(), String.t()) :: {:ok, pid()} | {:error, term()}
-  def start_worker(chain, instance_id) when is_binary(chain) and is_binary(instance_id) do
-    spec = {Worker, {chain, instance_id}}
+  @spec start_worker(pos_integer(), String.t()) :: {:ok, pid()} | {:error, term()}
+  def start_worker(chain_id, instance_id)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) do
+    spec = {Worker, {chain_id, instance_id}}
 
     case DynamicSupervisor.start_child(@dynamic_supervisor, spec) do
       {:ok, pid} ->
@@ -25,7 +26,7 @@ defmodule Lasso.BlockSync.Supervisor do
 
       {:error, reason} ->
         Logger.warning("Failed to start BlockSync worker",
-          chain: chain,
+          chain_id: chain_id,
           instance_id: instance_id,
           reason: inspect(reason)
         )
@@ -34,9 +35,10 @@ defmodule Lasso.BlockSync.Supervisor do
     end
   end
 
-  @spec stop_worker(String.t(), String.t()) :: :ok | {:error, term()}
-  def stop_worker(chain, instance_id) when is_binary(chain) and is_binary(instance_id) do
-    case GenServer.whereis(Worker.via(chain, instance_id)) do
+  @spec stop_worker(pos_integer(), String.t()) :: :ok | {:error, term()}
+  def stop_worker(chain_id, instance_id)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) do
+    case GenServer.whereis(Worker.via(chain_id, instance_id)) do
       nil ->
         :ok
 
@@ -48,16 +50,16 @@ defmodule Lasso.BlockSync.Supervisor do
     end
   end
 
-  @spec start_all_workers(String.t(), [String.t()]) :: :ok
-  def start_all_workers(chain, instance_ids)
-      when is_binary(chain) and is_list(instance_ids) do
+  @spec start_all_workers(pos_integer(), [String.t()]) :: :ok
+  def start_all_workers(chain_id, instance_ids)
+      when is_integer(chain_id) and chain_id > 0 and is_list(instance_ids) do
     Logger.info("Starting BlockSync workers",
-      chain: chain,
+      chain_id: chain_id,
       instance_count: length(instance_ids)
     )
 
     Enum.each(instance_ids, fn instance_id ->
-      start_worker(chain, instance_id)
+      start_worker(chain_id, instance_id)
     end)
   end
 

--- a/lib/lasso/core/block_sync/worker.ex
+++ b/lib/lasso/core/block_sync/worker.ex
@@ -26,8 +26,8 @@ defmodule Lasso.BlockSync.Worker do
 
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
   alias Lasso.BlockSync.Strategies.{HttpStrategy, WsStrategy}
-  alias Lasso.Config.{ChainConfig, ConfigStore}
-  alias Lasso.Providers.Catalog
+  alias Lasso.Config.{ChainConfig, ConfigStore, MonitoringDefaults}
+  alias Lasso.Providers.{Catalog, RestartCounter}
 
   @reconnect_delay_ms 5_000
   @ws_active_poll_multiplier 3
@@ -40,43 +40,55 @@ defmodule Lasso.BlockSync.Worker do
           staleness_threshold_ms: pos_integer()
         }
 
+  @type auth_scope :: :system
+
   @type t :: %__MODULE__{
-          chain: String.t(),
+          chain_id: pos_integer(),
           instance_id: String.t(),
           mode: mode() | nil,
           ws_strategy: pid() | nil,
           http_strategy: pid() | nil,
           config: config(),
           ws_retry_count: non_neg_integer(),
-          http_reduced: boolean()
+          http_reduced: boolean(),
+          auth_scope: auth_scope() | nil,
+          last_emitted_coalesced: tuple() | nil,
+          start_timer_ref: reference() | nil,
+          restart_count_cleared: boolean()
         }
 
   defstruct [
-    :chain,
+    :chain_id,
     :instance_id,
     :mode,
     :ws_strategy,
     :http_strategy,
     :config,
+    :auth_scope,
+    :last_emitted_coalesced,
+    :start_timer_ref,
     ws_retry_count: 0,
-    http_reduced: false
+    http_reduced: false,
+    restart_count_cleared: false
   ]
 
   ## Client API
 
-  @spec start_link({String.t(), String.t()}) :: GenServer.on_start()
-  def start_link({chain, instance_id}) when is_binary(chain) and is_binary(instance_id) do
-    GenServer.start_link(__MODULE__, {chain, instance_id}, name: via(chain, instance_id))
+  @spec start_link({pos_integer(), String.t()}) :: GenServer.on_start()
+  def start_link({chain_id, instance_id})
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) do
+    GenServer.start_link(__MODULE__, {chain_id, instance_id}, name: via(chain_id, instance_id))
   end
 
-  @spec via(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
-  def via(chain, instance_id) when is_binary(instance_id) do
-    {:via, Registry, {Lasso.Registry, {:block_sync_worker, chain, instance_id}}}
+  @spec via(pos_integer(), String.t()) :: {:via, Registry, {atom(), tuple()}}
+  def via(chain_id, instance_id) when is_integer(chain_id) and is_binary(instance_id) do
+    {:via, Registry, {Lasso.Registry, {:block_sync_worker, chain_id, instance_id}}}
   end
 
-  @spec get_status(String.t(), String.t()) :: map() | {:error, :not_running}
-  def get_status(chain, instance_id) when is_binary(instance_id) do
-    GenServer.call(via(chain, instance_id), :get_status)
+  @spec get_status(pos_integer(), String.t()) :: map() | {:error, :not_running}
+  def get_status(chain_id, instance_id)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) do
+    GenServer.call(via(chain_id, instance_id), :get_status)
   catch
     :exit, _ -> {:error, :not_running}
   end
@@ -84,32 +96,61 @@ defmodule Lasso.BlockSync.Worker do
   ## GenServer Callbacks
 
   @impl true
-  def init({chain, instance_id}) do
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:conn:instance:#{instance_id}")
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "instance_sub_manager:restarted:#{chain}")
-
-    config = load_config(instance_id, chain)
-
+  def init({chain_id, instance_id}) do
     state = %__MODULE__{
-      chain: chain,
+      chain_id: chain_id,
       instance_id: instance_id,
       mode: nil,
       ws_strategy: nil,
       http_strategy: nil,
-      config: config,
+      config: nil,
+      auth_scope: nil,
+      last_emitted_coalesced: nil,
+      start_timer_ref: nil,
       ws_retry_count: 0,
-      http_reduced: false
+      http_reduced: false,
+      restart_count_cleared: false
     }
 
-    Process.send_after(self(), :start_strategies, 2_000)
+    {:ok, state, {:continue, :deferred_start}}
+  end
 
-    Logger.debug("BlockSync.Worker started",
-      chain: chain,
-      instance_id: instance_id,
-      subscribe_new_heads: config.subscribe_new_heads
+  @impl true
+  def handle_continue(:deferred_start, state) do
+    Phoenix.PubSub.subscribe(
+      Lasso.PubSub,
+      Lasso.Topics.instance_config_updated(state.instance_id)
     )
 
-    {:ok, state}
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.ws_conn_instance(state.instance_id))
+
+    Phoenix.PubSub.subscribe(
+      Lasso.PubSub,
+      Lasso.Topics.instance_sub_manager_restarted(state.chain_id)
+    )
+
+    {config, auth_scope, last_emitted_coalesced} =
+      load_config_with_telemetry(state.instance_id, state.chain_id, nil, nil)
+
+    state = %{
+      state
+      | config: config,
+        auth_scope: auth_scope,
+        last_emitted_coalesced: last_emitted_coalesced
+    }
+
+    backoff = RestartCounter.backoff_for(RestartCounter.bump({:block_sync, state.instance_id}))
+    start_timer_ref = Process.send_after(self(), :start_strategies, backoff)
+    state = %{state | start_timer_ref: start_timer_ref}
+
+    Logger.debug("BlockSync.Worker started",
+      chain_id: state.chain_id,
+      instance_id: state.instance_id,
+      subscribe_new_heads: config.subscribe_new_heads,
+      start_backoff_ms: backoff
+    )
+
+    {:noreply, state}
   end
 
   @impl true
@@ -127,7 +168,41 @@ defmodule Lasso.BlockSync.Worker do
   end
 
   @impl true
+  def terminate(_reason, state) do
+    if state.start_timer_ref, do: Process.cancel_timer(state.start_timer_ref)
+
+    # Release strategy resources on supervised shutdown (auth rotation,
+    # provider removal, profile suspension). Without this, WS subscriptions
+    # leak on the InstanceSubscriptionManager and pending HTTP poll timers
+    # remain associated with a dead pid (cosmetically benign but obscures
+    # the supervision tree's reaper accounting).
+    if state.ws_strategy, do: WsStrategy.stop(state.ws_strategy)
+    if state.http_strategy, do: HttpStrategy.stop(state.http_strategy)
+    :ok
+  end
+
+  @impl true
+  def handle_info(:instance_config_updated, state) do
+    {new_config, auth_scope, last_emitted_coalesced} =
+      load_config_with_telemetry(
+        state.instance_id,
+        state.chain_id,
+        state.auth_scope,
+        state.last_emitted_coalesced
+      )
+
+    state =
+      state
+      |> Map.put(:auth_scope, auth_scope)
+      |> Map.put(:last_emitted_coalesced, last_emitted_coalesced)
+      |> apply_config_reload(new_config)
+
+    {:noreply, state}
+  end
+
+  @impl true
   def handle_info(:start_strategies, state) do
+    state = %{state | start_timer_ref: nil}
     state = start_strategies(state)
     {:noreply, state}
   end
@@ -137,9 +212,10 @@ defmodule Lasso.BlockSync.Worker do
       when instance_id == state.instance_id do
     source = if metadata[:latency_ms], do: :http, else: :ws
 
-    BlockSyncRegistry.put_height(state.chain, instance_id, height, source, metadata)
+    BlockSyncRegistry.put_height(state.chain_id, instance_id, height, source, metadata)
     broadcast_height_update(state, height, source)
 
+    state = maybe_clear_restart_count(state)
     {:noreply, state}
   end
 
@@ -151,13 +227,13 @@ defmodule Lasso.BlockSync.Worker do
   end
 
   # HTTP strategy poll timer
-  def handle_info({:http_strategy, :poll, instance_id}, state)
+  def handle_info({:http_strategy, :poll, instance_id, generation}, state)
       when instance_id == state.instance_id and state.http_strategy != nil do
-    {:ok, new_http_state} = HttpStrategy.handle_message(:poll, state.http_strategy)
+    {:ok, new_http_state} = HttpStrategy.handle_message({:poll, generation}, state.http_strategy)
     {:noreply, %{state | http_strategy: new_http_state}}
   end
 
-  def handle_info({:http_strategy, :poll, instance_id}, state)
+  def handle_info({:http_strategy, :poll, instance_id, _generation}, state)
       when instance_id == state.instance_id and state.http_strategy == nil do
     {:noreply, state}
   end
@@ -246,52 +322,204 @@ defmodule Lasso.BlockSync.Worker do
 
   ## Private Functions
 
+  # First successful block-height after a (re)start clears the
+  # restart counter so a worker that runs healthy for any meaningful
+  # interval no longer carries crash-loop debt. A worker that crashes
+  # between handle_continue and the first :block_height keeps its
+  # count — that's the desired flapping signal.
+  defp maybe_clear_restart_count(%{restart_count_cleared: true} = state), do: state
+
+  defp maybe_clear_restart_count(state) do
+    RestartCounter.clear({:block_sync, state.instance_id})
+    %{state | restart_count_cleared: true}
+  end
+
   defp broadcast_height_update(state, height, source) do
     profiles = Catalog.get_instance_refs(state.instance_id)
     timestamp = System.system_time(:millisecond)
 
     for profile <- profiles do
       provider_id =
-        Catalog.reverse_lookup_provider_id(profile, state.chain, state.instance_id) ||
+        Catalog.reverse_lookup_provider_id(profile, state.chain_id, state.instance_id) ||
           state.instance_id
 
       provider_key = {profile, provider_id}
       msg = {:block_height_update, provider_key, height, source, timestamp}
-      Phoenix.PubSub.broadcast(Lasso.PubSub, "block_sync:#{profile}:#{state.chain}", msg)
 
-      sync_msg = %{chain: state.chain, provider_id: provider_id, block_height: height}
-      Phoenix.PubSub.broadcast(Lasso.PubSub, "sync:updates:#{profile}", sync_msg)
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.block_sync(profile, state.chain_id),
+        msg
+      )
+
+      sync_msg = %{chain_id: state.chain_id, provider_id: provider_id, block_height: height}
+      Phoenix.PubSub.broadcast(Lasso.PubSub, Lasso.Topics.sync_updates(profile), sync_msg)
     end
   end
 
-  defp load_config(instance_id, chain) do
+  defp load_config_with_telemetry(instance_id, chain_id, existing_auth_scope, last_emitted) do
+    config = load_config(instance_id, chain_id)
+    refs = Catalog.get_instance_refs(instance_id)
+    auth_scope = existing_auth_scope || compute_auth_scope(refs)
+
+    ref_configs =
+      refs
+      |> Enum.map(fn ref -> ConfigStore.get_chain(ref, chain_id) end)
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(fn {:ok, cc} -> cc end)
+
+    ref_count = length(refs)
+    ref_count_with_config = length(ref_configs)
+
+    poll_intervals =
+      Enum.map(ref_configs, & &1.monitoring.probe_interval_ms)
+
+    coalesced_tuple =
+      {config.poll_interval_ms, config.staleness_threshold_ms, config.subscribe_new_heads,
+       Map.get(config, :max_backfill_blocks), Map.get(config, :backfill_timeout_ms)}
+
+    new_last_emitted =
+      if coalesced_tuple != last_emitted do
+        {p50, p99} = percentiles(poll_intervals)
+
+        :telemetry.execute(
+          [:lasso, :block_sync, :worker, :coalesced_config],
+          %{
+            coalesced_poll_interval_ms: config.poll_interval_ms,
+            ref_count: ref_count,
+            ref_count_with_config: ref_count_with_config,
+            poll_interval_p50_ms: p50,
+            poll_interval_p99_ms: p99
+          },
+          %{
+            instance_id: instance_id,
+            chain_id: chain_id,
+            auth_scope: auth_scope
+          }
+        )
+
+        coalesced_tuple
+      else
+        last_emitted
+      end
+
+    {config, auth_scope, new_last_emitted}
+  end
+
+  @doc "Loads and coalesces block-sync configuration for an instance."
+  @spec load_config(String.t(), pos_integer()) :: map()
+  def load_config(instance_id, chain_id) do
     refs = Catalog.get_instance_refs(instance_id)
     has_ws = instance_has_ws?(instance_id)
 
-    default_config = %{
-      subscribe_new_heads: has_ws,
-      poll_interval_ms: 15_000,
-      ws_active_poll_interval_ms: 15_000 * @ws_active_poll_multiplier,
-      staleness_threshold_ms: 35_000
-    }
+    ref_configs =
+      refs
+      |> Enum.map(fn ref -> {ref, ConfigStore.get_chain(ref, chain_id)} end)
+      |> Enum.filter(fn {_, result} -> match?({:ok, _}, result) end)
+      |> Enum.map(fn {ref, {:ok, cc}} -> {ref, cc} end)
 
-    with [ref_profile | _] <- refs,
-         {:ok, chain_config} <- ConfigStore.get_chain(ref_profile, chain) do
-      subscribe_new_heads =
-        resolve_subscribe_new_heads(chain_config, ref_profile, chain, instance_id) or
-          Enum.any?(refs, &check_profile_subscribe_new_heads(&1, chain, instance_id))
-
-      poll_interval_ms = chain_config.monitoring.probe_interval_ms
-
-      %{
-        subscribe_new_heads: subscribe_new_heads and has_ws,
-        poll_interval_ms: poll_interval_ms,
-        ws_active_poll_interval_ms: poll_interval_ms * @ws_active_poll_multiplier,
-        staleness_threshold_ms: chain_config.websocket.new_heads_timeout_ms
-      }
-    else
-      _ -> default_config
+    case ref_configs do
+      [] -> default_config(instance_id, has_ws)
+      _ -> coalesce_config(ref_configs, instance_id, chain_id, has_ws)
     end
+  end
+
+  @doc "Builds default block-sync configuration for an instance."
+  @spec default_config(String.t(), boolean()) :: map()
+  def default_config(instance_id, has_ws) do
+    block_time_ms = instance_block_time_ms(instance_id)
+    poll_interval_ms = MonitoringDefaults.default_probe_interval_ms(block_time_ms)
+
+    %{
+      subscribe_new_heads: has_ws,
+      poll_interval_ms: poll_interval_ms,
+      ws_active_poll_interval_ms: poll_interval_ms * @ws_active_poll_multiplier,
+      staleness_threshold_ms: 35_000,
+      max_backfill_blocks: nil,
+      backfill_timeout_ms: nil
+    }
+  end
+
+  @doc "Coalesces block-sync configuration across profile references."
+  @spec coalesce_config([{term(), term()}], String.t(), pos_integer(), boolean()) :: map()
+  def coalesce_config(ref_configs, instance_id, chain_id, has_ws) do
+    poll_interval_ms =
+      ref_configs
+      |> Enum.map(fn {_, cc} -> cc.monitoring.probe_interval_ms end)
+      |> Enum.min()
+
+    staleness_threshold_ms =
+      ref_configs
+      |> Enum.map(fn {_, cc} -> cc.websocket.new_heads_timeout_ms end)
+      |> Enum.max()
+
+    subscribe_new_heads =
+      Enum.any?(ref_configs, fn {ref, cc} ->
+        resolve_subscribe_new_heads(cc, ref, chain_id, instance_id)
+      end)
+
+    max_backfill_blocks =
+      ref_configs
+      |> Enum.map(fn {_, cc} ->
+        get_in(cc, [
+          Access.key(:websocket),
+          Access.key(:failover),
+          Access.key(:max_backfill_blocks)
+        ])
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> case do
+        [] -> nil
+        values -> Enum.min(values)
+      end
+
+    backfill_timeout_ms =
+      ref_configs
+      |> Enum.map(fn {_, cc} ->
+        get_in(cc, [
+          Access.key(:websocket),
+          Access.key(:failover),
+          Access.key(:backfill_timeout_ms)
+        ])
+      end)
+      |> Enum.reject(&is_nil/1)
+      |> case do
+        [] -> nil
+        values -> Enum.min(values)
+      end
+
+    %{
+      subscribe_new_heads: subscribe_new_heads and has_ws,
+      poll_interval_ms: poll_interval_ms,
+      ws_active_poll_interval_ms: poll_interval_ms * @ws_active_poll_multiplier,
+      staleness_threshold_ms: staleness_threshold_ms,
+      max_backfill_blocks: max_backfill_blocks,
+      backfill_timeout_ms: backfill_timeout_ms
+    }
+  end
+
+  defp instance_block_time_ms(instance_id) do
+    case Catalog.get_instance(instance_id) do
+      {:ok, %{block_time_ms: bt}} when is_integer(bt) and bt > 0 -> bt
+      _ -> nil
+    end
+  end
+
+  defp compute_auth_scope(_refs), do: :system
+
+  defp percentiles([] = _values) do
+    default_ms = MonitoringDefaults.default_probe_interval_ms(nil)
+    {default_ms, default_ms}
+  end
+
+  defp percentiles(values) do
+    sorted = Enum.sort(values)
+    n = length(sorted)
+
+    p50 = Enum.at(sorted, div(n - 1, 2))
+    p99 = Enum.at(sorted, round((n - 1) * 0.99))
+
+    {p50, p99}
   end
 
   defp instance_has_ws?(instance_id) do
@@ -301,8 +529,8 @@ defmodule Lasso.BlockSync.Worker do
     end
   end
 
-  defp resolve_subscribe_new_heads(chain_config, profile, chain, instance_id) do
-    provider_id = Catalog.reverse_lookup_provider_id(profile, chain, instance_id)
+  defp resolve_subscribe_new_heads(chain_config, profile, chain_id, instance_id) do
+    provider_id = Catalog.reverse_lookup_provider_id(profile, chain_id, instance_id)
 
     if provider_id do
       case ChainConfig.get_provider_by_id(chain_config, provider_id) do
@@ -314,14 +542,53 @@ defmodule Lasso.BlockSync.Worker do
     end
   end
 
-  defp check_profile_subscribe_new_heads(profile, chain, instance_id) do
-    case ConfigStore.get_chain(profile, chain) do
-      {:ok, chain_config} ->
-        resolve_subscribe_new_heads(chain_config, profile, chain, instance_id)
+  defp apply_config_reload(state, new_config) do
+    old_config = state.config
+    old_subscribe = old_config.subscribe_new_heads
+    new_subscribe = new_config.subscribe_new_heads
 
-      _ ->
-        false
+    state = %{state | config: new_config}
+
+    state =
+      cond do
+        old_subscribe and not new_subscribe ->
+          Logger.info("Config reload: subscribe_new_heads disabled, tearing down WS subscription",
+            chain_id: state.chain_id,
+            instance_id: state.instance_id
+          )
+
+          state = teardown_ws_subscription(state)
+          restore_http_polling(state)
+
+        not old_subscribe and new_subscribe ->
+          Logger.info("Config reload: subscribe_new_heads enabled, establishing WS subscription",
+            chain_id: state.chain_id,
+            instance_id: state.instance_id
+          )
+
+          add_ws_subscription(state)
+
+        true ->
+          state
+      end
+
+    if state.http_strategy && old_config.poll_interval_ms != new_config.poll_interval_ms do
+      new_interval =
+        if state.http_reduced,
+          do: new_config.ws_active_poll_interval_ms,
+          else: new_config.poll_interval_ms
+
+      %{state | http_strategy: HttpStrategy.set_poll_interval(state.http_strategy, new_interval)}
+    else
+      state
     end
+  end
+
+  defp teardown_ws_subscription(%{ws_strategy: nil} = state), do: state
+
+  defp teardown_ws_subscription(state) do
+    WsStrategy.stop(state.ws_strategy)
+    %{state | ws_strategy: nil, mode: :http_only, ws_retry_count: 0}
   end
 
   defp start_strategies(state) do
@@ -341,10 +608,10 @@ defmodule Lasso.BlockSync.Worker do
       poll_interval_ms: state.config.poll_interval_ms
     ]
 
-    {:ok, http_state} = HttpStrategy.start(state.chain, state.instance_id, http_opts)
+    {:ok, http_state} = HttpStrategy.start(state.chain_id, state.instance_id, http_opts)
 
     Logger.debug("HTTP polling started",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id,
       poll_interval_ms: state.config.poll_interval_ms
     )
@@ -359,13 +626,13 @@ defmodule Lasso.BlockSync.Worker do
       staleness_threshold_ms: state.config.staleness_threshold_ms
     ]
 
-    case WsStrategy.start(state.chain, state.instance_id, ws_opts) do
+    case WsStrategy.start(state.chain_id, state.instance_id, ws_opts) do
       {:ok, ws_state} ->
         %{state | mode: :http_with_ws, ws_strategy: ws_state, ws_retry_count: 0}
 
       {:error, :connection_unknown} ->
         Logger.debug("WS connection state unknown, will retry shortly",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: state.instance_id
         )
 
@@ -376,7 +643,7 @@ defmodule Lasso.BlockSync.Worker do
         level = if state.ws_retry_count > 0, do: :debug, else: :warning
 
         Logger.log(level, "WS subscription failed to start, HTTP polling continues",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: state.instance_id,
           reason: inspect(reason)
         )
@@ -387,13 +654,15 @@ defmodule Lasso.BlockSync.Worker do
   end
 
   defp handle_strategy_status(state, :ws, :active) do
+    state = maybe_clear_restart_count(state)
     state = %{state | mode: :http_with_ws, ws_retry_count: 0}
+
     reduce_http_polling(state)
   end
 
   defp handle_strategy_status(state, :ws, :failed) do
     Logger.debug("WS subscription failed, HTTP polling continues",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id
     )
 
@@ -402,7 +671,7 @@ defmodule Lasso.BlockSync.Worker do
 
   defp handle_strategy_status(state, :ws, status) when status in [:stale, :degraded] do
     Logger.info("WS subscription #{status}, restoring normal HTTP polling",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id
     )
 
@@ -411,7 +680,7 @@ defmodule Lasso.BlockSync.Worker do
 
   defp handle_strategy_status(state, :http, :degraded) do
     Logger.warning("HTTP polling degraded",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id
     )
 
@@ -420,11 +689,11 @@ defmodule Lasso.BlockSync.Worker do
 
   defp handle_strategy_status(state, :http, :healthy) do
     Logger.debug("HTTP polling recovered",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id
     )
 
-    state
+    maybe_clear_restart_count(state)
   end
 
   defp handle_strategy_status(state, _transport, _status) do
@@ -439,7 +708,7 @@ defmodule Lasso.BlockSync.Worker do
     new_http = HttpStrategy.set_poll_interval(state.http_strategy, reduced_interval)
 
     Logger.debug("HTTP polling reduced (WS active)",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id,
       poll_interval_ms: reduced_interval
     )
@@ -455,7 +724,7 @@ defmodule Lasso.BlockSync.Worker do
     new_http = HttpStrategy.set_poll_interval(state.http_strategy, normal_interval)
 
     Logger.debug("HTTP polling restored to normal",
-      chain: state.chain,
+      chain_id: state.chain_id,
       instance_id: state.instance_id,
       poll_interval_ms: normal_interval
     )
@@ -491,7 +760,7 @@ defmodule Lasso.BlockSync.Worker do
   defp handle_ws_disconnected(state) do
     if state.ws_strategy do
       Logger.info("WS subscription disconnected, HTTP polling continues",
-        chain: state.chain,
+        chain_id: state.chain_id,
         instance_id: state.instance_id
       )
 
@@ -524,10 +793,10 @@ defmodule Lasso.BlockSync.Worker do
         staleness_threshold_ms: state.config.staleness_threshold_ms
       ]
 
-      case WsStrategy.start(state.chain, state.instance_id, ws_opts) do
+      case WsStrategy.start(state.chain_id, state.instance_id, ws_opts) do
         {:ok, ws_state} ->
           Logger.info("WS subscription reconnected",
-            chain: state.chain,
+            chain_id: state.chain_id,
             instance_id: state.instance_id
           )
 
@@ -535,7 +804,7 @@ defmodule Lasso.BlockSync.Worker do
 
         {:error, reason} ->
           Logger.debug("WS subscription reconnect failed, will retry",
-            chain: state.chain,
+            chain_id: state.chain_id,
             instance_id: state.instance_id,
             reason: inspect(reason),
             retry_count: state.ws_retry_count + 1

--- a/lib/lasso/core/chain_state.ex
+++ b/lib/lasso/core/chain_state.ex
@@ -22,48 +22,49 @@ defmodule Lasso.RPC.ChainState do
   # Default freshness window for consensus calculation (30 seconds)
   @default_freshness_ms 30_000
 
-  @spec consensus_height(String.t(), keyword()) ::
+  @spec consensus_height(pos_integer(), keyword()) ::
           {:ok, non_neg_integer()}
           | {:error, term()}
-  def consensus_height(chain, opts \\ []) do
+  def consensus_height(chain_id, opts \\ []) when is_integer(chain_id) and chain_id > 0 do
     provider_ids = Keyword.get(opts, :provider_ids, nil)
     freshness_ms = Keyword.get(opts, :freshness_ms, @default_freshness_ms)
 
     if provider_ids do
-      BlockSyncRegistry.get_consensus_height_filtered(chain, provider_ids, freshness_ms)
+      BlockSyncRegistry.get_consensus_height_filtered(chain_id, provider_ids, freshness_ms)
     else
-      BlockSyncRegistry.get_consensus_height(chain, freshness_ms)
+      BlockSyncRegistry.get_consensus_height(chain_id, freshness_ms)
     end
   rescue
     e ->
       Logger.error("ChainState consensus_height crashed",
-        chain: chain,
+        chain_id: chain_id,
         error: Exception.message(e)
       )
 
       {:error, :calculation_failed}
   end
 
-  @spec consensus_height!(String.t()) :: non_neg_integer()
-  def consensus_height!(chain) do
-    case consensus_height(chain) do
+  @spec consensus_height!(pos_integer()) :: non_neg_integer()
+  def consensus_height!(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    case consensus_height(chain_id) do
       {:ok, height} ->
         height
 
       {:error, reason} ->
-        raise ArgumentError, "Consensus height unavailable for #{chain}: #{reason}"
+        raise ArgumentError, "Consensus height unavailable for chain_id #{chain_id}: #{reason}"
     end
   end
 
-  @spec provider_lag(String.t(), String.t(), keyword()) :: {:ok, integer()} | {:error, term()}
-  def provider_lag(chain, provider_id, opts \\ []) do
-    # Use BlockSync Registry for lag calculation
+  @spec provider_lag(pos_integer(), String.t(), keyword()) ::
+          {:ok, integer()} | {:error, term()}
+  def provider_lag(chain_id, provider_id, opts \\ [])
+      when is_integer(chain_id) and chain_id > 0 do
     freshness_ms = Keyword.get(opts, :freshness_ms, @default_freshness_ms)
-    BlockSyncRegistry.get_provider_lag(chain, provider_id, freshness_ms)
+    BlockSyncRegistry.get_provider_lag(chain_id, provider_id, freshness_ms)
   rescue
     e ->
       Logger.error("ChainState provider_lag crashed",
-        chain: chain,
+        chain_id: chain_id,
         provider_id: provider_id,
         error: Exception.message(e)
       )
@@ -71,9 +72,9 @@ defmodule Lasso.RPC.ChainState do
       {:error, :calculation_failed}
   end
 
-  @spec consensus_fresh?(String.t()) :: boolean()
-  def consensus_fresh?(chain) do
-    case consensus_height(chain) do
+  @spec consensus_fresh?(pos_integer()) :: boolean()
+  def consensus_fresh?(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    case consensus_height(chain_id) do
       {:ok, _height} -> true
       {:error, _} -> false
     end
@@ -83,9 +84,9 @@ defmodule Lasso.RPC.ChainState do
   Check if the BlockSync system has data for a chain.
   Returns the count of providers with height data.
   """
-  @spec data_available?(String.t()) :: boolean()
-  def data_available?(chain) do
-    case BlockSyncRegistry.get_all_heights(chain) do
+  @spec data_available?(pos_integer()) :: boolean()
+  def data_available?(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    case BlockSyncRegistry.get_all_heights(chain_id) do
       heights when map_size(heights) > 0 -> true
       _ -> false
     end
@@ -106,9 +107,9 @@ defmodule Lasso.RPC.ChainState do
       block.hash    # "0xabc..."
       block.timestamp # 1699876543
   """
-  @spec get_latest_block(String.t()) :: {:ok, map()} | {:error, term()}
-  def get_latest_block(chain) do
-    BlockCache.get_latest_block(chain)
+  @spec get_latest_block(pos_integer()) :: {:ok, map()} | {:error, term()}
+  def get_latest_block(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    BlockCache.get_latest_block(chain_id)
   end
 
   @doc """
@@ -120,10 +121,10 @@ defmodule Lasso.RPC.ChainState do
 
       {:ok, height, received_at} = ChainState.provider_height("ethereum", "alchemy")
   """
-  @spec provider_height(String.t(), String.t()) ::
+  @spec provider_height(pos_integer(), String.t()) ::
           {:ok, non_neg_integer(), non_neg_integer()} | {:error, term()}
-  def provider_height(chain, provider_id) do
-    case BlockSyncRegistry.get_height(chain, provider_id) do
+  def provider_height(chain_id, provider_id) when is_integer(chain_id) and chain_id > 0 do
+    case BlockSyncRegistry.get_height(chain_id, provider_id) do
       {:ok, {height, timestamp, _source, _metadata}} ->
         {:ok, height, timestamp}
 
@@ -141,12 +142,12 @@ defmodule Lasso.RPC.ChainState do
 
     * `:only_fresh` - Only return providers with data within freshness window (default: false)
   """
-  @spec all_provider_heights(String.t(), keyword()) :: [
+  @spec all_provider_heights(pos_integer(), keyword()) :: [
           {String.t(), non_neg_integer(), non_neg_integer()}
         ]
-  def all_provider_heights(chain, opts \\ []) do
+  def all_provider_heights(chain_id, opts \\ []) when is_integer(chain_id) and chain_id > 0 do
     only_fresh = Keyword.get(opts, :only_fresh, false)
-    heights = BlockSyncRegistry.get_all_heights(chain)
+    heights = BlockSyncRegistry.get_all_heights(chain_id)
 
     now = System.system_time(:millisecond)
     freshness_window = @default_freshness_ms
@@ -171,8 +172,8 @@ defmodule Lasso.RPC.ChainState do
 
   Returns a map of provider_id => status_map with height, lag, source, etc.
   """
-  @spec get_chain_status(String.t()) :: map()
-  def get_chain_status(chain) do
-    BlockSyncRegistry.get_chain_status(chain)
+  @spec get_chain_status(pos_integer()) :: map()
+  def get_chain_status(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    BlockSyncRegistry.get_chain_status(chain_id)
   end
 end

--- a/lib/lasso/core/events/provider.ex
+++ b/lib/lasso/core/events/provider.ex
@@ -9,30 +9,20 @@ defmodule Lasso.Events.Provider do
   Common fields:
   - v: schema version (integer)
   - ts: event timestamp (ms since UNIX epoch)
-  - chain: chain name (string)
+  - chain_id: EIP-155 chain_id (pos_integer)
   - provider_id: provider identifier (string)
   """
-
-  @provider_topic_prefix "provider:events:"
-
-  @doc """
-  Returns the profile-scoped PubSub topic for provider events.
-  """
-  @spec topic(String.t(), String.t()) :: String.t()
-  def topic(profile, chain) when is_binary(profile) and is_binary(chain) do
-    "#{@provider_topic_prefix}#{profile}:#{chain}"
-  end
 
   defmodule Healthy do
     @moduledoc "Event indicating a provider is healthy."
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil
+    @enforce_keys [:ts, :chain_id, :provider_id]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t()
           }
   end
@@ -40,13 +30,13 @@ defmodule Lasso.Events.Provider do
   defmodule Unhealthy do
     @moduledoc "Event indicating a provider is unhealthy."
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil, reason: nil
+    @enforce_keys [:ts, :chain_id, :provider_id]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil, reason: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             reason: term() | nil
           }
@@ -55,10 +45,10 @@ defmodule Lasso.Events.Provider do
   defmodule HealthCheckFailed do
     @moduledoc "Event indicating a provider health check failed."
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id]
+    @enforce_keys [:ts, :chain_id, :provider_id]
     defstruct v: 1,
               ts: nil,
-              chain: nil,
+              chain_id: nil,
               provider_id: nil,
               reason: nil,
               consecutive_failures: nil
@@ -66,7 +56,7 @@ defmodule Lasso.Events.Provider do
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             reason: term() | nil,
             consecutive_failures: non_neg_integer() | nil
@@ -84,13 +74,13 @@ defmodule Lasso.Events.Provider do
   defmodule WSDisconnected do
     @moduledoc "Event indicating a WebSocket connection was disconnected."
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil, reason: nil
+    @enforce_keys [:ts, :chain_id, :provider_id]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil, reason: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             reason: term() | nil
           }
@@ -99,13 +89,13 @@ defmodule Lasso.Events.Provider do
   defmodule WSClosed do
     @moduledoc "Event indicating a WebSocket connection was closed."
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id, :code]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil, code: nil, reason: nil
+    @enforce_keys [:ts, :chain_id, :provider_id, :code]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil, code: nil, reason: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             code: integer(),
             reason: term() | nil
@@ -118,16 +108,19 @@ defmodule Lasso.Events.Provider do
   defmodule WSConnected do
     @moduledoc "Event indicating a WebSocket connection was established."
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil
+    @enforce_keys [:ts, :chain_id, :provider_id]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t()
           }
   end
 
   def kind(%WSConnected{}), do: :ws_connected
+
+  @spec topic(String.t(), pos_integer()) :: String.t()
+  def topic(profile_id, chain_id), do: Lasso.Topics.provider_event(profile_id, chain_id)
 end

--- a/lib/lasso/core/events/subscription.ex
+++ b/lib/lasso/core/events/subscription.ex
@@ -6,23 +6,16 @@ defmodule Lasso.Events.Subscription do
   lifecycle moments (established, failed, failover, stale) in the Live Activity feed.
   """
 
-  @topic_prefix "subscription:lifecycle:"
-
-  @spec topic(String.t(), String.t()) :: String.t()
-  def topic(profile, chain) when is_binary(profile) and is_binary(chain) do
-    "#{@topic_prefix}#{profile}:#{chain}"
-  end
-
   defmodule Established do
     @moduledoc false
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id, :subscription_type]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil, subscription_type: nil
+    @enforce_keys [:ts, :chain_id, :provider_id, :subscription_type]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil, subscription_type: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             subscription_type: :new_heads | :logs
           }
@@ -31,13 +24,13 @@ defmodule Lasso.Events.Subscription do
   defmodule Failed do
     @moduledoc false
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id, :subscription_type]
-    defstruct v: 1, ts: nil, chain: nil, provider_id: nil, subscription_type: nil, reason: nil
+    @enforce_keys [:ts, :chain_id, :provider_id, :subscription_type]
+    defstruct v: 1, ts: nil, chain_id: nil, provider_id: nil, subscription_type: nil, reason: nil
 
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             subscription_type: :new_heads | :logs,
             reason: term() | nil
@@ -47,11 +40,11 @@ defmodule Lasso.Events.Subscription do
   defmodule Failover do
     @moduledoc false
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :subscription_type, :from_provider_id, :to_provider_id]
+    @enforce_keys [:ts, :chain_id, :subscription_type, :from_provider_id, :to_provider_id]
 
     defstruct v: 1,
               ts: nil,
-              chain: nil,
+              chain_id: nil,
               subscription_type: nil,
               from_provider_id: nil,
               to_provider_id: nil
@@ -59,7 +52,7 @@ defmodule Lasso.Events.Subscription do
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             subscription_type: :new_heads | :logs,
             from_provider_id: String.t() | nil,
             to_provider_id: String.t()
@@ -69,11 +62,11 @@ defmodule Lasso.Events.Subscription do
   defmodule Stale do
     @moduledoc false
     @derive Jason.Encoder
-    @enforce_keys [:ts, :chain, :provider_id, :subscription_type]
+    @enforce_keys [:ts, :chain_id, :provider_id, :subscription_type]
 
     defstruct v: 1,
               ts: nil,
-              chain: nil,
+              chain_id: nil,
               provider_id: nil,
               subscription_type: nil,
               stale_duration_ms: nil
@@ -81,7 +74,7 @@ defmodule Lasso.Events.Subscription do
     @type t :: %__MODULE__{
             v: pos_integer(),
             ts: non_neg_integer(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             provider_id: String.t(),
             subscription_type: :new_heads | :logs,
             stale_duration_ms: non_neg_integer() | nil
@@ -95,6 +88,10 @@ defmodule Lasso.Events.Subscription do
   def kind(%Stale{}), do: :subscription_stale
 
   @spec subscription_type(term()) :: :new_heads | :logs
+  def subscription_type({:route, _route, key}), do: subscription_type(key)
   def subscription_type({:newHeads}), do: :new_heads
   def subscription_type({:logs, _}), do: :logs
+
+  @spec topic(String.t(), pos_integer()) :: String.t()
+  def topic(profile_id, chain_id), do: Lasso.Topics.subscription_event(profile_id, chain_id)
 end

--- a/lib/lasso/core/providers/adapter_filter.ex
+++ b/lib/lasso/core/providers/adapter_filter.ex
@@ -57,7 +57,7 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
       method,
       params,
       channel.profile,
-      channel.chain
+      channel.chain_id
     )
   end
 
@@ -65,8 +65,8 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
 
   defp do_filter_channels(channels, method) do
     {capable, filtered} =
-      Enum.split_with(channels, fn %{provider_id: id, profile: profile, chain: chain} ->
-        caps = lookup_capabilities(profile, chain, id)
+      Enum.split_with(channels, fn %{provider_id: id, profile: profile, chain_id: chain_id} ->
+        caps = lookup_capabilities(profile, chain_id, id)
 
         try do
           :ok == Capabilities.supports_method?(method, caps)
@@ -87,9 +87,9 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
     apply_safety_check(capable, filtered, channels, method)
   end
 
-  defp safe_validate_params?(provider_id, method, params, profile, chain) do
-    ctx = %{provider_id: provider_id, profile: profile, chain: chain}
-    caps = lookup_capabilities(profile, chain, provider_id)
+  defp safe_validate_params?(provider_id, method, params, profile, chain_id) do
+    ctx = %{provider_id: provider_id, profile: profile, chain_id: chain_id}
+    caps = lookup_capabilities(profile, chain_id, provider_id)
 
     Capabilities.validate_params(method, params, caps, ctx)
     |> handle_validation_result(provider_id, method)
@@ -108,15 +108,16 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
       {:error, :adapter_crash}
   end
 
-  defp lookup_capabilities(profile, chain, provider_id)
-       when is_binary(profile) and is_binary(chain) and is_binary(provider_id) do
-    case Lasso.Config.ConfigStore.get_provider(profile, chain, provider_id) do
+  defp lookup_capabilities(profile, chain_id, provider_id)
+       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
+              is_binary(provider_id) do
+    case Lasso.Config.ConfigStore.get_provider(profile, chain_id, provider_id) do
       {:ok, provider_config} -> provider_config.capabilities
       _ -> nil
     end
   end
 
-  defp lookup_capabilities(_profile, _chain, _provider_id), do: nil
+  defp lookup_capabilities(_profile, _chain_id, _provider_id), do: nil
 
   defp handle_validation_result(:ok, _provider_id, _method), do: :ok
 

--- a/lib/lasso/core/providers/providers.ex
+++ b/lib/lasso/core/providers/providers.ex
@@ -30,14 +30,16 @@ defmodule Lasso.Providers do
           has_ws: boolean()
         }
 
-  @spec add_provider(String.t(), map(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  @type chain_identifier :: pos_integer() | String.t()
+
+  @spec add_provider(chain_identifier(), map(), keyword()) :: {:ok, String.t()} | {:error, term()}
   def add_provider(chain_name, provider_attrs, opts \\ []) do
     add_provider(@default_profile, chain_name, provider_attrs, opts)
   end
 
-  @spec add_provider(String.t(), String.t(), map(), keyword()) ::
+  @spec add_provider(String.t(), chain_identifier(), map(), keyword()) ::
           {:ok, String.t()} | {:error, term()}
-  def add_provider(profile, chain_name, provider_attrs, opts) do
+  def add_provider(profile, chain_identifier, provider_attrs, opts) do
     persist? = Keyword.get(opts, :persist, false)
     validate? = Keyword.get(opts, :validate, true)
     start_ws = Keyword.get(opts, :start_ws, :auto)
@@ -45,63 +47,77 @@ defmodule Lasso.Providers do
     provider_config = normalize_provider_config(provider_attrs)
     provider_id = Map.get(provider_config, :id)
 
-    with :ok <- maybe_validate(provider_config, validate?),
-         :ok <- ensure_chain_started(profile, chain_name),
-         :ok <- check_not_duplicate(profile, chain_name, provider_id),
-         :ok <- ConfigStore.register_provider_runtime(profile, chain_name, provider_config),
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier),
+         :ok <- maybe_validate(provider_config, validate?),
+         :ok <- ensure_chain_started(profile, chain_id),
+         :ok <- check_not_duplicate(profile, chain_id, provider_id),
+         :ok <- ConfigStore.register_provider_runtime(profile, chain_id, provider_config),
          :ok <-
-           ChainSupervisor.ensure_provider(profile, chain_name, provider_config,
-             start_ws: start_ws
-           ),
-         :ok <- maybe_persist_add(chain_name, provider_config, persist?) do
-      Logger.info("Successfully added provider #{provider_id} to #{chain_name}")
+           ChainSupervisor.ensure_provider(profile, chain_id, provider_config, start_ws: start_ws),
+         :ok <- maybe_persist_add(chain_id, provider_config, persist?) do
+      Logger.info("Successfully added provider #{provider_id} to chain #{chain_id}")
       {:ok, provider_id}
     else
       {:error, reason} = error ->
-        if is_binary(provider_id) do
-          _ = ConfigStore.unregister_provider_runtime(profile, chain_name, provider_id)
+        case resolve_chain_id(profile, chain_identifier) do
+          {:ok, chain_id} when is_binary(provider_id) ->
+            _ = ConfigStore.unregister_provider_runtime(profile, chain_id, provider_id)
+
+          _ ->
+            :ok
         end
 
-        Logger.error("Failed to add provider #{provider_id} to #{chain_name}: #{inspect(reason)}")
-        error
-    end
-  end
-
-  @spec remove_provider(String.t(), String.t()) :: :ok | {:error, term()}
-  def remove_provider(chain_name, provider_id)
-      when is_binary(chain_name) and is_binary(provider_id) do
-    remove_provider(@default_profile, chain_name, provider_id, [])
-  end
-
-  @spec remove_provider(String.t(), String.t(), String.t(), keyword()) :: :ok | {:error, term()}
-  def remove_provider(profile, chain_name, provider_id, opts \\ []) do
-    persist? = Keyword.get(opts, :persist, false)
-
-    with :ok <- ChainSupervisor.remove_provider(profile, chain_name, provider_id),
-         :ok <- ConfigStore.unregister_provider_runtime(profile, chain_name, provider_id),
-         :ok <- maybe_persist_remove(chain_name, provider_id, persist?) do
-      Logger.info("Successfully removed provider #{provider_id} from #{chain_name}")
-      :ok
-    else
-      {:error, :provider_not_found} ->
-        # It may already be absent from runtime config; treat as successful cleanup.
-        :ok
-
-      {:error, reason} = error ->
         Logger.error(
-          "Failed to remove provider #{provider_id} from #{chain_name}: #{inspect(reason)}"
+          "Failed to add provider #{provider_id} to chain #{inspect(chain_identifier)}: #{inspect(reason)}"
         )
 
         error
     end
   end
 
-  @spec update_provider(String.t(), String.t(), map(), keyword()) :: :ok | {:error, term()}
+  @spec remove_provider(chain_identifier(), String.t()) :: :ok | {:error, term()}
+  def remove_provider(chain_name, provider_id)
+      when (is_binary(chain_name) or (is_integer(chain_name) and chain_name > 0)) and
+             is_binary(provider_id) do
+    remove_provider(@default_profile, chain_name, provider_id, [])
+  end
+
+  @spec remove_provider(String.t(), chain_identifier(), String.t(), keyword()) ::
+          :ok | {:error, term()}
+  def remove_provider(profile, chain_identifier, provider_id, opts \\ []) do
+    persist? = Keyword.get(opts, :persist, false)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier),
+         {:ok, _provider} <- ConfigStore.get_provider(profile, chain_id, provider_id),
+         instance_id = Catalog.lookup_instance_id(profile, chain_id, provider_id),
+         :ok <- ConfigStore.unregister_provider_runtime(profile, chain_id, provider_id),
+         :ok <- ChainSupervisor.remove_provider(profile, chain_id, provider_id, instance_id),
+         :ok <- maybe_persist_remove(chain_id, provider_id, persist?) do
+      Logger.info("Successfully removed provider #{provider_id} from chain #{chain_id}")
+      :ok
+    else
+      {:error, :provider_not_found} ->
+        :ok
+
+      {:error, :not_found} ->
+        :ok
+
+      {:error, reason} = error ->
+        Logger.error(
+          "Failed to remove provider #{provider_id} from chain #{inspect(chain_identifier)}: #{inspect(reason)}"
+        )
+
+        error
+    end
+  end
+
+  @spec update_provider(chain_identifier(), String.t(), map(), keyword()) ::
+          :ok | {:error, term()}
   def update_provider(chain_name, provider_id, updates, opts \\ []) do
     update_provider(@default_profile, chain_name, provider_id, updates, opts)
   end
 
-  @spec update_provider(String.t(), String.t(), String.t(), map(), keyword()) ::
+  @spec update_provider(String.t(), chain_identifier(), String.t(), map(), keyword()) ::
           :ok | {:error, term()}
   def update_provider(profile, chain_name, provider_id, updates, opts) do
     persist? = Keyword.get(opts, :persist, false)
@@ -122,114 +138,86 @@ defmodule Lasso.Providers do
     end
   end
 
-  @spec list_providers(String.t()) :: {:ok, [provider_summary()]} | {:error, term()}
+  @spec list_providers(chain_identifier()) :: {:ok, [provider_summary()]} | {:error, term()}
   def list_providers(chain_name) do
     list_providers(@default_profile, chain_name)
   end
 
-  @spec list_providers(String.t(), String.t()) :: {:ok, [provider_summary()]} | {:error, term()}
-  def list_providers(profile, chain_name) do
-    profile_providers = Catalog.get_profile_providers(profile, chain_name)
+  @spec list_providers(String.t(), chain_identifier()) ::
+          {:ok, [provider_summary()]} | {:error, term()}
+  def list_providers(profile, chain_identifier) do
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      profile_providers = Catalog.get_profile_providers(profile, chain_id)
 
-    summaries =
-      Enum.map(profile_providers, fn pp ->
-        instance_id = pp.instance_id
+      summaries =
+        Enum.map(profile_providers, fn pp ->
+          instance_id = pp.instance_id
 
-        instance_config =
-          case Catalog.get_instance(instance_id) do
-            {:ok, config} -> config
-            _ -> %{}
-          end
+          instance_config =
+            case Catalog.get_instance(instance_id) do
+              {:ok, config} -> config
+              _ -> %{}
+            end
 
-        health = InstanceState.read_health(instance_id)
-        ws_status = InstanceState.read_ws_status(instance_id)
-        http_cb = InstanceState.read_circuit(instance_id, :http)
-        ws_cb = InstanceState.read_circuit(instance_id, :ws)
+          health = InstanceState.read_health(instance_id)
+          ws_status = InstanceState.read_ws_status(instance_id)
+          http_cb = InstanceState.read_circuit(instance_id, :http)
+          ws_cb = InstanceState.read_circuit(instance_id, :ws)
 
-        url = Map.get(instance_config, :url)
-        ws_url = Map.get(instance_config, :ws_url)
+          url = Map.get(instance_config, :url)
+          ws_url = Map.get(instance_config, :ws_url)
 
-        %{
-          id: pp.provider_id,
-          name: pp[:name] || pp.provider_id,
-          status: health.status,
-          availability: InstanceState.status_to_availability(health.status),
-          has_http: is_binary(url),
-          has_ws: is_binary(ws_url),
-          http_status: health.http_status,
-          ws_status: ws_status.status,
-          http_availability: InstanceState.status_to_availability(health.http_status),
-          ws_availability: InstanceState.status_to_availability(ws_status.status),
-          http_cb_state: http_cb.state,
-          ws_cb_state: ws_cb.state
-        }
-      end)
+          %{
+            id: pp.provider_id,
+            name: pp[:name] || pp.provider_id,
+            status: health.status,
+            availability: InstanceState.status_to_availability(health.status),
+            has_http: is_binary(url),
+            has_ws: is_binary(ws_url),
+            http_status: health.http_status,
+            ws_status: ws_status.status,
+            http_availability: InstanceState.status_to_availability(health.http_status),
+            ws_availability: InstanceState.status_to_availability(ws_status.status),
+            http_cb_state: http_cb.state,
+            ws_cb_state: ws_cb.state
+          }
+        end)
 
-    {:ok, summaries}
+      {:ok, summaries}
+    end
   end
 
-  @spec get_provider(String.t(), String.t()) :: {:ok, map()} | {:error, term()}
+  @spec get_provider(chain_identifier(), String.t()) :: {:ok, map()} | {:error, term()}
   def get_provider(chain_name, provider_id) do
     get_provider(@default_profile, chain_name, provider_id)
   end
 
-  @spec get_provider(String.t(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
-  def get_provider(profile, chain_name, provider_id) do
-    ConfigStore.get_provider(profile, chain_name, provider_id)
+  @spec get_provider(String.t(), chain_identifier(), String.t()) ::
+          {:ok, map()} | {:error, term()}
+  def get_provider(profile, chain_identifier, provider_id) do
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      ConfigStore.get_provider(profile, chain_id, provider_id)
+    end
   end
 
   # Private functions
 
-  defp ensure_chain_started(profile, chain_name) do
-    case ConfigStore.get_chain(profile, chain_name) do
-      {:ok, _chain_config} ->
-        :ok
+  defp resolve_chain_id(_profile, chain_id) when is_integer(chain_id) and chain_id > 0,
+    do: {:ok, chain_id}
 
-      {:error, :not_found} ->
-        Logger.info("Chain '#{chain_name}' not found, creating with default configuration")
-
-        default_config = create_default_chain_config(chain_name)
-
-        with :ok <- ConfigStore.register_chain_runtime(profile, chain_name, default_config),
-             {:ok, _pid} <- start_chain_supervisor(profile, chain_name, default_config) do
-          Logger.info("Successfully started chain supervisor for '#{chain_name}'")
-          :ok
-        else
-          {:error, {:already_started, _pid}} ->
-            :ok
-
-          {:error, reason} = error ->
-            Logger.error("Failed to start chain '#{chain_name}': #{inspect(reason)}")
-            error
-        end
+  defp resolve_chain_id(profile, chain_identifier) when is_binary(chain_identifier) do
+    case ConfigStore.lookup_chain_id_in_profile(profile, chain_identifier) do
+      {:ok, chain_id} -> {:ok, chain_id}
+      :not_found -> {:error, :chain_not_found}
     end
   end
 
-  defp create_default_chain_config(chain_name) do
-    %{
-      chain_id: nil,
-      name: chain_name,
-      providers: [],
-      connection: %{
-        heartbeat_interval: 30_000,
-        reconnect_interval: 5_000,
-        max_reconnect_attempts: 5
-      },
-      failover: %{
-        enabled: true,
-        max_backfill_blocks: 100,
-        backfill_timeout: 30_000
-      }
-    }
-  end
+  defp resolve_chain_id(_profile, _chain_identifier), do: {:error, :chain_not_found}
 
-  defp start_chain_supervisor(profile, chain_name, _chain_config_attrs) do
-    case ConfigStore.get_chain(profile, chain_name) do
-      {:ok, chain_config} ->
-        Lasso.ProfileChainSupervisor.start_profile_chain(profile, chain_name, chain_config)
-
-      {:error, reason} ->
-        {:error, {:config_fetch_failed, reason}}
+  defp ensure_chain_started(profile, chain_id) when is_integer(chain_id) and chain_id > 0 do
+    case ConfigStore.get_chain(profile, chain_id) do
+      {:ok, _chain_config} -> :ok
+      {:error, :not_found} -> {:error, :chain_not_found}
     end
   end
 

--- a/lib/lasso/core/providers/providers.ex
+++ b/lib/lasso/core/providers/providers.ex
@@ -47,26 +47,27 @@ defmodule Lasso.Providers do
     provider_config = normalize_provider_config(provider_attrs)
     provider_id = Map.get(provider_config, :id)
 
-    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier),
-         :ok <- maybe_validate(provider_config, validate?),
-         :ok <- ensure_chain_started(profile, chain_id),
-         :ok <- check_not_duplicate(profile, chain_id, provider_id),
-         :ok <- ConfigStore.register_provider_runtime(profile, chain_id, provider_config),
-         :ok <-
-           ChainSupervisor.ensure_provider(profile, chain_id, provider_config, start_ws: start_ws),
-         :ok <- maybe_persist_add(chain_id, provider_config, persist?) do
-      Logger.info("Successfully added provider #{provider_id} to chain #{chain_id}")
-      {:ok, provider_id}
-    else
+    result =
+      with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier),
+           :ok <- maybe_validate(provider_config, validate?),
+           :ok <- ensure_chain_started(profile, chain_id),
+           :ok <- check_not_duplicate(profile, chain_id, provider_id),
+           :ok <- ConfigStore.register_provider_runtime(profile, chain_id, provider_config) do
+        finish_provider_add(
+          profile,
+          chain_id,
+          provider_config,
+          start_ws,
+          persist?
+        )
+      end
+
+    case result do
+      :ok ->
+        Logger.info("Successfully added provider #{provider_id} to chain #{chain_identifier}")
+        {:ok, provider_id}
+
       {:error, reason} = error ->
-        case resolve_chain_id(profile, chain_identifier) do
-          {:ok, chain_id} when is_binary(provider_id) ->
-            _ = ConfigStore.unregister_provider_runtime(profile, chain_id, provider_id)
-
-          _ ->
-            :ok
-        end
-
         Logger.error(
           "Failed to add provider #{provider_id} to chain #{inspect(chain_identifier)}: #{inspect(reason)}"
         )
@@ -232,14 +233,49 @@ defmodule Lasso.Providers do
     end
   end
 
+  defp finish_provider_add(profile, chain_id, provider_config, start_ws, persist?) do
+    result =
+      case ChainSupervisor.ensure_provider(profile, chain_id, provider_config, start_ws: start_ws) do
+        :ok -> maybe_persist_add(chain_id, provider_config, persist?)
+        {:error, _reason} = error -> error
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, _reason} = error ->
+        instance_id = Catalog.lookup_instance_id(profile, chain_id, provider_config.id)
+        _ = ConfigStore.unregister_provider_runtime(profile, chain_id, provider_config.id)
+        _ = ChainSupervisor.remove_provider(profile, chain_id, provider_config.id, instance_id)
+        error
+    end
+  end
+
   defp normalize_provider_config(attrs) when is_map(attrs) do
     %{
-      id: Map.get(attrs, :id) || Map.get(attrs, "id"),
-      name: Map.get(attrs, :name) || Map.get(attrs, "name"),
-      url: Map.get(attrs, :url) || Map.get(attrs, "url"),
-      ws_url: Map.get(attrs, :ws_url) || Map.get(attrs, "ws_url"),
-      priority: Map.get(attrs, :priority) || Map.get(attrs, "priority") || 100
+      id: attr(attrs, :id),
+      name: attr(attrs, :name),
+      url: attr(attrs, :url),
+      ws_url: attr(attrs, :ws_url),
+      priority: attr(attrs, :priority, 100),
+      capabilities: attr(attrs, :capabilities),
+      subscribe_new_heads: attr(attrs, :subscribe_new_heads),
+      archival: attr(attrs, :archival, true),
+      sharing_mode: attr(attrs, :sharing_mode, :auto),
+      api_key: attr(attrs, :api_key),
+      credentials: attr(attrs, :credentials),
+      headers: attr(attrs, :headers),
+      auth_headers: attr(attrs, :auth_headers),
+      __mock__: attr(attrs, :__mock__)
     }
+  end
+
+  defp attr(attrs, key, default \\ nil) do
+    case Map.fetch(attrs, key) do
+      {:ok, value} -> value
+      :error -> Map.get(attrs, Atom.to_string(key), default)
+    end
   end
 
   defp maybe_validate(provider_config, true) do

--- a/lib/lasso/core/providers/providers.ex
+++ b/lib/lasso/core/providers/providers.ex
@@ -216,8 +216,19 @@ defmodule Lasso.Providers do
 
   defp ensure_chain_started(profile, chain_id) when is_integer(chain_id) and chain_id > 0 do
     case ConfigStore.get_chain(profile, chain_id) do
-      {:ok, _chain_config} -> :ok
-      {:error, :not_found} -> {:error, :chain_not_found}
+      {:ok, chain_config} ->
+        if Lasso.ProfileChainSupervisor.running?(profile, chain_id) do
+          :ok
+        else
+          case Lasso.ProfileChainSupervisor.start_profile_chain(profile, chain_id, chain_config) do
+            {:ok, _pid} -> :ok
+            {:error, {:already_started, _pid}} -> :ok
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+      {:error, :not_found} ->
+        {:error, :chain_not_found}
     end
   end
 

--- a/lib/lasso/core/request/request_context.ex
+++ b/lib/lasso/core/request/request_context.ex
@@ -17,8 +17,7 @@ defmodule Lasso.RPC.RequestContext do
   @type t :: %__MODULE__{
           # Request identification
           request_id: String.t(),
-          account_id: String.t() | nil,
-          chain: String.t(),
+          chain_id: pos_integer(),
           method: String.t(),
           params: list(),
           transport: :http | :ws,
@@ -73,8 +72,7 @@ defmodule Lasso.RPC.RequestContext do
         }
 
   defstruct request_id: nil,
-            account_id: nil,
-            chain: nil,
+            chain_id: nil,
             method: nil,
             params: [],
             transport: :http,
@@ -115,18 +113,16 @@ defmodule Lasso.RPC.RequestContext do
   If :request_id is provided in opts, it will be used (typically from Phoenix's Plug.RequestId).
   Otherwise, a new request_id will be generated.
   """
-  @spec new(String.t(), String.t(), list(), keyword()) :: t()
-  def new(chain, method, params, opts \\ []) do
+  @spec new(pos_integer(), String.t(), list(), keyword()) :: t()
+  def new(chain_id, method, params, opts \\ []) do
     request_id = Keyword.get(opts, :request_id) || generate_request_id()
 
-    # Use plug_start_time if available for accurate E2E, otherwise use current time
     plug_start = Keyword.get(opts, :plug_start_time)
     start_time = plug_start || System.monotonic_time(:microsecond)
 
     %__MODULE__{
       request_id: request_id,
-      account_id: Keyword.get(opts, :account_id),
-      chain: chain,
+      chain_id: chain_id,
       method: method,
       params: params,
       transport: Keyword.get(opts, :transport, :http),

--- a/lib/lasso/core/request/request_options.ex
+++ b/lib/lasso/core/request/request_options.ex
@@ -15,7 +15,6 @@ defmodule Lasso.RPC.RequestOptions do
 
   @enforce_keys [:timeout_ms]
   defstruct profile: @default_profile,
-            account_id: nil,
             strategy: :load_balanced,
             provider_override: nil,
             transport: nil,
@@ -29,7 +28,6 @@ defmodule Lasso.RPC.RequestOptions do
 
   @type t :: %__MODULE__{
           profile: String.t(),
-          account_id: String.t() | nil,
           strategy: strategy,
           provider_override: String.t() | nil,
           transport: transport,

--- a/lib/lasso/core/request/request_options_builder.ex
+++ b/lib/lasso/core/request/request_options_builder.ex
@@ -40,7 +40,7 @@ defmodule Lasso.RPC.RequestOptions.Builder do
   """
   @spec from_conn(Plug.Conn.t(), String.t(), override_opts) :: RequestOptions.t()
   def from_conn(%Plug.Conn{} = conn, method, overrides \\ []) when is_binary(method) do
-    profile = Map.get(conn.assigns, :profile_slug, ProfileValidator.default_profile())
+    profile = routing_profile_from_conn(conn)
     strategy = resolve_strategy_from_conn(conn, overrides)
     provider_override = resolve_provider_from_conn(conn, overrides)
     transport = resolve_transport(method, resolve_transport_preference_from_conn(conn, overrides))
@@ -111,6 +111,14 @@ defmodule Lasso.RPC.RequestOptions.Builder do
       overrides[:request_context],
       method
     )
+  end
+
+  # ProfileResolverPlug establishes the opaque runtime identity at the HTTP
+  # boundary. The slug fallback preserves direct/internal callers because file
+  # profiles use the slug as their system profile ID.
+  defp routing_profile_from_conn(conn) do
+    Map.get(conn.assigns, :profile_id) ||
+      Map.get(conn.assigns, :profile_slug, ProfileValidator.default_profile())
   end
 
   # Strategy resolution

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -38,7 +38,7 @@ defmodule Lasso.RPC.RequestPipeline do
   alias Lasso.RPC.RequestPipeline.{FailoverStrategy, Observability}
 
   # Type definitions
-  @type chain :: String.t()
+  @type chain_id :: pos_integer()
   @type method :: String.t()
   @type params :: list()
   @type result :: {:ok, any(), RequestContext.t()} | {:error, JError.t(), RequestContext.t()}
@@ -72,7 +72,7 @@ defmodule Lasso.RPC.RequestPipeline do
   ## Examples
 
       {:ok, result, ctx} = execute_via_channels(
-        "ethereum",
+        1,
         "eth_blockNumber",
         [],
         %RequestOptions{strategy: :fastest}
@@ -80,19 +80,20 @@ defmodule Lasso.RPC.RequestPipeline do
       # ctx.executed_channel contains the channel that succeeded
 
       {:error, %JError{}, ctx} = execute_via_channels(
-        "ethereum",
+        1,
         "eth_call",
         [],
         %RequestOptions{provider_override: "failing_provider"}
       )
   """
-  @spec execute_via_channels(chain(), method(), params(), RequestOptions.t()) :: result()
-  def execute_via_channels(chain, method, params, %RequestOptions{} = opts) do
-    ctx = initialize_context(chain, method, params, opts)
+  @spec execute_via_channels(chain_id(), method(), params(), RequestOptions.t()) :: result()
+  def execute_via_channels(chain_id, method, params, %RequestOptions{} = opts)
+      when is_integer(chain_id) and chain_id > 0 do
+    ctx = initialize_context(chain_id, method, params, opts)
     rpc_request = build_rpc_request(method, params, ctx, opts)
     ctx = RequestContext.set_execution_params(ctx, rpc_request, opts.timeout_ms, opts)
 
-    case validate_provider_override(chain, opts) do
+    case validate_provider_override(chain_id, opts) do
       :ok ->
         channel_source = build_channel_source(opts)
         execute_pipeline(channel_source, ctx)
@@ -102,14 +103,14 @@ defmodule Lasso.RPC.RequestPipeline do
     end
   end
 
-  @spec validate_provider_override(chain(), RequestOptions.t()) :: :ok | {:error, JError.t()}
-  defp validate_provider_override(_chain, %RequestOptions{provider_override: nil}), do: :ok
+  @spec validate_provider_override(chain_id(), RequestOptions.t()) :: :ok | {:error, JError.t()}
+  defp validate_provider_override(_chain_id, %RequestOptions{provider_override: nil}), do: :ok
 
-  defp validate_provider_override(chain, %RequestOptions{
+  defp validate_provider_override(chain_id, %RequestOptions{
          provider_override: provider_id,
          profile: profile
        }) do
-    case ConfigStore.get_provider(profile, chain, provider_id) do
+    case ConfigStore.get_provider(profile, chain_id, provider_id) do
       {:ok, _provider} ->
         :ok
 
@@ -118,7 +119,7 @@ defmodule Lasso.RPC.RequestPipeline do
          JError.new(-32_602, "Provider '#{provider_id}' not found",
            category: :invalid_params,
            retriable?: false,
-           data: %{provider_id: provider_id, chain: chain, profile: profile}
+           data: %{provider_id: provider_id, chain_id: chain_id, profile: profile}
          )}
     end
   end
@@ -128,7 +129,7 @@ defmodule Lasso.RPC.RequestPipeline do
     ctx = RequestContext.mark_request_start(ctx)
 
     Observability.record_request_start(
-      ctx.chain,
+      ctx.chain_id,
       ctx.method,
       ctx.opts.strategy,
       ctx.opts.provider_override
@@ -162,9 +163,8 @@ defmodule Lasso.RPC.RequestPipeline do
   # Params are extracted from RequestContext - no need to pass separately (prevents closure footgun)
   @spec build_channel_source(RequestOptions.t()) :: channel_source()
   defp build_channel_source(%RequestOptions{provider_override: nil, profile: profile} = opts) do
-    # Normal selection: get best channels via Selection module
-    fn %RequestContext{chain: chain, method: method, params: params} = _ctx ->
-      Selection.select_channels(profile, chain, method,
+    fn %RequestContext{chain_id: chain_id, method: method, params: params} = _ctx ->
+      Selection.select_channels(profile, chain_id, method,
         strategy: opts.strategy,
         transport: opts.transport || :both,
         limit: @max_channel_candidates,
@@ -176,14 +176,12 @@ defmodule Lasso.RPC.RequestPipeline do
   defp build_channel_source(
          %RequestOptions{provider_override: provider_id, profile: profile} = opts
        ) do
-    # Provider override: get channels for specific provider, optionally with failover
-    fn %RequestContext{chain: chain, method: method, params: params} = _ctx ->
-      primary_channels = get_provider_channels(profile, chain, provider_id, opts.transport)
+    fn %RequestContext{chain_id: chain_id, method: method, params: params} = _ctx ->
+      primary_channels = get_provider_channels(profile, chain_id, provider_id, opts.transport)
 
       if opts.failover_on_override do
-        # Append alternative channels for failover
         failover_channels =
-          Selection.select_channels(profile, chain, method,
+          Selection.select_channels(profile, chain_id, method,
             strategy: opts.strategy,
             transport: :both,
             exclude: [provider_id],
@@ -200,9 +198,8 @@ defmodule Lasso.RPC.RequestPipeline do
 
   @spec attempt_channels([Channel.t()], RequestContext.t()) :: result()
   defp attempt_channels([], ctx) do
-    # All channels exhausted
     Logger.warning("All channels exhausted",
-      chain: ctx.chain,
+      chain_id: ctx.chain_id,
       method: ctx.method,
       request_id: ctx.request_id,
       attempts: length(ctx.attempted_channels)
@@ -239,7 +236,8 @@ defmodule Lasso.RPC.RequestPipeline do
 
   @spec execute_on_channel(Channel.t(), [Channel.t()], RequestContext.t()) :: result()
   defp execute_on_channel(channel, rest_channels, ctx) do
-    instance_id = Catalog.lookup_instance_id(channel.profile, channel.chain, channel.provider_id)
+    instance_id =
+      Catalog.lookup_instance_id(channel.profile, channel.chain_id, channel.provider_id)
 
     cb_state =
       case instance_id do
@@ -416,9 +414,9 @@ defmodule Lasso.RPC.RequestPipeline do
     profile = if ctx.opts, do: ctx.opts.profile, else: ProfileValidator.default_profile()
 
     retry_after_ms =
-      calculate_min_recovery_time(profile, ctx.chain, ctx.opts && ctx.opts.transport)
+      calculate_min_recovery_time(profile, ctx.chain_id, ctx.opts && ctx.opts.transport)
 
-    {message, data} = build_exhaustion_error_message(ctx.method, retry_after_ms, ctx.chain)
+    {message, data} = build_exhaustion_error_message(ctx.method, retry_after_ms, ctx.chain_id)
 
     jerr =
       JError.new(-32_000, message,
@@ -428,12 +426,12 @@ defmodule Lasso.RPC.RequestPipeline do
       )
 
     Logger.warning("No channels available",
-      chain: ctx.chain,
+      chain_id: ctx.chain_id,
       method: ctx.method,
       retry_after_ms: retry_after_ms
     )
 
-    Observability.record_exhaustion(ctx.chain, ctx.method, ctx.opts.transport, retry_after_ms)
+    Observability.record_exhaustion(ctx.chain_id, ctx.method, ctx.opts.transport, retry_after_ms)
 
     finalize_error(jerr, ctx)
   end
@@ -498,15 +496,15 @@ defmodule Lasso.RPC.RequestPipeline do
     end
   end
 
-  @spec initialize_context(chain(), method(), params(), RequestOptions.t()) :: RequestContext.t()
-  defp initialize_context(chain, method, params, opts) do
+  @spec initialize_context(chain_id(), method(), params(), RequestOptions.t()) ::
+          RequestContext.t()
+  defp initialize_context(chain_id, method, params, opts) do
     opts.request_context ||
-      RequestContext.new(chain, method, params,
+      RequestContext.new(chain_id, method, params,
         transport: opts.transport || :http,
         strategy: opts.strategy,
         request_id: opts.request_id,
-        plug_start_time: opts.plug_start_time,
-        account_id: opts.account_id
+        plug_start_time: opts.plug_start_time
       )
   end
 
@@ -520,19 +518,19 @@ defmodule Lasso.RPC.RequestPipeline do
     }
   end
 
-  @spec get_provider_channels(String.t(), chain(), String.t(), atom() | nil) :: [Channel.t()]
-  defp get_provider_channels(profile, chain, provider_id, transport_override) do
+  @spec get_provider_channels(String.t(), chain_id(), String.t(), atom() | nil) :: [Channel.t()]
+  defp get_provider_channels(profile, chain_id, provider_id, transport_override) do
     transports = if transport_override, do: [transport_override], else: [:http, :ws]
 
     for transport <- transports,
-        channel = fetch_channel_safe(profile, chain, provider_id, transport),
+        channel = fetch_channel_safe(profile, chain_id, provider_id, transport),
         not is_nil(channel),
         do: channel
   end
 
-  @spec fetch_channel_safe(String.t(), chain(), String.t(), atom()) :: Channel.t() | nil
-  defp fetch_channel_safe(profile, chain, provider_id, transport) do
-    case TransportRegistry.get_channel(profile, chain, provider_id, transport) do
+  @spec fetch_channel_safe(String.t(), chain_id(), String.t(), atom()) :: Channel.t() | nil
+  defp fetch_channel_safe(profile, chain_id, provider_id, transport) do
+    case TransportRegistry.get_channel(profile, chain_id, provider_id, transport) do
       {:ok, channel} -> channel
       {:error, _} -> nil
     end
@@ -540,13 +538,13 @@ defmodule Lasso.RPC.RequestPipeline do
     :exit, _ -> nil
   end
 
-  @spec build_exhaustion_error_message(method(), non_neg_integer() | nil, chain()) ::
+  @spec build_exhaustion_error_message(method(), non_neg_integer() | nil, chain_id()) ::
           {String.t(), map()}
-  defp build_exhaustion_error_message(method, nil, _chain) do
+  defp build_exhaustion_error_message(method, nil, _chain_id) do
     {"No available channels for method: #{method}. All circuit breakers are open.", %{}}
   end
 
-  defp build_exhaustion_error_message(method, ms, _chain) when is_integer(ms) and ms > 0 do
+  defp build_exhaustion_error_message(method, ms, _chain_id) when is_integer(ms) and ms > 0 do
     seconds = div(ms, 1000)
 
     message =
@@ -555,16 +553,19 @@ defmodule Lasso.RPC.RequestPipeline do
     {message, %{retry_after_ms: ms}}
   end
 
-  defp build_exhaustion_error_message(method, retry_after_ms, chain) do
-    Logger.warning("Invalid recovery time: #{inspect(retry_after_ms)}", chain: chain)
+  defp build_exhaustion_error_message(method, retry_after_ms, chain_id) do
+    Logger.warning("Invalid recovery time: #{inspect(retry_after_ms)}", chain_id: chain_id)
     {"No available channels for method: #{method}. All circuit breakers are open.", %{}}
   end
 
-  @spec calculate_min_recovery_time(String.t(), chain(), atom() | nil) :: non_neg_integer() | nil
-  defp calculate_min_recovery_time(profile, chain, transport_filter) do
+  @spec calculate_min_recovery_time(String.t(), chain_id(), atom() | nil) ::
+          non_neg_integer() | nil
+  defp calculate_min_recovery_time(profile, chain_id, transport_filter) do
     transport = transport_filter || :both
 
-    {:ok, min_time} = CandidateListing.get_min_recovery_time(profile, chain, transport: transport)
+    {:ok, min_time} =
+      CandidateListing.get_min_recovery_time(profile, chain_id, transport: transport)
+
     min_time
   end
 
@@ -595,7 +596,7 @@ defmodule Lasso.RPC.RequestPipeline do
     )
 
     Observability.record_very_slow_request(
-      ctx.chain,
+      ctx.chain_id,
       method,
       channel.provider_id,
       channel.transport,
@@ -612,7 +613,7 @@ defmodule Lasso.RPC.RequestPipeline do
     )
 
     Observability.record_slow_request(
-      ctx.chain,
+      ctx.chain_id,
       method,
       channel.provider_id,
       channel.transport,

--- a/lib/lasso/core/request/request_pipeline/failover_strategy.ex
+++ b/lib/lasso/core/request/request_pipeline/failover_strategy.ex
@@ -106,7 +106,7 @@ defmodule Lasso.RPC.RequestPipeline.FailoverStrategy do
         error_message: error.message,
         method: ctx.method,
         repeated_count: repeated_count,
-        chain: ctx.chain
+        chain_id: ctx.chain_id
       )
 
       {false, :repeated_client_error}
@@ -125,7 +125,7 @@ defmodule Lasso.RPC.RequestPipeline.FailoverStrategy do
         method: ctx.method,
         repeated_count: repeated_count,
         threshold: @repeated_capability_violation_threshold,
-        chain: ctx.chain
+        chain_id: ctx.chain_id
       )
 
       {false, :universal_capability_violation}
@@ -144,7 +144,7 @@ defmodule Lasso.RPC.RequestPipeline.FailoverStrategy do
         method: ctx.method,
         repeated_count: repeated_count,
         threshold: @repeated_capability_violation_threshold,
-        chain: ctx.chain
+        chain_id: ctx.chain_id
       )
 
       {false, :universal_method_not_found}

--- a/lib/lasso/core/request/request_pipeline/observability.ex
+++ b/lib/lasso/core/request/request_pipeline/observability.ex
@@ -23,7 +23,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   alias Lasso.RPC.{Channel, RateLimitState, RequestContext}
 
   @type telemetry_metadata :: %{
-          chain: String.t(),
+          chain_id: pos_integer(),
           method: String.t(),
           strategy: atom(),
           provider_id: String.t(),
@@ -46,18 +46,17 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
       ) do
     profile = ctx.opts.profile
 
-    Metrics.record_success(profile, ctx.chain, provider_id, method, duration_ms,
+    Metrics.record_success(profile, ctx.chain_id, provider_id, method, duration_ms,
       transport: transport
     )
 
-    instance_id = Catalog.lookup_instance_id(profile, ctx.chain, provider_id)
+    instance_id = Catalog.lookup_instance_id(profile, ctx.chain_id, provider_id)
     report_success_to_ets(instance_id, transport)
 
     publish_routing_decision(
       request_id: ctx.request_id,
-      account_id: ctx.account_id,
       profile: profile,
-      chain: ctx.chain,
+      chain_id: ctx.chain_id,
       method: method,
       strategy: strategy,
       provider_id: provider_id,
@@ -68,7 +67,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
     )
 
     emit_request_telemetry(
-      ctx.chain,
+      ctx.chain_id,
       method,
       strategy,
       provider_id,
@@ -106,19 +105,18 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
     jerr = JError.from(reason, provider_id: provider_id)
 
     if ErrorClassification.provider_health_failure?(jerr.category) do
-      Metrics.record_failure(profile, ctx.chain, provider_id, method, duration_ms,
+      Metrics.record_failure(profile, ctx.chain_id, provider_id, method, duration_ms,
         transport: transport
       )
     end
 
-    instance_id = Catalog.lookup_instance_id(profile, ctx.chain, provider_id)
-    report_failure_to_ets(instance_id, transport, jerr, profile, ctx.chain, provider_id)
+    instance_id = Catalog.lookup_instance_id(profile, ctx.chain_id, provider_id)
+    report_failure_to_ets(instance_id, transport, jerr, profile, ctx.chain_id, provider_id)
 
     publish_routing_decision(
       request_id: ctx.request_id,
-      account_id: ctx.account_id,
       profile: profile,
-      chain: ctx.chain,
+      chain_id: ctx.chain_id,
       method: method,
       strategy: strategy,
       provider_id: provider_id,
@@ -129,7 +127,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
     )
 
     emit_request_telemetry(
-      ctx.chain,
+      ctx.chain_id,
       method,
       strategy,
       provider_id,
@@ -146,7 +144,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
       when is_binary(provider_id) do
     Logger.warning("record_failure called with bare provider_id, skipping metrics",
       provider_id: provider_id,
-      chain: ctx.chain
+      chain_id: ctx.chain_id
     )
 
     :ok
@@ -170,7 +168,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
       [:lasso, :failover, :fast_fail],
       %{count: 1, duration: duration_ms},
       %{
-        chain: ctx.chain,
+        chain_id: ctx.chain_id,
         method: ctx.method,
         request_id: ctx.request_id,
         provider_id: provider_id,
@@ -180,13 +178,9 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
       }
     )
 
-    # Skip BenchmarkStore recording — failover intermediaries should not count against
-    # a provider's success rate. Only requests a provider actually "served" (success or
-    # terminal failure) should be tracked in performance metrics.
-    # ETS health counters still update here (they already filter via breaker_penalty?).
-    instance_id = Catalog.lookup_instance_id(profile, ctx.chain, provider_id)
+    instance_id = Catalog.lookup_instance_id(profile, ctx.chain_id, provider_id)
     jerr = JError.from(error_reason, provider_id: provider_id)
-    report_failure_to_ets(instance_id, transport, jerr, profile, ctx.chain, provider_id)
+    report_failure_to_ets(instance_id, transport, jerr, profile, ctx.chain_id, provider_id)
 
     :ok
   end
@@ -199,7 +193,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
     :telemetry.execute(
       [:lasso, :failover, :circuit_open],
       %{count: 1},
-      %{chain: ctx.chain, provider_id: provider_id, transport: transport}
+      %{chain_id: ctx.chain_id, provider_id: provider_id, transport: transport}
     )
 
     :ok
@@ -208,9 +202,9 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @doc """
   Records request start telemetry.
   """
-  @spec record_request_start(String.t(), String.t(), atom(), String.t() | nil) :: :ok
-  def record_request_start(chain, method, strategy, provider_id \\ nil) do
-    metadata = %{chain: chain, method: method, strategy: strategy}
+  @spec record_request_start(pos_integer(), String.t(), atom(), String.t() | nil) :: :ok
+  def record_request_start(chain_id, method, strategy, provider_id \\ nil) do
+    metadata = %{chain_id: chain_id, method: method, strategy: strategy}
     metadata = if provider_id, do: Map.put(metadata, :provider_id, provider_id), else: metadata
     :telemetry.execute([:lasso, :rpc, :request, :start], %{count: 1}, metadata)
     :ok
@@ -219,12 +213,12 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @doc """
   Records when entering degraded mode (attempting half-open circuits).
   """
-  @spec record_degraded_mode(String.t(), String.t()) :: :ok
-  def record_degraded_mode(chain, method) do
+  @spec record_degraded_mode(pos_integer(), String.t()) :: :ok
+  def record_degraded_mode(chain_id, method) do
     :telemetry.execute(
       [:lasso, :failover, :degraded_mode],
       %{count: 1},
-      %{chain: chain, method: method}
+      %{chain_id: chain_id, method: method}
     )
 
     :ok
@@ -233,15 +227,15 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @doc """
   Records successful request via degraded mode (half-open circuit).
   """
-  @spec record_degraded_success(String.t(), String.t(), Channel.t()) :: :ok
-  def record_degraded_success(chain, method, %Channel{
+  @spec record_degraded_success(pos_integer(), String.t(), Channel.t()) :: :ok
+  def record_degraded_success(chain_id, method, %Channel{
         provider_id: provider_id,
         transport: transport
       }) do
     :telemetry.execute(
       [:lasso, :failover, :degraded_success],
       %{count: 1},
-      %{chain: chain, method: method, provider_id: provider_id, transport: transport}
+      %{chain_id: chain_id, method: method, provider_id: provider_id, transport: transport}
     )
 
     :ok
@@ -250,13 +244,13 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @doc """
   Records channel exhaustion (all circuits open).
   """
-  @spec record_exhaustion(String.t(), String.t(), atom(), non_neg_integer() | nil) :: :ok
-  def record_exhaustion(chain, method, transport, retry_after_ms) do
+  @spec record_exhaustion(pos_integer(), String.t(), atom(), non_neg_integer() | nil) :: :ok
+  def record_exhaustion(chain_id, method, transport, retry_after_ms) do
     :telemetry.execute(
       [:lasso, :failover, :exhaustion],
       %{count: 1},
       %{
-        chain: chain,
+        chain_id: chain_id,
         method: method,
         retry_after_ms: retry_after_ms || 0,
         transport: transport || :both
@@ -269,12 +263,12 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @doc """
   Records slow request (>2000ms) telemetry.
   """
-  @spec record_slow_request(String.t(), String.t(), String.t(), atom(), float()) :: :ok
-  def record_slow_request(chain, method, provider_id, transport, latency_ms) do
+  @spec record_slow_request(pos_integer(), String.t(), String.t(), atom(), float()) :: :ok
+  def record_slow_request(chain_id, method, provider_id, transport, latency_ms) do
     :telemetry.execute(
       [:lasso, :request, :slow],
       %{latency_ms: latency_ms},
-      %{chain: chain, method: method, provider: provider_id, transport: transport}
+      %{chain_id: chain_id, method: method, provider: provider_id, transport: transport}
     )
 
     :ok
@@ -283,12 +277,12 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @doc """
   Records very slow request (>4000ms) telemetry.
   """
-  @spec record_very_slow_request(String.t(), String.t(), String.t(), atom(), float()) :: :ok
-  def record_very_slow_request(chain, method, provider_id, transport, latency_ms) do
+  @spec record_very_slow_request(pos_integer(), String.t(), String.t(), atom(), float()) :: :ok
+  def record_very_slow_request(chain_id, method, provider_id, transport, latency_ms) do
     :telemetry.execute(
       [:lasso, :request, :very_slow],
       %{latency_ms: latency_ms},
-      %{chain: chain, method: method, provider: provider_id, transport: transport}
+      %{chain_id: chain_id, method: method, provider: provider_id, transport: transport}
     )
 
     :ok
@@ -321,9 +315,9 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
     :ets.insert(:lasso_instance_state, {{:health_routing, instance_id}, merged})
   end
 
-  defp report_failure_to_ets(nil, _transport, _jerr, _profile, _chain, _provider_id), do: :ok
+  defp report_failure_to_ets(nil, _transport, _jerr, _profile, _chain_id, _provider_id), do: :ok
 
-  defp report_failure_to_ets(instance_id, transport, jerr, profile, chain, provider_id) do
+  defp report_failure_to_ets(instance_id, transport, jerr, profile, chain_id, provider_id) do
     cond do
       jerr.category == :rate_limit ->
         retry_after_ms = RateLimitState.extract_retry_after(jerr.data)
@@ -341,7 +335,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
             })
         end
 
-        publish_provider_event(profile, chain, provider_id, :rate_limited)
+        publish_provider_event(profile, chain_id, provider_id, :rate_limited)
 
       not ErrorClassification.breaker_penalty?(jerr.category) ->
         :ok
@@ -369,7 +363,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
         :ets.insert(:lasso_instance_state, {{:health_routing, instance_id}, merged})
 
         if new_status == :unhealthy do
-          publish_provider_event(profile, chain, provider_id, :unhealthy)
+          publish_provider_event(profile, chain_id, provider_id, :unhealthy)
         end
     end
   end
@@ -386,19 +380,24 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
     end
   end
 
-  defp publish_provider_event(profile, chain, provider_id, event_type) do
+  defp publish_provider_event(profile, chain_id, provider_id, event_type) do
     ts = System.system_time(:millisecond)
 
     typed =
       case event_type do
         :unhealthy ->
-          %Provider.Unhealthy{ts: ts, chain: chain, provider_id: provider_id, reason: nil}
+          %Provider.Unhealthy{ts: ts, chain_id: chain_id, provider_id: provider_id, reason: nil}
 
         :rate_limited ->
-          %Provider.Unhealthy{ts: ts, chain: chain, provider_id: provider_id, reason: :rate_limit}
+          %Provider.Unhealthy{
+            ts: ts,
+            chain_id: chain_id,
+            provider_id: provider_id,
+            reason: :rate_limit
+          }
       end
 
-    Phoenix.PubSub.broadcast(Lasso.PubSub, Provider.topic(profile, chain), typed)
+    Phoenix.PubSub.broadcast(Lasso.PubSub, Lasso.Topics.provider_event(profile, chain_id), typed)
   end
 
   # Private helpers
@@ -406,14 +405,13 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
   @spec publish_routing_decision(keyword()) :: :ok | {:error, term()}
   defp publish_routing_decision(opts) do
     instance_id =
-      Catalog.lookup_instance_id(opts[:profile], opts[:chain], opts[:provider_id])
+      Catalog.lookup_instance_id(opts[:profile], opts[:chain_id], opts[:provider_id])
 
     event =
       RoutingDecision.new(
         request_id: opts[:request_id],
-        account_id: opts[:account_id],
         profile: opts[:profile],
-        chain: opts[:chain],
+        chain_id: opts[:chain_id],
         method: opts[:method],
         strategy: opts[:strategy],
         provider_id: opts[:provider_id],
@@ -426,13 +424,13 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
 
     Phoenix.PubSub.broadcast(
       Lasso.PubSub,
-      RoutingDecision.topic(opts[:profile]),
+      Lasso.Topics.routing_decision(opts[:profile]),
       event
     )
   end
 
   @spec emit_request_telemetry(
-          String.t(),
+          pos_integer(),
           String.t(),
           atom(),
           String.t(),
@@ -442,7 +440,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
           non_neg_integer()
         ) :: :ok
   defp emit_request_telemetry(
-         chain,
+         chain_id,
          method,
          strategy,
          provider_id,
@@ -455,7 +453,7 @@ defmodule Lasso.RPC.RequestPipeline.Observability do
       [:lasso, :rpc, :request, :stop],
       %{duration: duration_ms},
       %{
-        chain: chain,
+        chain_id: chain_id,
         method: method,
         strategy: strategy,
         provider_id: provider_id,

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -44,10 +44,10 @@ defmodule Lasso.RPC.Selection do
 
   Returns {:ok, provider_id} or {:error, reason}
   """
-  @spec select_provider(String.t(), String.t(), String.t(), keyword()) ::
+  @spec select_provider(String.t(), pos_integer(), String.t(), keyword()) ::
           {:ok, String.t()} | {:error, term()}
-  def select_provider(profile, chain, method, opts \\ [])
-      when is_binary(profile) and is_binary(chain) and is_binary(method) do
+  def select_provider(profile, chain_id, method, opts \\ [])
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_binary(method) do
     params = Keyword.get(opts, :params, [])
 
     selection_opts = %{
@@ -55,27 +55,29 @@ defmodule Lasso.RPC.Selection do
       protocol: Keyword.get(opts, :protocol, :both),
       exclude: Keyword.get(opts, :exclude, []),
       include_half_open: Keyword.get(opts, :include_half_open, false),
-      timeout: Keyword.get(opts, :timeout, 30_000)
+      timeout: Keyword.get(opts, :timeout, 30_000),
+      requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false)
     }
 
-    do_select_provider(profile, chain, method, params, selection_opts)
+    do_select_provider(profile, chain_id, method, params, selection_opts)
   end
 
   # Private implementation
 
-  defp do_select_provider(profile, chain, method, params, selection_opts) do
+  defp do_select_provider(profile, chain_id, method, params, selection_opts) do
     filters =
       build_selection_filters(
         profile,
-        chain,
+        chain_id,
         method,
         params,
         selection_opts.exclude,
         selection_opts.protocol,
-        include_half_open: selection_opts.include_half_open
+        include_half_open: selection_opts.include_half_open,
+        requires_subscribe_new_heads: selection_opts.requires_subscribe_new_heads
       )
 
-    candidates = CandidateListing.list_candidates(profile, chain, filters)
+    candidates = CandidateListing.list_candidates(profile, chain_id, filters)
 
     case candidates do
       [] ->
@@ -85,7 +87,7 @@ defmodule Lasso.RPC.Selection do
         strategy_mod = StrategyRegistry.resolve(selection_opts.strategy)
 
         prepared_ctx =
-          strategy_mod.prepare_context(profile, chain, method, selection_opts.timeout)
+          strategy_mod.prepare_context(profile, chain_id, method, selection_opts.timeout)
 
         channels =
           candidates
@@ -98,7 +100,7 @@ defmodule Lasso.RPC.Selection do
               end
 
             Enum.flat_map(transports, fn t ->
-              case TransportRegistry.get_channel(profile, chain, provider_id, t,
+              case TransportRegistry.get_channel(profile, chain_id, provider_id, t,
                      method: method,
                      provider_config: provider_config
                    ) do
@@ -109,12 +111,12 @@ defmodule Lasso.RPC.Selection do
           end)
 
         ordered =
-          strategy_mod.rank_channels(channels, method, prepared_ctx, profile, chain)
+          strategy_mod.rank_channels(channels, method, prepared_ctx, profile, chain_id)
 
         case List.first(ordered) do
           %Channel{provider_id: pid} ->
             :telemetry.execute([:lasso, :selection, :success], %{count: 1}, %{
-              chain: chain,
+              chain_id: chain_id,
               method: method,
               strategy: selection_opts.strategy,
               protocol: selection_opts.protocol,
@@ -146,9 +148,9 @@ defmodule Lasso.RPC.Selection do
 
   Returns a list of Channel structs ordered by strategy preference.
   """
-  @spec select_channels(String.t(), String.t(), String.t(), keyword()) :: [Channel.t()]
-  def select_channels(profile, chain, method, opts \\ [])
-      when is_binary(profile) and is_binary(chain) and is_binary(method) do
+  @spec select_channels(String.t(), pos_integer(), String.t(), keyword()) :: [Channel.t()]
+  def select_channels(profile, chain_id, method, opts \\ [])
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_binary(method) do
     strategy = Keyword.get(opts, :strategy, :load_balanced)
     transport = Keyword.get(opts, :transport, :both)
     exclude = Keyword.get(opts, :exclude, [])
@@ -163,9 +165,8 @@ defmodule Lasso.RPC.Selection do
         _ -> nil
       end
 
-    # Analyze request to determine archival requirements
-    archival_threshold = get_archival_threshold(profile, chain)
-    consensus_height = get_consensus_height(chain)
+    archival_threshold = get_archival_threshold(profile, chain_id)
+    consensus_height = get_consensus_height(chain_id)
 
     requirements =
       Lasso.RPC.RequestAnalysis.analyze(
@@ -180,21 +181,21 @@ defmodule Lasso.RPC.Selection do
         protocol: pool_protocol,
         exclude: exclude,
         include_half_open: include_half_open,
-        max_lag_blocks: get_max_lag(profile, chain),
+        max_lag_blocks: get_max_lag(profile, chain_id),
         min_block: requirements.requested_block,
-        requires_archival: requirements.requires_archival
+        requires_archival: requirements.requires_archival,
+        requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false)
       )
 
-    # Instrument CandidateListing.list_candidates call time
     pool_start = System.monotonic_time(:microsecond)
-    provider_candidates = CandidateListing.list_candidates(profile, chain, pool_filters)
+    provider_candidates = CandidateListing.list_candidates(profile, chain_id, pool_filters)
 
     pool_duration_us = System.monotonic_time(:microsecond) - pool_start
 
     :telemetry.execute(
       [:lasso, :selection, :pool_candidates],
       %{duration_us: pool_duration_us, candidate_count: length(provider_candidates)},
-      %{chain: chain, method: method, strategy: strategy}
+      %{chain_id: chain_id, method: method, strategy: strategy}
     )
 
     # Build circuit state lookup map: {provider_id, transport} => :closed | :half_open
@@ -222,7 +223,7 @@ defmodule Lasso.RPC.Selection do
 
     channels =
       provider_candidates
-      |> Enum.flat_map(&build_provider_channels(&1, transport, profile, chain, method))
+      |> Enum.flat_map(&build_provider_channels(&1, transport, profile, chain_id, method))
       |> Enum.reject(&is_nil/1)
 
     registry_duration_us = System.monotonic_time(:microsecond) - registry_start
@@ -230,7 +231,7 @@ defmodule Lasso.RPC.Selection do
     :telemetry.execute(
       [:lasso, :selection, :channel_building],
       %{duration_us: registry_duration_us, channel_count: length(channels)},
-      %{chain: chain, method: method, provider_count: length(provider_candidates)}
+      %{chain_id: chain_id, method: method, provider_count: length(provider_candidates)}
     )
 
     # Filter channels by method capability (adapter-based filtering)
@@ -257,10 +258,10 @@ defmodule Lasso.RPC.Selection do
     # Strategy delegation: allow strategy modules to rank channels when available.
     strategy_mod = StrategyRegistry.resolve(strategy)
     timeout = Keyword.get(opts, :timeout, 30_000)
-    prepared_ctx = strategy_mod.prepare_context(profile, chain, method, timeout)
+    prepared_ctx = strategy_mod.prepare_context(profile, chain_id, method, timeout)
 
     ordered_channels =
-      strategy_mod.rank_channels(capable_channels, method, prepared_ctx, profile, chain)
+      strategy_mod.rank_channels(capable_channels, method, prepared_ctx, profile, chain_id)
 
     # Health-based tiering: reorder providers by circuit breaker state and rate limit status.
     #
@@ -307,10 +308,11 @@ defmodule Lasso.RPC.Selection do
 
   Returns {:ok, channel} or {:error, reason}.
   """
-  @spec select_provider_channel(String.t(), String.t(), String.t(), :http | :ws, keyword()) ::
+  @spec select_provider_channel(String.t(), pos_integer(), String.t(), :http | :ws, keyword()) ::
           {:ok, Channel.t()} | {:error, term()}
-  def select_provider_channel(profile, chain, provider_id, transport, opts \\ []) do
-    TransportRegistry.get_channel(profile, chain, provider_id, transport, opts)
+  def select_provider_channel(profile, chain_id, provider_id, transport, opts \\ [])
+      when is_integer(chain_id) and chain_id > 0 do
+    TransportRegistry.get_channel(profile, chain_id, provider_id, transport, opts)
   end
 
   ## Private Functions
@@ -321,13 +323,13 @@ defmodule Lasso.RPC.Selection do
          %{id: provider_id, config: config},
          transport,
          profile,
-         chain,
+         chain_id,
          method
        ) do
     transport
     |> transports_to_check()
     |> Enum.filter(fn t -> provider_supports_transport?(config, t) end)
-    |> Enum.flat_map(fn t -> fetch_channel(profile, chain, provider_id, t, method, config) end)
+    |> Enum.flat_map(fn t -> fetch_channel(profile, chain_id, provider_id, t, method, config) end)
   end
 
   defp transports_to_check(:http), do: [:http]
@@ -337,8 +339,8 @@ defmodule Lasso.RPC.Selection do
   defp provider_supports_transport?(config, :http), do: is_binary(Map.get(config, :url))
   defp provider_supports_transport?(config, :ws), do: is_binary(Map.get(config, :ws_url))
 
-  defp fetch_channel(profile, chain, provider_id, transport, method, provider_config) do
-    case TransportRegistry.get_channel(profile, chain, provider_id, transport,
+  defp fetch_channel(profile, chain_id, provider_id, transport, method, provider_config) do
+    case TransportRegistry.get_channel(profile, chain_id, provider_id, transport,
            method: method,
            provider_config: provider_config
          ) do
@@ -347,20 +349,12 @@ defmodule Lasso.RPC.Selection do
     end
   end
 
-  # Configuration helper: Get max lag threshold for a specific profile/chain
-  # Returns nil if no lag filtering should be applied
-  # Configuration precedence (highest to lowest):
-  # 1. Per-chain default (from profile config)
-  # 2. Global application default
-  defp get_max_lag(profile, chain) do
-    # Try to get chain-specific config from the profile
-    case Lasso.Config.ConfigStore.get_chain(profile, chain) do
+  defp get_max_lag(profile, chain_id) do
+    case Lasso.Config.ConfigStore.get_chain(profile, chain_id) do
       {:ok, %{selection: %{max_lag_blocks: chain_default}}} ->
-        # Use chain-level default
         chain_default || get_global_max_lag()
 
       _ ->
-        # No chain config or selection config, use global default
         get_global_max_lag()
     end
   end
@@ -372,8 +366,8 @@ defmodule Lasso.RPC.Selection do
     |> Keyword.get(:max_lag_blocks)
   end
 
-  defp get_archival_threshold(profile, chain) do
-    case Lasso.Config.ConfigStore.get_chain(profile, chain) do
+  defp get_archival_threshold(profile, chain_id) do
+    case Lasso.Config.ConfigStore.get_chain(profile, chain_id) do
       {:ok, %{selection: %{archival_threshold: threshold}}} when is_integer(threshold) ->
         threshold
 
@@ -382,17 +376,18 @@ defmodule Lasso.RPC.Selection do
     end
   end
 
-  defp get_consensus_height(chain) do
-    case ChainState.consensus_height(chain) do
+  defp get_consensus_height(chain_id) do
+    case ChainState.consensus_height(chain_id) do
       {:ok, height} -> height
       {:error, _} -> nil
     end
   end
 
-  defp build_selection_filters(profile, chain, method, params, exclude, protocol, opts) do
-    archival_threshold = get_archival_threshold(profile, chain)
-    consensus_height = get_consensus_height(chain)
+  defp build_selection_filters(profile, chain_id, method, params, exclude, protocol, opts) do
+    archival_threshold = get_archival_threshold(profile, chain_id)
+    consensus_height = get_consensus_height(chain_id)
     include_half_open = Keyword.get(opts, :include_half_open, false)
+    requires_subscribe_new_heads = Keyword.get(opts, :requires_subscribe_new_heads, false)
 
     requirements =
       RequestAnalysis.analyze(
@@ -406,9 +401,10 @@ defmodule Lasso.RPC.Selection do
       exclude: exclude,
       protocol: protocol,
       include_half_open: include_half_open,
-      max_lag_blocks: get_max_lag(profile, chain),
+      max_lag_blocks: get_max_lag(profile, chain_id),
       min_block: requirements.requested_block,
-      requires_archival: requirements.requires_archival
+      requires_archival: requirements.requires_archival,
+      requires_subscribe_new_heads: requires_subscribe_new_heads
     )
   end
 end

--- a/lib/lasso/core/selection/selection_filters.ex
+++ b/lib/lasso/core/selection/selection_filters.ex
@@ -16,7 +16,8 @@ defmodule Lasso.RPC.SelectionFilters do
           exclude_rate_limited: boolean(),
           max_lag_blocks: non_neg_integer() | nil,
           min_block: non_neg_integer() | nil,
-          requires_archival: boolean()
+          requires_archival: boolean(),
+          requires_subscribe_new_heads: boolean()
         }
 
   defstruct protocol: nil,
@@ -25,7 +26,8 @@ defmodule Lasso.RPC.SelectionFilters do
             exclude_rate_limited: false,
             max_lag_blocks: nil,
             min_block: nil,
-            requires_archival: false
+            requires_archival: false,
+            requires_subscribe_new_heads: false
 
   @doc """
   Creates a new SelectionFilters struct with validated defaults.
@@ -39,6 +41,8 @@ defmodule Lasso.RPC.SelectionFilters do
     * `:max_lag_blocks` - Maximum acceptable block lag (nil = no limit)
     * `:min_block` - Minimum block height the provider must have (nil = no filter)
     * `:requires_archival` - Request requires archival data support (default: false)
+    * `:requires_subscribe_new_heads` - Request is an `eth_subscribe newHeads`
+      and must route only to providers that declare the capability (default: false)
 
   ## Examples
 
@@ -57,7 +61,8 @@ defmodule Lasso.RPC.SelectionFilters do
       exclude_rate_limited: Keyword.get(opts, :exclude_rate_limited, false),
       max_lag_blocks: Keyword.get(opts, :max_lag_blocks),
       min_block: Keyword.get(opts, :min_block),
-      requires_archival: Keyword.get(opts, :requires_archival, false)
+      requires_archival: Keyword.get(opts, :requires_archival, false),
+      requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false)
     }
   end
 
@@ -76,7 +81,11 @@ defmodule Lasso.RPC.SelectionFilters do
         to_boolean(map[:exclude_rate_limited] || Map.get(map, "exclude_rate_limited")),
       max_lag_blocks: map[:max_lag_blocks] || Map.get(map, "max_lag_blocks"),
       min_block: map[:min_block] || Map.get(map, "min_block"),
-      requires_archival: to_boolean(map[:requires_archival] || Map.get(map, "requires_archival"))
+      requires_archival: to_boolean(map[:requires_archival] || Map.get(map, "requires_archival")),
+      requires_subscribe_new_heads:
+        to_boolean(
+          map[:requires_subscribe_new_heads] || Map.get(map, "requires_subscribe_new_heads")
+        )
     }
   end
 
@@ -92,7 +101,8 @@ defmodule Lasso.RPC.SelectionFilters do
       exclude_rate_limited: filters.exclude_rate_limited,
       max_lag_blocks: filters.max_lag_blocks,
       min_block: filters.min_block,
-      requires_archival: filters.requires_archival
+      requires_archival: filters.requires_archival,
+      requires_subscribe_new_heads: filters.requires_subscribe_new_heads
     }
   end
 

--- a/lib/lasso/core/selection/strategies/fastest.ex
+++ b/lib/lasso/core/selection/strategies/fastest.ex
@@ -33,17 +33,16 @@ defmodule Lasso.RPC.Strategies.Fastest do
   @min_success_rate 0.9
 
   @impl true
-  def prepare_context(profile, chain, method, timeout) do
-    base_ctx = StrategyContext.new(chain, timeout)
+  def prepare_context(profile, chain_id, method, timeout) do
+    base_ctx = StrategyContext.new(chain_id, timeout)
 
     min_calls = Application.get_env(:lasso, :fastest_min_calls, @min_calls)
     min_success_rate = Application.get_env(:lasso, :fastest_min_success_rate, @min_success_rate)
 
-    # Calculate fallback latency for providers with no data
     fallback_latency =
       StrategyContext.calculate_fallback_latency(
         profile,
-        chain,
+        chain_id,
         method
       )
 
@@ -65,16 +64,15 @@ defmodule Lasso.RPC.Strategies.Fastest do
   - Missing metrics: Use P75 of known providers as dynamic baseline
   """
   @impl true
-  def rank_channels(channels, method, ctx, profile, chain) do
+  def rank_channels(channels, method, ctx, profile, chain_id) do
     current_time = System.system_time(:millisecond)
 
-    # Batch fetch all metrics (eliminates N sequential GenServer calls)
     requests =
       Enum.map(channels, fn ch ->
         {ch.provider_id, method, ch.transport}
       end)
 
-    metrics_map = Metrics.batch_get_transport_performance(profile, chain, requests)
+    metrics_map = Metrics.batch_get_transport_performance(profile, chain_id, requests)
 
     # Sort using pre-fetched metrics with staleness and cold start checks
     Enum.sort_by(channels, fn channel ->

--- a/lib/lasso/core/selection/strategies/latency_weighted.ex
+++ b/lib/lasso/core/selection/strategies/latency_weighted.ex
@@ -44,14 +44,13 @@ defmodule Lasso.RPC.Strategies.LatencyWeighted do
   @default_explore_floor 0.05
 
   @impl true
-  def prepare_context(profile, chain, method, timeout) do
-    base = StrategyContext.new(chain, timeout)
+  def prepare_context(profile, chain_id, method, timeout) do
+    base = StrategyContext.new(chain_id, timeout)
 
-    # Calculate fallback latency for providers with no data
     fallback_latency =
       StrategyContext.calculate_fallback_latency(
         profile,
-        chain,
+        chain_id,
         method
       )
 
@@ -76,22 +75,19 @@ defmodule Lasso.RPC.Strategies.LatencyWeighted do
   probabilistic weighting based on latency, success rate, and confidence.
   """
   @impl true
-  def rank_channels(channels, method, ctx, profile, chain) do
+  def rank_channels(channels, method, ctx, profile, chain_id) do
     current_time = System.system_time(:millisecond)
 
-    # Fetch strategy-specific tuning params from app config
     beta = Application.get_env(:lasso, :lw_beta, @default_beta)
     ms_floor = Application.get_env(:lasso, :lw_ms_floor, @default_ms_floor)
     explore_floor = Application.get_env(:lasso, :lw_explore_floor, @default_explore_floor)
 
-    # Use context fields populated in prepare_context
     min_calls = ctx.min_calls || @default_min_calls
     min_sr = ctx.min_success_rate || @default_min_sr
     freshness_cutoff = ctx.freshness_cutoff_ms || 10 * 60 * 1000
 
-    # Batch fetch all metrics (eliminates N sequential GenServer calls)
     requests = Enum.map(channels, fn ch -> {ch.provider_id, method, ch.transport} end)
-    metrics_map = Metrics.batch_get_transport_performance(profile, chain, requests)
+    metrics_map = Metrics.batch_get_transport_performance(profile, chain_id, requests)
 
     weight_fn = fn ch ->
       key = {ch.provider_id, method, ch.transport}

--- a/lib/lasso/core/selection/strategies/load_balanced.ex
+++ b/lib/lasso/core/selection/strategies/load_balanced.ex
@@ -15,8 +15,8 @@ defmodule Lasso.RPC.Strategies.LoadBalanced do
   @behaviour Lasso.RPC.Strategy
 
   @impl true
-  def prepare_context(_profile, chain, _method, timeout) do
-    Lasso.RPC.StrategyContext.new(chain, timeout)
+  def prepare_context(_profile, chain_id, _method, timeout) do
+    Lasso.RPC.StrategyContext.new(chain_id, timeout)
   end
 
   @impl true

--- a/lib/lasso/core/selection/strategies/priority.ex
+++ b/lib/lasso/core/selection/strategies/priority.ex
@@ -6,8 +6,8 @@ defmodule Lasso.RPC.Strategies.Priority do
   alias Lasso.Config.ConfigStore
 
   @impl true
-  def prepare_context(_profile, chain, _method, timeout) do
-    Lasso.RPC.StrategyContext.new(chain, timeout)
+  def prepare_context(_profile, chain_id, _method, timeout) do
+    Lasso.RPC.StrategyContext.new(chain_id, timeout)
   end
 
   @doc """
@@ -15,8 +15,8 @@ defmodule Lasso.RPC.Strategies.Priority do
   Lower numeric priority wins; HTTP preferred over WS for equal priority.
   """
   @impl true
-  def rank_channels(channels, _method, _ctx, profile, chain) do
-    priority_by_id = provider_priority_map(profile, chain)
+  def rank_channels(channels, _method, _ctx, profile, chain_id) do
+    priority_by_id = provider_priority_map(profile, chain_id)
 
     Enum.sort_by(channels, fn ch ->
       provider_priority = Map.get(priority_by_id, ch.provider_id, 1_000_000)
@@ -25,8 +25,8 @@ defmodule Lasso.RPC.Strategies.Priority do
     end)
   end
 
-  defp provider_priority_map(profile, chain) do
-    case ConfigStore.get_chain(profile, chain) do
+  defp provider_priority_map(profile, chain_id) do
+    case ConfigStore.get_chain(profile, chain_id) do
       {:ok, %{providers: providers}} when is_list(providers) ->
         providers
         |> Enum.map(fn p ->

--- a/lib/lasso/core/selection/strategy.ex
+++ b/lib/lasso/core/selection/strategy.ex
@@ -30,7 +30,7 @@ defmodule Lasso.RPC.Strategy do
   """
   @callback prepare_context(
               profile :: String.t(),
-              chain :: String.t(),
+              chain_id :: pos_integer(),
               method :: String.t(),
               timeout :: non_neg_integer()
             ) :: StrategyContext.t()
@@ -46,6 +46,6 @@ defmodule Lasso.RPC.Strategy do
               method :: String.t(),
               ctx :: context(),
               profile :: String.t(),
-              chain :: String.t()
+              chain_id :: pos_integer()
             ) :: [Channel.t()]
 end

--- a/lib/lasso/core/selection/strategy_context.ex
+++ b/lib/lasso/core/selection/strategy_context.ex
@@ -12,9 +12,9 @@ defmodule Lasso.RPC.StrategyContext do
   @default_fallback_latency_ms 500.0
   @max_fallback_latency_ms 10_000.0
 
-  @enforce_keys [:chain, :now_ms, :timeout]
+  @enforce_keys [:chain_id, :now_ms, :timeout]
   defstruct [
-    :chain,
+    :chain_id,
     :now_ms,
     :timeout,
     # Optional fields populated by strategies
@@ -26,7 +26,7 @@ defmodule Lasso.RPC.StrategyContext do
   ]
 
   @type t :: %__MODULE__{
-          chain: String.t(),
+          chain_id: pos_integer(),
           now_ms: integer(),
           timeout: non_neg_integer(),
           total_requests: non_neg_integer() | nil,
@@ -39,10 +39,10 @@ defmodule Lasso.RPC.StrategyContext do
   @doc """
   Builds the base strategy context.
   """
-  @spec new(String.t(), non_neg_integer()) :: t()
-  def new(chain, timeout) when is_binary(chain) and is_integer(timeout) do
+  @spec new(pos_integer(), non_neg_integer()) :: t()
+  def new(chain_id, timeout) when is_integer(chain_id) and chain_id > 0 and is_integer(timeout) do
     %__MODULE__{
-      chain: chain,
+      chain_id: chain_id,
       now_ms: System.monotonic_time(:millisecond),
       timeout: timeout
     }
@@ -55,9 +55,9 @@ defmodule Lasso.RPC.StrategyContext do
   if no providers have data. This provides context-aware penalties rather than
   using a fixed value for all methods.
   """
-  @spec calculate_fallback_latency(String.t(), String.t(), String.t()) :: float()
-  def calculate_fallback_latency(profile, chain, method) do
-    case get_valid_latencies(profile, chain, method) do
+  @spec calculate_fallback_latency(String.t(), pos_integer(), String.t()) :: float()
+  def calculate_fallback_latency(profile, chain_id, method) do
+    case get_valid_latencies(profile, chain_id, method) do
       [] -> @default_fallback_latency_ms
       latencies -> min(median(latencies), @max_fallback_latency_ms)
     end
@@ -65,9 +65,9 @@ defmodule Lasso.RPC.StrategyContext do
 
   # Private functions
 
-  defp get_valid_latencies(profile, chain, method) do
+  defp get_valid_latencies(profile, chain_id, method) do
     profile
-    |> Metrics.get_method_performance(chain, method)
+    |> Metrics.get_method_performance(chain_id, method)
     |> Enum.map(& &1.performance.latency_ms)
     |> Enum.filter(&(is_number(&1) and &1 > 0))
     |> Enum.sort()

--- a/lib/lasso/core/strategies/strategy_registry.ex
+++ b/lib/lasso/core/strategies/strategy_registry.ex
@@ -41,6 +41,31 @@ defmodule Lasso.RPC.Strategies.Registry do
     |> Map.keys()
   end
 
+  @doc """
+  Returns the URL-slug form of every registered strategy
+  (`:load_balanced → "load-balanced"`, etc.) in stable order.
+
+  Single source of truth for any UI / docs surface that lists
+  exposed strategies. Adding a strategy in `default_registry/0`
+  (or via the `:strategy_registry` config override) automatically
+  shows up everywhere this function is consumed — no parallel
+  hand-maintained list to drift against.
+  """
+  @spec strategy_slugs() :: [String.t()]
+  def strategy_slugs do
+    strategy_atoms()
+    |> Enum.map(&strategy_atom_to_slug/1)
+    |> Enum.sort()
+  end
+
+  @doc """
+  Converts a strategy atom to its URL-slug form. Defined here so
+  consumers don't reimplement the `_` → `-` convention.
+  """
+  @spec strategy_atom_to_slug(atom()) :: String.t()
+  def strategy_atom_to_slug(atom) when is_atom(atom),
+    do: atom |> Atom.to_string() |> String.replace("_", "-")
+
   @spec default_registry() :: %{strategy => module()}
   def default_registry do
     %{

--- a/lib/lasso/core/streaming/client_subscription_registry.ex
+++ b/lib/lasso/core/streaming/client_subscription_registry.ex
@@ -10,47 +10,54 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
   use GenServer
   require Logger
 
-  @type key :: {:newHeads} | {:logs, map()}
+  alias Lasso.Core.Streaming.UpstreamSubscriptionPool
 
-  @spec start_link({String.t(), String.t()}) :: GenServer.on_start()
-  def start_link({profile, chain}) when is_binary(profile) and is_binary(chain) do
-    GenServer.start_link(__MODULE__, {profile, chain}, name: via(profile, chain))
+  @type subscription_key :: {:newHeads} | {:logs, map()}
+  @type key :: subscription_key() | {:route, String.t() | :routed, subscription_key()}
+
+  @spec start_link({String.t(), pos_integer()}) :: GenServer.on_start()
+  def start_link({profile, chain_id})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.start_link(__MODULE__, {profile, chain_id}, name: via(profile, chain_id))
   end
 
-  @spec via(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
-  def via(profile, chain) when is_binary(profile) and is_binary(chain) do
-    {:via, Registry, {Lasso.Registry, {:client_registry, profile, chain}}}
+  @spec via(String.t(), pos_integer()) :: {:via, Registry, {atom(), tuple()}}
+  def via(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    {:via, Registry, {Lasso.Registry, {:client_registry, profile, chain_id}}}
   end
 
-  @spec add_client(String.t(), String.t(), String.t(), pid(), key) :: :ok
-  def add_client(profile, chain, subscription_id, client_pid, key)
-      when is_binary(profile) and is_binary(chain) do
-    GenServer.call(via(profile, chain), {:add, subscription_id, client_pid, key})
+  @spec add_client(String.t(), pos_integer(), String.t(), pid(), key) :: :ok
+  def add_client(profile, chain_id, subscription_id, client_pid, key)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(via(profile, chain_id), {:add, subscription_id, client_pid, key})
   end
 
-  @spec remove_client(String.t(), String.t(), String.t()) :: {:ok, key | nil}
-  def remove_client(profile, chain, subscription_id)
-      when is_binary(profile) and is_binary(chain) do
-    GenServer.call(via(profile, chain), {:remove, subscription_id})
+  @spec remove_client(String.t(), pos_integer(), String.t()) :: {:ok, key | nil}
+  def remove_client(profile, chain_id, subscription_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(via(profile, chain_id), {:remove, subscription_id})
   end
 
-  @spec list_by_key(String.t(), String.t(), key) :: [String.t()]
-  def list_by_key(profile, chain, key) when is_binary(profile) and is_binary(chain) do
-    GenServer.call(via(profile, chain), {:list_by_key, key})
+  @spec list_by_key(String.t(), pos_integer(), key) :: [String.t()]
+  def list_by_key(profile, chain_id, key)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(via(profile, chain_id), {:list_by_key, key})
   end
 
-  @spec dispatch(String.t(), String.t(), key, map()) :: :ok
-  def dispatch(profile, chain, key, payload) when is_binary(profile) and is_binary(chain) do
-    GenServer.cast(via(profile, chain), {:dispatch, key, payload})
+  @spec dispatch(String.t(), pos_integer(), key, map()) :: :ok
+  def dispatch(profile, chain_id, key, payload)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.cast(via(profile, chain_id), {:dispatch, key, payload})
   end
 
   # GenServer callbacks
 
   @impl true
-  def init({profile, chain}) do
+  def init({profile, chain_id}) do
     state = %{
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       by_id: %{},
       by_key: %{}
     }
@@ -68,7 +75,7 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
       Map.update(state.by_key, key, [subscription_id], fn ids -> [subscription_id | ids] end)
 
     :telemetry.execute([:lasso, :subs, :client_subscribe], %{count: 1}, %{
-      chain: state.chain,
+      chain_id: state.chain_id,
       subscription_id: subscription_id
     })
 
@@ -91,7 +98,7 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
             else: Map.put(state.by_key, key, new_ids)
 
         :telemetry.execute([:lasso, :subs, :client_unsubscribe], %{count: 1}, %{
-          chain: state.chain,
+          chain_id: state.chain_id,
           subscription_id: subscription_id
         })
 
@@ -136,10 +143,15 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
 
   @impl true
   def handle_info({:DOWN, _mref, :process, pid, _reason}, state) do
-    # Cleanup any subscriptions tied to this client process
-    {removed, new_state} = remove_by_pid(state, pid)
+    {removed_by_key, new_state} = remove_by_pid(state, pid)
+    removed = removed_by_key |> Map.values() |> Enum.sum()
 
     if removed > 0 do
+      GenServer.cast(
+        UpstreamSubscriptionPool.via(state.profile, state.chain_id),
+        {:clients_removed, removed_by_key}
+      )
+
       Logger.debug("Cleaned up #{removed} subscriptions for dead client pid")
     end
 
@@ -158,6 +170,11 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
         if new_ids == [], do: Map.delete(acc, key), else: Map.put(acc, key, new_ids)
       end)
 
-    {length(to_remove), %{state | by_id: new_by_id, by_key: new_by_key}}
+    removed_by_key =
+      Enum.reduce(to_remove, %{}, fn {_subscription_id, %{key: key}}, acc ->
+        Map.update(acc, key, 1, &(&1 + 1))
+      end)
+
+    {removed_by_key, %{state | by_id: new_by_id, by_key: new_by_key}}
   end
 end

--- a/lib/lasso/core/streaming/instance_subscription_manager.ex
+++ b/lib/lasso/core/streaming/instance_subscription_manager.ex
@@ -40,7 +40,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
 
   defstruct [
     :instance_id,
-    :chain,
+    :chain_id,
     active_subscriptions: %{},
     upstream_index: %{},
     connection_state: nil,
@@ -50,9 +50,10 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
 
   # Client API
 
-  @spec start_link({String.t(), String.t()}) :: GenServer.on_start()
-  def start_link({chain, instance_id}) when is_binary(chain) and is_binary(instance_id) do
-    GenServer.start_link(__MODULE__, {chain, instance_id}, name: via(instance_id))
+  @spec start_link({pos_integer(), String.t()}) :: GenServer.on_start()
+  def start_link({chain_id, instance_id})
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) do
+    GenServer.start_link(__MODULE__, {chain_id, instance_id}, name: via(instance_id))
   end
 
   @spec via(String.t()) :: {:via, Registry, {atom(), tuple()}}
@@ -91,24 +92,24 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
   # GenServer Callbacks
 
   @impl true
-  def init({chain, instance_id}) do
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:subs:instance:#{instance_id}")
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:conn:instance:#{instance_id}")
+  def init({chain_id, instance_id}) do
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.ws_subs_instance(instance_id))
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.ws_conn_instance(instance_id))
 
     Process.send_after(self(), :cleanup_check, @cleanup_interval_ms)
 
     Phoenix.PubSub.broadcast(
       Lasso.PubSub,
-      "instance_sub_manager:restarted:#{chain}",
+      Lasso.Topics.instance_sub_manager_restarted(chain_id),
       {:instance_sub_manager_restarted, instance_id}
     )
 
-    new_heads_staleness_threshold_ms = calculate_staleness_threshold(instance_id, chain)
+    new_heads_staleness_threshold_ms = calculate_staleness_threshold(instance_id, chain_id)
 
     {:ok,
      %__MODULE__{
        instance_id: instance_id,
-       chain: chain,
+       chain_id: chain_id,
        new_heads_staleness_threshold_ms: new_heads_staleness_threshold_ms
      }}
   end
@@ -131,7 +132,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
   def handle_call(:get_status, _from, state) do
     status = %{
       instance_id: state.instance_id,
-      chain: state.chain,
+      chain_id: state.chain_id,
       connection_state: state.connection_state,
       active_subscriptions:
         Map.new(state.active_subscriptions, fn {sub_key, info} ->
@@ -523,14 +524,14 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
     :telemetry.execute(
       [:lasso, :upstream_subscriptions, event],
       %{count: 1},
-      %{instance_id: state.instance_id, chain: state.chain, sub_key: inspect(sub_key)}
+      %{instance_id: state.instance_id, chain_id: state.chain_id, sub_key: inspect(sub_key)}
     )
   end
 
-  defp calculate_staleness_threshold(instance_id, chain) do
+  defp calculate_staleness_threshold(instance_id, chain_id) do
     case Catalog.get_instance_refs(instance_id) do
       [ref_profile | _] ->
-        case ConfigStore.get_chain(ref_profile, chain) do
+        case ConfigStore.get_chain(ref_profile, chain_id) do
           {:ok, config} -> config.websocket.new_heads_timeout_ms
           _ -> @default_new_heads_staleness_threshold_ms
         end
@@ -593,7 +594,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
     :telemetry.execute(
       [:lasso, :upstream_subscriptions, :staleness_detected],
       %{count: 1, stale_duration_ms: stale_duration_ms},
-      %{instance_id: state.instance_id, chain: state.chain, sub_key: inspect(sub_key)}
+      %{instance_id: state.instance_id, chain_id: state.chain_id, sub_key: inspect(sub_key)}
     )
 
     # Fan out Subscription.Stale to all profiles referencing this instance
@@ -622,18 +623,18 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
 
     for profile <- profiles do
       provider_id =
-        Catalog.reverse_lookup_provider_id(profile, state.chain, state.instance_id) ||
+        Catalog.reverse_lookup_provider_id(profile, state.chain_id, state.instance_id) ||
           state.instance_id
 
       event = %Subscription.Stale{
         ts: System.system_time(:millisecond),
-        chain: state.chain,
+        chain_id: state.chain_id,
         provider_id: provider_id,
         subscription_type: Subscription.subscription_type(sub_key),
         stale_duration_ms: stale_duration_ms
       }
 
-      topic = Subscription.topic(profile, state.chain)
+      topic = Lasso.Topics.subscription_event(profile, state.chain_id)
       Phoenix.PubSub.broadcast(Lasso.PubSub, topic, event)
     end
   end

--- a/lib/lasso/core/streaming/stream_coordinator.ex
+++ b/lib/lasso/core/streaming/stream_coordinator.ex
@@ -29,7 +29,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     @moduledoc false
     defstruct [
       :profile,
-      :chain,
+      :chain_id,
       :max_backfill,
       :backfill_timeout,
       :continuity_policy,
@@ -38,7 +38,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
     @type t :: %__MODULE__{
             profile: String.t(),
-            chain: String.t(),
+            chain_id: pos_integer(),
             max_backfill: non_neg_integer(),
             backfill_timeout: non_neg_integer(),
             continuity_policy: atom(),
@@ -55,22 +55,25 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   @max_event_buffer 100
   @degraded_mode_retry_delay_ms 60_000
 
-  @spec start_link({String.t(), String.t(), term(), keyword()}) :: GenServer.on_start()
-  def start_link({profile, chain, key, opts})
-      when is_binary(profile) and is_binary(chain) do
-    GenServer.start_link(__MODULE__, {profile, chain, key, opts}, name: via(profile, chain, key))
+  @spec start_link({String.t(), pos_integer(), term(), keyword()}) :: GenServer.on_start()
+  def start_link({profile, chain_id, key, opts})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.start_link(__MODULE__, {profile, chain_id, key, opts},
+      name: via(profile, chain_id, key)
+    )
   end
 
-  @spec via(String.t(), String.t(), term()) :: {:via, Registry, {atom(), tuple()}}
-  def via(profile, chain, key) when is_binary(profile) and is_binary(chain) do
-    {:via, Registry, {Lasso.Registry, {:stream_coordinator, profile, chain, key}}}
+  @spec via(String.t(), pos_integer(), term()) :: {:via, Registry, {atom(), tuple()}}
+  def via(profile, chain_id, key)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    {:via, Registry, {Lasso.Registry, {:stream_coordinator, profile, chain_id, key}}}
   end
 
   # API called by UpstreamSubscriptionPool
 
   @spec upstream_event(
           String.t(),
-          String.t(),
+          pos_integer(),
           term(),
           String.t(),
           String.t() | nil,
@@ -78,27 +81,27 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
           integer()
         ) ::
           :ok
-  def upstream_event(profile, chain, key, provider_id, upstream_id, payload, received_at)
-      when is_binary(profile) and is_binary(chain) do
+  def upstream_event(profile, chain_id, key, provider_id, upstream_id, payload, received_at)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
     GenServer.cast(
-      via(profile, chain, key),
+      via(profile, chain_id, key),
       {:upstream_event, provider_id, upstream_id, payload, received_at}
     )
   end
 
-  @spec provider_unhealthy(String.t(), String.t(), term(), String.t(), String.t()) :: :ok
-  def provider_unhealthy(profile, chain, key, failed_id, proposed_new_id)
-      when is_binary(profile) and is_binary(chain) do
-    GenServer.cast(via(profile, chain, key), {:provider_unhealthy, failed_id, proposed_new_id})
+  @spec provider_unhealthy(String.t(), pos_integer(), term(), String.t(), String.t()) :: :ok
+  def provider_unhealthy(profile, chain_id, key, failed_id, proposed_new_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.cast(via(profile, chain_id, key), {:provider_unhealthy, failed_id, proposed_new_id})
   end
 
   # GenServer callbacks
 
   @impl true
-  def init({profile, chain, key, opts}) do
+  def init({profile, chain_id, key, opts}) do
     state = %{
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       key: key,
       primary_provider_id: Keyword.get(opts, :primary_provider_id),
       state:
@@ -139,16 +142,18 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
       :degraded ->
         # Circuit breaker triggered, drop events
-        # Emit telemetry for production visibility (metrics)
         :telemetry.execute(
           [:lasso, :stream, :dropped_event],
           %{count: 1},
-          %{chain: state.chain, reason: :degraded_mode}
+          %{chain_id: state.chain_id, reason: :degraded_mode}
         )
 
-        # Downgrade to DEBUG (filtered in production)
-        Logger.debug("Dropping event in degraded mode",
-          chain: state.chain,
+        # Info level (not debug) so degraded-mode drops are visible to ops
+        # without enabling debug logging globally. Bounded volume since the
+        # coordinator stays in :degraded with retry-cooldown gating.
+        Logger.info("Dropping event in degraded mode",
+          chain_id: state.chain_id,
+          profile: state.profile,
           key: inspect(state.key)
         )
 
@@ -162,7 +167,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       initiate_failover(state, failed_id, proposed_new_id)
     else
       Logger.warning("Ignoring provider_unhealthy signal during active failover",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key),
         current_status: state.failover_status
       )
@@ -178,7 +183,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       complete_failover(state, provider_id, upstream_id)
     else
       Logger.warning("Unexpected subscription_confirmed in status #{state.failover_status}",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
@@ -193,7 +198,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       handle_resubscribe_failure(state, reason)
     else
       Logger.warning("Unexpected subscription_failed in status #{state.failover_status}",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
@@ -218,7 +223,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
     if state.failover_context && state.failover_context.backfill_task_ref == ref do
       Logger.error("Backfill task crashed: #{inspect(reason)}",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
@@ -233,7 +238,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   def handle_info(:retry_from_degraded, state) do
     if state.failover_status == :degraded do
       Logger.info("Retrying failover from degraded mode",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
@@ -259,11 +264,11 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   # Internal implementation
 
   defp process_event_normal(state, payload) do
-    case state.key do
+    case subscription_key(state.key) do
       {:newHeads} ->
         case StreamState.ingest_new_head(state.state, payload) do
           {stream_state, :emit} ->
-            ClientSubscriptionRegistry.dispatch(state.profile, state.chain, state.key, payload)
+            ClientSubscriptionRegistry.dispatch(state.profile, state.chain_id, state.key, payload)
             {:noreply, %{state | state: stream_state}}
 
           {stream_state, :skip} ->
@@ -273,7 +278,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       {:logs, _filter} ->
         case StreamState.ingest_log(state.state, payload) do
           {stream_state, :emit} ->
-            ClientSubscriptionRegistry.dispatch(state.profile, state.chain, state.key, payload)
+            ClientSubscriptionRegistry.dispatch(state.profile, state.chain_id, state.key, payload)
             {:noreply, %{state | state: stream_state}}
 
           {stream_state, :skip} ->
@@ -285,20 +290,28 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   defp buffer_event(state, payload) do
     if state.failover_context do
       buffer = state.failover_context.event_buffer
+      buffer_count = Map.get(state.failover_context, :event_buffer_count, length(buffer))
 
-      if length(buffer) < state.max_event_buffer do
-        updated_context = %{state.failover_context | event_buffer: buffer ++ [payload]}
+      if buffer_count < state.max_event_buffer do
+        updated_context =
+          state.failover_context
+          |> Map.put(:event_buffer, [payload | buffer])
+          |> Map.put(:event_buffer_count, buffer_count + 1)
+
         {:noreply, %{state | failover_context: updated_context}}
       else
-        Logger.warning("Event buffer full (#{state.max_event_buffer}), dropping oldest event",
-          chain: state.chain,
+        Logger.error("Event buffer full (#{state.max_event_buffer}), entering degraded mode",
+          chain_id: state.chain_id,
           key: inspect(state.key)
         )
 
-        # Drop oldest, keep newest
-        updated_buffer = Enum.drop(buffer, 1) ++ [payload]
-        updated_context = %{state.failover_context | event_buffer: updated_buffer}
-        {:noreply, %{state | failover_context: updated_context}}
+        :telemetry.execute(
+          [:lasso, :stream, :event_buffer_overflow],
+          %{count: 1},
+          %{chain_id: state.chain_id, profile: state.profile, key: inspect(state.key)}
+        )
+
+        enter_degraded_mode(state, failover_budget(state))
       end
     else
       {:noreply, state}
@@ -313,7 +326,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   # Failover initiation with preserved buffer (used during cascade)
   defp initiate_failover_with_buffer(state, old_provider_id, new_provider_id, initial_buffer) do
     Logger.info("Initiating failover: #{old_provider_id} -> #{new_provider_id}",
-      chain: state.chain,
+      chain_id: state.chain_id,
       key: inspect(state.key)
     )
 
@@ -326,15 +339,14 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     if recent_failures >= max_failover_attempts do
       Logger.error(
         "Circuit breaker triggered: #{recent_failures}/#{max_failover_attempts} attempts in #{state.failover_cooldown_ms}ms",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
       enter_degraded_mode(state, budget)
     else
-      # Start backfill task
       profile = state.profile
-      chain = state.chain
+      chain_id = state.chain_id
       key = state.key
       max_backfill = state.max_backfill_blocks
       backfill_timeout = state.backfill_timeout
@@ -343,7 +355,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
       backfill_ctx = %BackfillContext{
         profile: profile,
-        chain: chain,
+        chain_id: chain_id,
         max_backfill: max_backfill,
         backfill_timeout: backfill_timeout,
         continuity_policy: continuity_policy,
@@ -363,6 +375,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
         started_at: System.monotonic_time(:millisecond),
         # Preserve events from previous cascade attempt
         event_buffer: initial_buffer,
+        event_buffer_count: length(initial_buffer),
         attempt_count: recent_failures + 1
       }
 
@@ -377,7 +390,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
         end
 
       telemetry_failover_initiated(
-        state.chain,
+        state.chain_id,
         state.key,
         old_provider_id,
         new_provider_id,
@@ -387,7 +400,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
       broadcast_subscription_event(state, %Subscription.Failover{
         ts: System.system_time(:millisecond),
-        chain: state.chain,
+        chain_id: state.chain_id,
         subscription_type: Subscription.subscription_type(state.key),
         from_provider_id: old_provider_id,
         to_provider_id: new_provider_id
@@ -404,7 +417,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   end
 
   defp execute_backfill(ctx, key, new_provider_id, stream_state) do
-    case key do
+    case subscription_key(key) do
       {:newHeads} ->
         backfill_blocks(ctx, key, new_provider_id, stream_state)
 
@@ -413,7 +426,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   rescue
     e ->
-      Logger.error("Backfill error: #{inspect(e)}", chain: ctx.chain, key: inspect(key))
+      Logger.error("Backfill error: #{inspect(e)}", chain_id: ctx.chain_id, key: inspect(key))
       :error
   end
 
@@ -421,8 +434,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     last = StreamState.last_block_num(stream_state)
 
     # Use decoupled HTTP provider selection for backfill
-    http_provider = pick_best_http_provider(ctx.profile, ctx.chain, ctx.excluded_providers)
-    head = fetch_head(ctx.chain, http_provider)
+    http_provider = pick_best_http_provider(ctx.profile, ctx.chain_id, ctx.excluded_providers)
+    head = fetch_head(ctx.chain_id, http_provider)
 
     case ContinuityPolicy.needed_block_range(
            last,
@@ -434,15 +447,15 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
         :ok
 
       {:range, from_n, to_n} ->
-        telemetry_backfill_started(ctx.chain, from_n, to_n, http_provider)
+        telemetry_backfill_started(ctx.chain_id, from_n, to_n, http_provider)
 
         {:ok, blocks} =
-          GapFiller.ensure_blocks(ctx.chain, http_provider, from_n, to_n,
+          GapFiller.ensure_blocks(ctx.chain_id, http_provider, from_n, to_n,
             timeout_ms: ctx.backfill_timeout
           )
 
         # Send blocks to coordinator via cast
-        coordinator_pid = via(ctx.profile, ctx.chain, key)
+        coordinator_pid = via(ctx.profile, ctx.chain_id, key)
 
         Enum.each(blocks, fn block ->
           GenServer.cast(
@@ -451,26 +464,26 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
           )
         end)
 
-        telemetry_backfill_completed(ctx.chain, from_n, to_n, length(blocks))
+        telemetry_backfill_completed(ctx.chain_id, from_n, to_n, length(blocks))
         :ok
 
       {:exceeded, from_n, to_n} ->
         Logger.warning("Gap exceeds max_backfill_blocks: #{from_n}-#{to_n}",
-          chain: ctx.chain,
+          chain_id: ctx.chain_id,
           key: inspect(key)
         )
 
         case ctx.continuity_policy do
           :best_effort ->
             # Fill what we can
-            telemetry_backfill_started(ctx.chain, from_n, to_n, http_provider)
+            telemetry_backfill_started(ctx.chain_id, from_n, to_n, http_provider)
 
             {:ok, blocks} =
-              GapFiller.ensure_blocks(ctx.chain, http_provider, from_n, to_n,
+              GapFiller.ensure_blocks(ctx.chain_id, http_provider, from_n, to_n,
                 timeout_ms: ctx.backfill_timeout
               )
 
-            coordinator_pid = via(ctx.profile, ctx.chain, key)
+            coordinator_pid = via(ctx.profile, ctx.chain_id, key)
 
             Enum.each(blocks, fn block ->
               GenServer.cast(
@@ -479,7 +492,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
               )
             end)
 
-            telemetry_backfill_completed(ctx.chain, from_n, to_n, length(blocks))
+            telemetry_backfill_completed(ctx.chain_id, from_n, to_n, length(blocks))
             :ok
 
           :strict_abort ->
@@ -492,8 +505,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     last = StreamState.last_log_block(stream_state) || StreamState.last_block_num(stream_state)
 
     # Use decoupled HTTP provider selection for backfill
-    http_provider = pick_best_http_provider(ctx.profile, ctx.chain, ctx.excluded_providers)
-    head = fetch_head(ctx.chain, http_provider)
+    http_provider = pick_best_http_provider(ctx.profile, ctx.chain_id, ctx.excluded_providers)
+    head = fetch_head(ctx.chain_id, http_provider)
 
     case ContinuityPolicy.needed_block_range(
            last,
@@ -505,13 +518,13 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
         :ok
 
       {:range, from_n, to_n} ->
-        telemetry_backfill_started(ctx.chain, from_n, to_n, http_provider)
+        telemetry_backfill_started(ctx.chain_id, from_n, to_n, http_provider)
 
-        case GapFiller.ensure_logs(ctx.chain, http_provider, filter, from_n, to_n,
+        case GapFiller.ensure_logs(ctx.chain_id, http_provider, filter, from_n, to_n,
                timeout_ms: ctx.backfill_timeout
              ) do
           {:ok, logs} ->
-            coordinator_pid = via(ctx.profile, ctx.chain, key)
+            coordinator_pid = via(ctx.profile, ctx.chain_id, key)
 
             Enum.each(logs, fn log ->
               GenServer.cast(
@@ -520,7 +533,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
               )
             end)
 
-            telemetry_backfill_completed(ctx.chain, from_n, to_n, length(logs))
+            telemetry_backfill_completed(ctx.chain_id, from_n, to_n, length(logs))
             :ok
 
           {:error, reason} ->
@@ -530,18 +543,18 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
       {:exceeded, from_n, to_n} ->
         Logger.warning("Gap exceeds max_backfill_blocks: #{from_n}-#{to_n}",
-          chain: ctx.chain,
+          chain_id: ctx.chain_id,
           key: inspect(key)
         )
 
         # For logs, best effort fill
-        telemetry_backfill_started(ctx.chain, from_n, to_n, http_provider)
+        telemetry_backfill_started(ctx.chain_id, from_n, to_n, http_provider)
 
-        case GapFiller.ensure_logs(ctx.chain, http_provider, filter, from_n, to_n,
+        case GapFiller.ensure_logs(ctx.chain_id, http_provider, filter, from_n, to_n,
                timeout_ms: ctx.backfill_timeout
              ) do
           {:ok, logs} ->
-            coordinator_pid = via(ctx.profile, ctx.chain, key)
+            coordinator_pid = via(ctx.profile, ctx.chain_id, key)
 
             Enum.each(logs, fn log ->
               GenServer.cast(
@@ -550,7 +563,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
               )
             end)
 
-            telemetry_backfill_completed(ctx.chain, from_n, to_n, length(logs))
+            telemetry_backfill_completed(ctx.chain_id, from_n, to_n, length(logs))
             :ok
 
           {:error, reason} ->
@@ -562,12 +575,12 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
   defp transition_to_switching(state) do
     Logger.info("Backfill complete, transitioning to :switching",
-      chain: state.chain,
+      chain_id: state.chain_id,
       key: inspect(state.key)
     )
 
     # Request resubscription from Pool
-    pool_ref = Lasso.Core.Streaming.UpstreamSubscriptionPool.via(state.profile, state.chain)
+    pool_ref = Lasso.Core.Streaming.UpstreamSubscriptionPool.via(state.profile, state.chain_id)
 
     GenServer.cast(
       pool_ref,
@@ -575,7 +588,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     )
 
     telemetry_resubscribe_initiated(
-      state.chain,
+      state.chain_id,
       state.key,
       state.failover_context.new_provider_id
     )
@@ -585,7 +598,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
   defp complete_failover(state, provider_id, _upstream_id) do
     Logger.info("Failover complete: now on provider #{provider_id}",
-      chain: state.chain,
+      chain_id: state.chain_id,
       key: inspect(state.key)
     )
 
@@ -602,7 +615,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     }
 
     duration_ms = System.monotonic_time(:millisecond) - state.failover_context.started_at
-    telemetry_failover_completed(final_state.chain, final_state.key, duration_ms)
+    telemetry_failover_completed(final_state.chain_id, final_state.key, duration_ms)
 
     {:noreply, final_state}
   end
@@ -611,13 +624,13 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     if state.failover_context && state.failover_context.event_buffer != [] do
       Logger.debug(
         "Draining #{length(state.failover_context.event_buffer)} buffered events",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
       # Sort deterministically before deduping
       ordered_buffer =
-        case state.key do
+        case subscription_key(state.key) do
           {:newHeads} ->
             Enum.sort_by(state.failover_context.event_buffer, fn payload ->
               decode_hex(Map.get(payload, "number", "0x0"))
@@ -632,11 +645,11 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
         end
 
       Enum.reduce(ordered_buffer, state, fn payload, acc ->
-        case acc.key do
+        case subscription_key(acc.key) do
           {:newHeads} ->
             case StreamState.ingest_new_head(acc.state, payload) do
               {stream_state, :emit} ->
-                ClientSubscriptionRegistry.dispatch(acc.profile, acc.chain, acc.key, payload)
+                ClientSubscriptionRegistry.dispatch(acc.profile, acc.chain_id, acc.key, payload)
                 %{acc | state: stream_state}
 
               {stream_state, :skip} ->
@@ -646,7 +659,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
           {:logs, _filter} ->
             case StreamState.ingest_log(acc.state, payload) do
               {stream_state, :emit} ->
-                ClientSubscriptionRegistry.dispatch(acc.profile, acc.chain, acc.key, payload)
+                ClientSubscriptionRegistry.dispatch(acc.profile, acc.chain_id, acc.key, payload)
                 %{acc | state: stream_state}
 
               {stream_state, :skip} ->
@@ -661,7 +674,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
   defp handle_resubscribe_failure(state, reason) do
     Logger.error("Resubscription failed: #{inspect(reason)}",
-      chain: state.chain,
+      chain_id: state.chain_id,
       key: inspect(state.key)
     )
 
@@ -673,7 +686,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
     if recent_failures >= max_failover_attempts do
       Logger.error("Max failover attempts reached, entering degraded mode",
-        chain: state.chain,
+        chain_id: state.chain_id,
         key: inspect(state.key)
       )
 
@@ -691,7 +704,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       case pick_next_provider(state, excluded, include_half_open: false) do
         {:ok, next_provider_id} ->
           Logger.info("Cascading to next provider: #{next_provider_id}",
-            chain: state.chain,
+            chain_id: state.chain_id,
             key: inspect(state.key)
           )
 
@@ -711,7 +724,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
         {:error, :no_providers} ->
           Logger.error("No more providers available",
-            chain: state.chain,
+            chain_id: state.chain_id,
             key: inspect(state.key)
           )
 
@@ -722,7 +735,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
   defp handle_backfill_failure(state, _reason) do
     Logger.error("Backfill task failed",
-      chain: state.chain,
+      chain_id: state.chain_id,
       key: inspect(state.key)
     )
 
@@ -731,15 +744,32 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   end
 
   defp enter_degraded_mode(state, budget) do
-    Logger.error("Entering degraded mode",
-      chain: state.chain,
-      key: inspect(state.key)
+    tried_providers =
+      state.failover_history
+      |> Enum.map(& &1.provider_id)
+      |> Enum.uniq()
+
+    last_error =
+      case state.failover_history do
+        [%{reason: reason} | _] -> reason
+        _ -> nil
+      end
+
+    Logger.error("Entering degraded mode — dropping events until retry",
+      chain_id: state.chain_id,
+      profile: state.profile,
+      key: inspect(state.key),
+      attempts: length(state.failover_history),
+      attempts_budget: budget.attempts,
+      tried_providers: inspect(tried_providers),
+      last_error: inspect(last_error),
+      retry_delay_ms: @degraded_mode_retry_delay_ms
     )
 
     # Schedule retry after cooldown
     Process.send_after(self(), :retry_from_degraded, @degraded_mode_retry_delay_ms)
 
-    telemetry_failover_degraded(state.chain, state.key, budget)
+    telemetry_failover_degraded(state.chain_id, state.key, budget)
 
     {:noreply,
      %{
@@ -762,24 +792,28 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
     case Selection.select_provider(
            state.profile,
-           state.chain,
+           state.chain_id,
            "eth_subscribe",
            strategy: :priority,
            protocol: :ws,
            include_half_open: include_half_open,
-           exclude: excluded
+           exclude: excluded,
+           requires_subscribe_new_heads: subscription_key(state.key) == {:newHeads}
          ) do
       {:ok, provider_id} -> {:ok, provider_id}
       _ -> {:error, :no_providers}
     end
   end
 
+  defp subscription_key({:route, _route, key}), do: key
+  defp subscription_key(key), do: key
+
   defp failover_budget(%{max_failover_attempts: override})
        when is_integer(override) and override > 0,
        do: %{attempts: override, provider_count: nil, source: :override}
 
   defp failover_budget(state) do
-    provider_count = ws_provider_count(state.profile, state.chain)
+    provider_count = ws_provider_count(state.profile, state.chain_id)
 
     if provider_count > 0 do
       attempts = min(provider_count * 2 + 1, @max_dynamic_failover_attempts)
@@ -793,9 +827,9 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
-  defp ws_provider_count(profile, chain) do
+  defp ws_provider_count(profile, chain_id) do
     profile
-    |> Catalog.get_profile_providers(chain)
+    |> Catalog.get_profile_providers(chain_id)
     |> Enum.count(fn %{instance_id: instance_id} -> ws_instance?(instance_id) end)
   end
 
@@ -806,11 +840,10 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
-  defp pick_best_http_provider(profile, chain, excluded) do
-    # Select best available HTTP provider for backfill (decoupled from WS selection)
+  defp pick_best_http_provider(profile, chain_id, excluded) do
     case Selection.select_provider(
            profile,
-           chain,
+           chain_id,
            "eth_getBlockByNumber",
            strategy: :fastest,
            protocol: :http,
@@ -821,12 +854,11 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
-  defp fetch_head(chain, _provider_id) do
-    # Use consensus height for fast failover (<1ms vs 200-500ms)
-    case ChainState.consensus_height(chain) do
+  defp fetch_head(chain_id, _provider_id) do
+    case ChainState.consensus_height(chain_id) do
       {:ok, height} ->
         Logger.debug("Using consensus height for failover gap calculation",
-          chain: chain,
+          chain_id: chain_id,
           height: height
         )
 
@@ -834,19 +866,17 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
       {:error, reason} ->
         Logger.warning("Consensus unavailable during failover, using blocking request",
-          chain: chain,
+          chain_id: chain_id,
           reason: reason
         )
 
-        # Fallback to blocking HTTP request if consensus unavailable
-        fetch_head_blocking(chain)
+        fetch_head_blocking(chain_id)
     end
   end
 
-  defp fetch_head_blocking(chain) do
-    # Original blocking implementation as fallback
+  defp fetch_head_blocking(chain_id) do
     case Lasso.RPC.RequestPipeline.execute_via_channels(
-           chain,
+           chain_id,
            "eth_blockNumber",
            [],
            %RequestOptions{
@@ -871,13 +901,13 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   # Telemetry helpers
 
   defp broadcast_subscription_event(state, event) do
-    topic = Subscription.topic(state.profile, state.chain)
+    topic = Lasso.Topics.subscription_event(state.profile, state.chain_id)
     Phoenix.PubSub.broadcast(Lasso.PubSub, topic, event)
   end
 
-  defp telemetry_failover_initiated(chain, key, old_id, new_id, recent_failures, budget) do
+  defp telemetry_failover_initiated(chain_id, key, old_id, new_id, recent_failures, budget) do
     :telemetry.execute([:lasso, :subs, :failover, :initiated], %{count: 1}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key),
       old_provider: inspect(old_id),
       new_provider: inspect(new_id),
@@ -888,12 +918,12 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     })
   end
 
-  defp telemetry_backfill_started(chain, from_n, to_n, provider_id) do
+  defp telemetry_backfill_started(chain_id, from_n, to_n, provider_id) do
     :telemetry.execute(
       [:lasso, :subs, :failover, :backfill_started],
       %{count: to_n - from_n + 1},
       %{
-        chain: chain,
+        chain_id: chain_id,
         provider_id: provider_id,
         from_block: from_n,
         to_block: to_n
@@ -901,36 +931,36 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     )
   end
 
-  defp telemetry_backfill_completed(chain, from_n, to_n, fetched_count) do
+  defp telemetry_backfill_completed(chain_id, from_n, to_n, fetched_count) do
     :telemetry.execute(
       [:lasso, :subs, :failover, :backfill_completed],
       %{count: fetched_count},
       %{
-        chain: chain,
+        chain_id: chain_id,
         from_block: from_n,
         to_block: to_n
       }
     )
   end
 
-  defp telemetry_resubscribe_initiated(chain, key, provider_id) do
+  defp telemetry_resubscribe_initiated(chain_id, key, provider_id) do
     :telemetry.execute([:lasso, :subs, :failover, :resubscribe_initiated], %{count: 1}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key),
       provider_id: provider_id
     })
   end
 
-  defp telemetry_failover_completed(chain, key, duration_ms) do
+  defp telemetry_failover_completed(chain_id, key, duration_ms) do
     :telemetry.execute([:lasso, :subs, :failover, :completed], %{duration_ms: duration_ms}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key)
     })
   end
 
-  defp telemetry_failover_degraded(chain, key, budget) do
+  defp telemetry_failover_degraded(chain_id, key, budget) do
     :telemetry.execute([:lasso, :subs, :failover, :degraded], %{count: 1}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key),
       failover_budget: budget.attempts,
       provider_count: budget.provider_count,

--- a/lib/lasso/core/streaming/stream_supervisor.ex
+++ b/lib/lasso/core/streaming/stream_supervisor.ex
@@ -7,14 +7,16 @@ defmodule Lasso.Core.Streaming.StreamSupervisor do
 
   alias Lasso.Core.Streaming.StreamCoordinator
 
-  @spec start_link({String.t(), String.t()}) :: Supervisor.on_start()
-  def start_link({profile, chain}) when is_binary(profile) and is_binary(chain) do
-    DynamicSupervisor.start_link(__MODULE__, {profile, chain}, name: via(profile, chain))
+  @spec start_link({String.t(), pos_integer()}) :: Supervisor.on_start()
+  def start_link({profile, chain_id})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    DynamicSupervisor.start_link(__MODULE__, {profile, chain_id}, name: via(profile, chain_id))
   end
 
-  @spec via(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
-  def via(profile, chain) when is_binary(profile) and is_binary(chain) do
-    {:via, Registry, {Lasso.Registry, {:stream_supervisor, profile, chain}}}
+  @spec via(String.t(), pos_integer()) :: {:via, Registry, {atom(), tuple()}}
+  def via(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    {:via, Registry, {Lasso.Registry, {:stream_supervisor, profile, chain_id}}}
   end
 
   @impl true
@@ -22,17 +24,17 @@ defmodule Lasso.Core.Streaming.StreamSupervisor do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
-  @spec ensure_coordinator(String.t(), String.t(), term(), keyword()) ::
+  @spec ensure_coordinator(String.t(), pos_integer(), term(), keyword()) ::
           {:ok, pid()} | {:error, term()}
-  def ensure_coordinator(profile, chain, key, opts)
-      when is_binary(profile) and is_binary(chain) do
-    name = StreamCoordinator.via(profile, chain, key)
+  def ensure_coordinator(profile, chain_id, key, opts)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    name = StreamCoordinator.via(profile, chain_id, key)
 
     case GenServer.whereis(name) do
       nil ->
-        spec = {StreamCoordinator, {profile, chain, key, opts}}
+        spec = {StreamCoordinator, {profile, chain_id, key, opts}}
 
-        case DynamicSupervisor.start_child(via(profile, chain), spec) do
+        case DynamicSupervisor.start_child(via(profile, chain_id), spec) do
           {:ok, pid} -> {:ok, pid}
           {:error, {:already_started, pid}} -> {:ok, pid}
           other -> other
@@ -43,16 +45,17 @@ defmodule Lasso.Core.Streaming.StreamSupervisor do
     end
   end
 
-  @spec stop_coordinator(String.t(), String.t(), term()) :: :ok | {:error, :not_found}
-  def stop_coordinator(profile, chain, key) when is_binary(profile) and is_binary(chain) do
-    name = StreamCoordinator.via(profile, chain, key)
+  @spec stop_coordinator(String.t(), pos_integer(), term()) :: :ok | {:error, :not_found}
+  def stop_coordinator(profile, chain_id, key)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    name = StreamCoordinator.via(profile, chain_id, key)
 
     case GenServer.whereis(name) do
       nil ->
         :ok
 
       pid ->
-        DynamicSupervisor.terminate_child(via(profile, chain), pid)
+        DynamicSupervisor.terminate_child(via(profile, chain_id), pid)
     end
   end
 end

--- a/lib/lasso/core/streaming/subscription_router.ex
+++ b/lib/lasso/core/streaming/subscription_router.ex
@@ -12,22 +12,24 @@ defmodule Lasso.Core.Streaming.SubscriptionRouter do
 
   @type key :: {:newHeads} | {:logs, map()}
 
-  @spec subscribe(String.t(), String.t(), {:newHeads}) :: {:ok, String.t()} | {:error, term()}
-  def subscribe(profile, chain, {:newHeads})
-      when is_binary(profile) and is_binary(chain) do
-    UpstreamSubscriptionPool.subscribe_client(profile, chain, self(), {:newHeads})
+  @spec subscribe(String.t(), pos_integer(), key(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def subscribe(profile, chain_id, key, opts \\ [])
+
+  def subscribe(profile, chain_id, {:newHeads}, opts)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:newHeads}, opts)
   end
 
-  @spec subscribe(String.t(), String.t(), {:logs, map()}) :: {:ok, String.t()} | {:error, term()}
-  def subscribe(profile, chain, {:logs, filter})
-      when is_binary(profile) and is_binary(chain) and is_map(filter) do
+  def subscribe(profile, chain_id, {:logs, filter}, opts)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_map(filter) do
     norm = FilterNormalizer.normalize(filter)
-    UpstreamSubscriptionPool.subscribe_client(profile, chain, self(), {:logs, norm})
+    UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:logs, norm}, opts)
   end
 
-  @spec unsubscribe(String.t(), String.t(), String.t()) :: :ok | {:error, term()}
-  def unsubscribe(profile, chain, subscription_id)
-      when is_binary(profile) and is_binary(chain) do
-    UpstreamSubscriptionPool.unsubscribe_client(profile, chain, subscription_id)
+  @spec unsubscribe(String.t(), pos_integer(), String.t()) :: :ok | {:error, term()}
+  def unsubscribe(profile, chain_id, subscription_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, subscription_id)
   end
 end

--- a/lib/lasso/core/streaming/upstream_subscription_pool.ex
+++ b/lib/lasso/core/streaming/upstream_subscription_pool.ex
@@ -18,6 +18,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
   alias Lasso.Config.ConfigStore
   alias Lasso.Events.{Provider, Subscription}
+  alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.Catalog
 
   alias Lasso.RPC.{
@@ -33,54 +34,60 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     StreamSupervisor
   }
 
-  @max_noproc_retries 5
+  @max_readiness_retries 50
+  @readiness_retry_ms 100
 
   @type profile :: String.t()
-  @type chain :: String.t()
+  @type chain_id :: pos_integer()
   @type provider_id :: String.t()
   @type key :: {:newHeads} | {:logs, map()}
 
-  @spec start_link({String.t(), String.t()}) :: GenServer.on_start()
-  def start_link({profile, chain}) when is_binary(profile) and is_binary(chain) do
-    GenServer.start_link(__MODULE__, {profile, chain}, name: via(profile, chain))
+  @spec start_link({String.t(), pos_integer()}) :: GenServer.on_start()
+  def start_link({profile, chain_id})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.start_link(__MODULE__, {profile, chain_id}, name: via(profile, chain_id))
   end
 
-  @spec via(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
-  def via(profile, chain) when is_binary(profile) and is_binary(chain) do
-    {:via, Registry, {Lasso.Registry, {:pool, profile, chain}}}
+  @spec via(String.t(), pos_integer()) :: {:via, Registry, {atom(), tuple()}}
+  def via(profile, chain_id) when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    {:via, Registry, {Lasso.Registry, {:pool, profile, chain_id}}}
   end
 
-  @spec subscribe_client(profile, chain, pid(), key) :: {:ok, String.t()} | {:error, term()}
-  def subscribe_client(profile, chain, client_pid, key)
-      when is_binary(profile) and is_binary(chain) do
-    GenServer.call(via(profile, chain), {:subscribe, client_pid, key})
+  @spec subscribe_client(profile, chain_id, pid(), key, keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  def subscribe_client(profile, chain_id, client_pid, key, opts \\ [])
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    provider_constraint = Keyword.get(opts, :provider_id)
+    pool_key = pool_key(key, provider_constraint)
+
+    GenServer.call(
+      via(profile, chain_id),
+      {:subscribe, client_pid, pool_key, key, provider_constraint}
+    )
   end
 
-  @spec unsubscribe_client(profile, chain, String.t()) :: :ok | {:error, term()}
-  def unsubscribe_client(profile, chain, subscription_id)
-      when is_binary(profile) and is_binary(chain) do
-    GenServer.call(via(profile, chain), {:unsubscribe, subscription_id})
+  @spec unsubscribe_client(profile, chain_id, String.t()) :: :ok | {:error, term()}
+  def unsubscribe_client(profile, chain_id, subscription_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(via(profile, chain_id), {:unsubscribe, subscription_id})
   end
 
   # GenServer callbacks
 
   @impl true
-  def init({profile, chain}) do
-    Phoenix.PubSub.subscribe(Lasso.PubSub, Provider.topic(profile, chain))
-
-    # Chain-scoped restart topic (Pool doesn't know instance_ids at init)
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "instance_sub_manager:restarted:#{chain}")
+  def init({profile, chain_id}) do
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.provider_event(profile, chain_id))
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.instance_sub_manager_restarted(chain_id))
 
     dedupe_cfg =
-      case ConfigStore.get_chain(profile, chain) do
+      case ConfigStore.get_chain(profile, chain_id) do
         {:ok, cfg} -> Map.get(cfg, :dedupe, %{})
         _ -> %{}
       end
 
     state = %{
       profile: profile,
-      chain: chain,
-      # key => %{refcount, primary_provider_id, instance_id, status, markers, dedupe, noproc_retries}
+      chain_id: chain_id,
       keys: %{},
       dedupe_max_items: Map.get(dedupe_cfg, :max_items, 256),
       dedupe_max_age_ms: Map.get(dedupe_cfg, :max_age_ms, 30_000),
@@ -92,63 +99,90 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   end
 
   @impl true
-  def handle_call({:subscribe, client_pid, key}, _from, state) do
-    subscription_id = generate_id()
+  def handle_call(
+        {:subscribe, client_pid, pool_key, subscription_key, provider_constraint},
+        _from,
+        state
+      ) do
+    case validate_provider_constraint(state, subscription_key, provider_constraint) do
+      :ok ->
+        subscription_id = generate_id()
 
-    :ok =
-      ClientSubscriptionRegistry.add_client(
-        state.profile,
-        state.chain,
-        subscription_id,
-        client_pid,
-        key
-      )
+        :ok =
+          ClientSubscriptionRegistry.add_client(
+            state.profile,
+            state.chain_id,
+            subscription_id,
+            client_pid,
+            pool_key
+          )
 
-    _ = start_coordinator_for_key(state, key)
+        send(self(), {:ensure_coordinator, pool_key})
 
-    new_state =
-      case Map.get(state.keys, key) do
-        nil ->
-          GenServer.cast(self(), {:establish_upstream, key, []})
+        new_state =
+          case Map.get(state.keys, pool_key) do
+            nil ->
+              generation = make_ref()
+              GenServer.cast(self(), {:establish_upstream, pool_key, generation, []})
 
-          entry = %{
-            refcount: 1,
-            status: :establishing,
-            primary_provider_id: nil,
-            instance_id: nil,
-            markers: %{},
-            dedupe: nil,
-            noproc_retries: 0
-          }
+              entry = %{
+                refcount: 1,
+                status: :establishing,
+                primary_provider_id: nil,
+                instance_id: nil,
+                subscription_key: subscription_key,
+                provider_constraint: provider_constraint,
+                establishment_generation: generation,
+                readiness_retries: 0,
+                transient_excluded_providers: MapSet.new(),
+                markers: %{},
+                dedupe: nil,
+                noproc_retries: 0
+              }
 
-          telemetry_subscription_status(:establishing, state.chain, key, 1)
-          %{state | keys: Map.put(state.keys, key, entry)}
+              telemetry_subscription_status(:establishing, state.chain_id, pool_key, 1)
+              %{state | keys: Map.put(state.keys, pool_key, entry)}
 
-        entry when entry.status in [:establishing, :active] ->
-          updated = %{entry | refcount: entry.refcount + 1}
-          telemetry_subscription_status(entry.status, state.chain, key, updated.refcount)
-          %{state | keys: Map.put(state.keys, key, updated)}
+            entry when entry.status in [:establishing, :active] ->
+              updated = %{entry | refcount: entry.refcount + 1}
 
-        entry when entry.status == :failed ->
-          GenServer.cast(self(), {:establish_upstream, key, []})
+              telemetry_subscription_status(
+                entry.status,
+                state.chain_id,
+                pool_key,
+                updated.refcount
+              )
 
-          updated = %{
-            entry
-            | refcount: entry.refcount + 1,
-              status: :establishing,
-              noproc_retries: 0
-          }
+              %{state | keys: Map.put(state.keys, pool_key, updated)}
 
-          telemetry_subscription_status(:retry, state.chain, key, updated.refcount)
-          %{state | keys: Map.put(state.keys, key, updated)}
-      end
+            entry when entry.status == :failed ->
+              generation = make_ref()
+              GenServer.cast(self(), {:establish_upstream, pool_key, generation, []})
 
-    {:reply, {:ok, subscription_id}, new_state}
+              updated = %{
+                entry
+                | refcount: entry.refcount + 1,
+                  status: :establishing,
+                  establishment_generation: generation,
+                  readiness_retries: 0,
+                  transient_excluded_providers: MapSet.new(),
+                  noproc_retries: 0
+              }
+
+              telemetry_subscription_status(:retry, state.chain_id, pool_key, updated.refcount)
+              %{state | keys: Map.put(state.keys, pool_key, updated)}
+          end
+
+        {:reply, {:ok, subscription_id}, new_state}
+
+      {:error, error} ->
+        {:reply, {:error, error}, state}
+    end
   end
 
   @impl true
   def handle_call({:unsubscribe, subscription_id}, _from, state) do
-    case ClientSubscriptionRegistry.remove_client(state.profile, state.chain, subscription_id) do
+    case ClientSubscriptionRegistry.remove_client(state.profile, state.chain_id, subscription_id) do
       {:ok, nil} ->
         {:reply, :ok, state}
 
@@ -158,47 +192,116 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  @impl true
-  def handle_cast({:resubscribe, key, new_provider_id, coordinator_pid}, state) do
-    Logger.info("Resubscribing key #{inspect(key)} to provider #{new_provider_id}")
+  defp validate_provider_constraint(_state, _subscription_key, nil), do: :ok
 
-    entry = Map.get(state.keys, key)
+  defp validate_provider_constraint(state, subscription_key, provider_id) do
+    case ConfigStore.get_provider(state.profile, state.chain_id, provider_id) do
+      {:ok, provider} ->
+        validate_constrained_provider(state, subscription_key, provider)
+
+      {:error, _reason} ->
+        {:error,
+         invalid_provider_error(state, provider_id, "Provider '#{provider_id}' not found")}
+    end
+  end
+
+  defp validate_constrained_provider(state, subscription_key, provider) do
+    cond do
+      not is_binary(provider.ws_url) ->
+        {:error,
+         invalid_provider_error(
+           state,
+           provider.id,
+           "Provider '#{provider.id}' does not support WebSocket subscriptions"
+         )}
+
+      subscription_key == {:newHeads} and not new_heads_capable?(state, provider.id) ->
+        {:error,
+         invalid_provider_error(
+           state,
+           provider.id,
+           "Provider '#{provider.id}' does not support newHeads subscriptions"
+         )}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp new_heads_capable?(state, provider_id) do
+    state.profile
+    |> Catalog.get_profile_providers(state.chain_id)
+    |> Enum.any?(&(&1.provider_id == provider_id and &1.subscribe_new_heads == true))
+  end
+
+  defp invalid_provider_error(state, provider_id, message) do
+    JError.new(-32_602, message,
+      category: :invalid_params,
+      retriable?: false,
+      data: %{provider_id: provider_id, chain_id: state.chain_id, profile: state.profile}
+    )
+  end
+
+  @impl true
+  def handle_cast({:resubscribe, pool_key, new_provider_id, coordinator_pid}, state) do
+    Logger.info("Resubscribing key #{inspect(pool_key)} to provider #{new_provider_id}")
+
+    entry = Map.get(state.keys, pool_key)
 
     if entry do
       old_provider_id = entry.primary_provider_id
       old_instance_id = entry.instance_id
 
       new_instance_id =
-        Catalog.lookup_instance_id(state.profile, state.chain, new_provider_id)
+        Catalog.lookup_instance_id(state.profile, state.chain_id, new_provider_id)
 
       if is_nil(new_instance_id) do
         Logger.error("Cannot resolve instance_id for provider #{new_provider_id}")
         send(coordinator_pid, {:subscription_failed, :no_instance})
         {:noreply, state}
       else
-        # Register in InstanceSubscriptionRegistry for events from new instance
-        InstanceSubscriptionRegistry.register_consumer(new_instance_id, key)
+        subscription_key = entry.subscription_key
+        InstanceSubscriptionRegistry.register_consumer(new_instance_id, subscription_key)
 
-        case InstanceSubscriptionManager.ensure_subscription(new_instance_id, key) do
+        case InstanceSubscriptionManager.ensure_subscription(new_instance_id, subscription_key) do
           {:ok, _status} ->
+            release_overwritten_transition(
+              state,
+              pool_key,
+              entry,
+              subscription_key,
+              new_instance_id
+            )
+
+            transition_fields =
+              if old_instance_id && old_instance_id != new_instance_id do
+                %{
+                  transitioning_from: old_provider_id,
+                  transitioning_from_instance_id: old_instance_id
+                }
+              else
+                %{}
+              end
+
             updated_entry =
-              Map.merge(entry, %{
+              entry
+              |> Map.drop([:transitioning_from, :transitioning_from_instance_id])
+              |> Map.merge(%{
                 primary_provider_id: new_provider_id,
                 instance_id: new_instance_id,
-                status: :active,
-                transitioning_from: old_provider_id,
-                transitioning_from_instance_id: old_instance_id
+                status: :active
               })
+              |> Map.merge(transition_fields)
 
-            new_state = %{state | keys: Map.put(state.keys, key, updated_entry)}
+            new_state = %{state | keys: Map.put(state.keys, pool_key, updated_entry)}
 
             send(coordinator_pid, {:subscription_confirmed, new_provider_id, nil})
-            telemetry_resubscribe_success(state.chain, key, new_provider_id)
+            telemetry_resubscribe_success(state.chain_id, pool_key, new_provider_id)
 
-            if old_instance_id do
+            if old_instance_id && old_instance_id != new_instance_id do
               Process.send_after(
                 self(),
-                {:deferred_release, key, old_provider_id, old_instance_id},
+                {:deferred_release, pool_key, old_provider_id, old_instance_id},
                 5_000
               )
             end
@@ -206,48 +309,72 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
             {:noreply, new_state}
 
           {:error, reason} ->
-            InstanceSubscriptionRegistry.unregister_consumer(new_instance_id, key)
+            unless instance_in_use_elsewhere?(
+                     state,
+                     pool_key,
+                     new_instance_id,
+                     subscription_key
+                   ) do
+              InstanceSubscriptionRegistry.unregister_consumer(new_instance_id, subscription_key)
+            end
 
             Logger.error(
-              "Resubscription failed for #{inspect(key)} to #{new_provider_id}: #{inspect(reason)}"
+              "Resubscription failed for #{inspect(pool_key)} to #{new_provider_id}: #{inspect(reason)}"
             )
 
             send(coordinator_pid, {:subscription_failed, reason})
-            telemetry_resubscribe_failed(state.chain, key, new_provider_id, reason)
+            telemetry_resubscribe_failed(state.chain_id, pool_key, new_provider_id, reason)
             {:noreply, state}
         end
       end
     else
-      Logger.debug("Resubscription skipped: key #{inspect(key)} no longer active")
+      Logger.debug("Resubscription skipped: key #{inspect(pool_key)} no longer active")
       send(coordinator_pid, {:subscription_failed, :key_inactive})
       {:noreply, state}
     end
   end
 
   @impl true
-  def handle_cast({:establish_upstream, key, excluded_providers}, state) do
-    with {:ok, entry} <- validate_entry_for_establishment(state.keys[key]),
-         {:ok, provider_id} <-
-           select_available_provider(state.profile, state.chain, excluded_providers),
-         {:ok, instance_id} <- resolve_instance_id(state, provider_id),
-         {:ok, _status} <- attempt_upstream_subscribe(provider_id, instance_id, key) do
-      InstanceSubscriptionRegistry.register_consumer(instance_id, key)
+  def handle_cast({:clients_removed, removed_by_key}, state) when is_map(removed_by_key) do
+    new_state =
+      Enum.reduce(removed_by_key, state, fn {key, count}, acc ->
+        maybe_drop_upstream_refs(acc, key, count)
+      end)
 
-      new_state = activate_subscription(state, key, entry, provider_id, instance_id)
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_cast({:establish_upstream, pool_key, generation, excluded_providers}, state) do
+    with {:ok, entry} <- validate_entry_for_establishment(state.keys[pool_key], generation),
+         {:ok, provider_id} <-
+           select_available_provider(
+             state.profile,
+             state.chain_id,
+             entry.subscription_key,
+             excluded_providers,
+             entry.provider_constraint
+           ),
+         {:ok, instance_id} <- resolve_instance_id(state, provider_id),
+         {:ok, _status} <-
+           attempt_upstream_subscribe(provider_id, instance_id, entry.subscription_key) do
+      InstanceSubscriptionRegistry.register_consumer(instance_id, entry.subscription_key)
+
+      new_state = activate_subscription(state, pool_key, entry, provider_id, instance_id)
 
       Logger.info(
-        "Upstream subscription established for key #{inspect(key)} on provider #{provider_id}"
+        "Upstream subscription established for key #{inspect(pool_key)} on provider #{provider_id}"
       )
 
       broadcast_subscription_event(state, %Subscription.Established{
         ts: System.system_time(:millisecond),
-        chain: state.chain,
+        chain_id: state.chain_id,
         provider_id: provider_id,
-        subscription_type: Subscription.subscription_type(key)
+        subscription_type: Subscription.subscription_type(entry.subscription_key)
       })
 
-      telemetry_upstream(:subscribe, state.chain, provider_id, key)
-      telemetry_subscription_status(:active, state.chain, key, entry.refcount)
+      telemetry_upstream(:subscribe, state.chain_id, provider_id, pool_key)
+      telemetry_subscription_status(:active, state.chain_id, pool_key, entry.refcount)
 
       {:noreply, new_state}
     else
@@ -255,62 +382,79 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
         {:noreply, state}
 
       {:error, :no_providers} ->
-        new_state = mark_subscription_failed(state, key, "No available providers")
-        {:noreply, new_state}
+        {new_state, retry_exclusions} =
+          recycle_transient_exclusions(state, pool_key, excluded_providers)
+
+        retry_readiness(new_state, pool_key, generation, retry_exclusions)
 
       {:error, :no_instance} ->
-        new_state = mark_subscription_failed(state, key, "Cannot resolve instance")
-        {:noreply, new_state}
+        retry_readiness(state, pool_key, generation, excluded_providers)
 
       {:error, {:noproc, _instance_id}} ->
-        entry = state.keys[key]
-        retries = if entry, do: entry.noproc_retries, else: 0
+        retry_readiness(state, pool_key, generation, excluded_providers)
 
-        if retries < @max_noproc_retries do
-          Process.send_after(self(), {:retry_establish, key}, 1_000)
-          new_state = update_entry_field(state, key, entry, :noproc_retries, retries + 1)
-          {:noreply, new_state}
-        else
-          new_state = update_entry_field(state, key, entry, :noproc_retries, 0)
-          do_handle_subscription_failure(new_state, key, excluded_providers)
-        end
+      {:error, {:subscribe_failed, provider_id, reason}}
+      when reason in [:connection_unknown, :not_connected, :timeout] ->
+        retry_transient_failure(state, pool_key, generation, excluded_providers, provider_id)
+
+      {:error, {:subscribe_failed, provider_id, %JError{retriable?: true}}} ->
+        retry_transient_failure(state, pool_key, generation, excluded_providers, provider_id)
 
       {:error, {:subscribe_failed, provider_id, _reason}} ->
-        new_excluded = [provider_id | excluded_providers]
-        do_handle_subscription_failure(state, key, new_excluded)
+        entry = state.keys[pool_key]
+
+        if entry.provider_constraint do
+          new_state = mark_subscription_failed(state, pool_key, "Constrained provider rejected")
+          {:noreply, new_state}
+        else
+          new_excluded = [provider_id | excluded_providers]
+          do_handle_subscription_failure(state, pool_key, generation, new_excluded)
+        end
     end
   end
 
-  defp validate_entry_for_establishment(nil), do: {:error, :entry_invalid}
+  defp validate_entry_for_establishment(nil, _generation), do: {:error, :entry_invalid}
 
-  defp validate_entry_for_establishment(entry) when entry.status != :establishing,
+  defp validate_entry_for_establishment(entry, generation)
+       when entry.status != :establishing or entry.establishment_generation != generation,
+       do: {:error, :entry_invalid}
+
+  defp validate_entry_for_establishment(entry, _generation) when entry.refcount < 1,
     do: {:error, :entry_invalid}
 
-  defp validate_entry_for_establishment(entry) when entry.refcount < 1,
-    do: {:error, :entry_invalid}
+  defp validate_entry_for_establishment(entry, _generation), do: {:ok, entry}
 
-  defp validate_entry_for_establishment(entry), do: {:ok, entry}
-
-  defp select_available_provider(profile, chain, excluded_providers) do
+  defp select_available_provider(
+         profile,
+         chain_id,
+         subscription_key,
+         excluded_providers,
+         provider_constraint
+       ) do
     channels =
-      Selection.select_channels(profile, chain, "eth_subscribe",
+      Selection.select_channels(profile, chain_id, "eth_subscribe",
         strategy: :priority,
         transport: :ws,
-        limit: 1
+        exclude: excluded_providers,
+        limit: if(provider_constraint, do: 1_000, else: 1),
+        requires_subscribe_new_heads: subscription_key == {:newHeads}
       )
 
-    case Enum.find(channels, fn ch -> ch.provider_id not in excluded_providers end) do
-      %Channel{provider_id: provider_id} ->
-        {:ok, provider_id}
+    channel =
+      if provider_constraint do
+        Enum.find(channels, &(&1.provider_id == provider_constraint))
+      else
+        List.first(channels)
+      end
 
-      nil ->
-        Logger.error("No available WS channels (excluded: #{inspect(excluded_providers)})")
-        {:error, :no_providers}
+    case channel do
+      %Channel{provider_id: provider_id} -> {:ok, provider_id}
+      nil -> {:error, :no_providers}
     end
   end
 
   defp resolve_instance_id(state, provider_id) do
-    case Catalog.lookup_instance_id(state.profile, state.chain, provider_id) do
+    case Catalog.lookup_instance_id(state.profile, state.chain_id, provider_id) do
       nil ->
         Logger.error("Cannot resolve instance_id for provider #{provider_id}")
         {:error, :no_instance}
@@ -338,41 +482,120 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  defp update_entry_field(state, _key, nil, _field, _value), do: state
-
-  defp update_entry_field(state, key, entry, field, value) do
-    updated = Map.put(entry, field, value)
-    %{state | keys: Map.put(state.keys, key, updated)}
-  end
-
-  defp activate_subscription(state, key, entry, provider_id, instance_id) do
+  defp activate_subscription(state, pool_key, entry, provider_id, instance_id) do
     updated_entry = %{
       entry
       | status: :active,
         primary_provider_id: provider_id,
         instance_id: instance_id,
+        readiness_retries: 0,
+        transient_excluded_providers: MapSet.new(),
         noproc_retries: 0
     }
 
-    %{state | keys: Map.put(state.keys, key, updated_entry)}
+    %{state | keys: Map.put(state.keys, pool_key, updated_entry)}
   end
 
-  defp do_handle_subscription_failure(state, key, excluded_providers) do
+  defp retry_transient_failure(
+         state,
+         pool_key,
+         generation,
+         excluded_providers,
+         provider_id
+       ) do
+    case Map.get(state.keys, pool_key) do
+      %{provider_constraint: constraint} when is_binary(constraint) ->
+        retry_readiness(state, pool_key, generation, excluded_providers)
+
+      %{status: :establishing, establishment_generation: ^generation} = entry ->
+        new_excluded = Enum.uniq([provider_id | excluded_providers])
+
+        transient_excluded_providers =
+          entry
+          |> Map.get(:transient_excluded_providers, MapSet.new())
+          |> MapSet.put(provider_id)
+
+        updated_entry = %{
+          entry
+          | transient_excluded_providers: transient_excluded_providers
+        }
+
+        GenServer.cast(self(), {:establish_upstream, pool_key, generation, new_excluded})
+        {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated_entry)}}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  defp recycle_transient_exclusions(state, pool_key, excluded_providers) do
+    case Map.get(state.keys, pool_key) do
+      %{provider_constraint: nil} = entry ->
+        transient_excluded_providers =
+          Map.get(entry, :transient_excluded_providers, MapSet.new())
+
+        retry_exclusions =
+          Enum.reject(
+            excluded_providers,
+            &MapSet.member?(transient_excluded_providers, &1)
+          )
+
+        updated_entry = %{entry | transient_excluded_providers: MapSet.new()}
+        {%{state | keys: Map.put(state.keys, pool_key, updated_entry)}, retry_exclusions}
+
+      _ ->
+        {state, excluded_providers}
+    end
+  end
+
+  defp retry_readiness(state, pool_key, generation, excluded_providers) do
+    case Map.get(state.keys, pool_key) do
+      %{
+        status: :establishing,
+        establishment_generation: ^generation,
+        readiness_retries: retries
+      } = entry
+      when retries < @max_readiness_retries ->
+        Process.send_after(
+          self(),
+          {:retry_establish, pool_key, generation, excluded_providers},
+          @readiness_retry_ms
+        )
+
+        updated = %{entry | readiness_retries: retries + 1}
+        {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated)}}
+
+      %{status: :establishing, establishment_generation: ^generation} = entry ->
+        if entry.provider_constraint do
+          Process.send_after(
+            self(),
+            {:retry_establish, pool_key, generation, excluded_providers},
+            1_000
+          )
+
+          updated = %{entry | readiness_retries: 0}
+          {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated)}}
+        else
+          {:noreply, mark_subscription_failed(state, pool_key, "No ready providers")}
+        end
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  defp do_handle_subscription_failure(state, pool_key, generation, excluded_providers) do
     max_attempts = 3
 
     if length(excluded_providers) < max_attempts do
       Logger.info(
-        "Retrying upstream establishment for #{inspect(key)} (attempt #{length(excluded_providers) + 1}/#{max_attempts})"
+        "Retrying upstream establishment for #{inspect(pool_key)} (attempt #{length(excluded_providers) + 1}/#{max_attempts})"
       )
 
-      GenServer.cast(self(), {:establish_upstream, key, excluded_providers})
+      GenServer.cast(self(), {:establish_upstream, pool_key, generation, excluded_providers})
       {:noreply, state}
     else
-      Logger.error(
-        "Failed to establish upstream for #{inspect(key)} after #{max_attempts} attempts"
-      )
-
-      new_state = mark_subscription_failed(state, key, "Max retries exceeded")
+      new_state = mark_subscription_failed(state, pool_key, "Max retries exceeded")
       {:noreply, new_state}
     end
   end
@@ -383,17 +606,17 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
         state
 
       entry ->
-        updated_entry = %{entry | status: :failed}
+        updated_entry = %{entry | status: :failed, establishment_generation: make_ref()}
 
         broadcast_subscription_event(state, %Subscription.Failed{
           ts: System.system_time(:millisecond),
-          chain: state.chain,
-          provider_id: entry.primary_provider_id,
-          subscription_type: Subscription.subscription_type(key),
+          chain_id: state.chain_id,
+          provider_id: entry.provider_constraint || entry.primary_provider_id,
+          subscription_type: Subscription.subscription_type(entry.subscription_key),
           reason: reason
         })
 
-        telemetry_subscription_status(:failed, state.chain, key, entry.refcount)
+        telemetry_subscription_status(:failed, state.chain_id, key, entry.refcount)
         Logger.error("Subscription failed for #{inspect(key)}: #{reason}")
         %{state | keys: Map.put(state.keys, key, updated_entry)}
     end
@@ -402,58 +625,75 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   @impl true
   # Events from InstanceSubscriptionManager via InstanceSubscriptionRegistry
   def handle_info(
-        {:instance_subscription_event, instance_id, key, payload, received_at},
+        {:instance_subscription_event, instance_id, subscription_key, payload, received_at},
         state
       )
       when is_map(payload) do
-    case Map.get(state.keys, key) do
-      %{instance_id: ^instance_id, status: :active} = entry ->
-        StreamCoordinator.upstream_event(
-          state.profile,
-          state.chain,
-          key,
-          entry.primary_provider_id,
-          nil,
-          payload,
-          received_at
-        )
+    Enum.each(state.keys, fn {pool_key, entry} ->
+      cond do
+        entry.subscription_key != subscription_key or entry.status != :active ->
+          :ok
 
-        {:noreply, state}
+        entry.instance_id == instance_id ->
+          StreamCoordinator.upstream_event(
+            state.profile,
+            state.chain_id,
+            pool_key,
+            entry.primary_provider_id,
+            nil,
+            payload,
+            received_at
+          )
 
-      %{transitioning_from_instance_id: ^instance_id, status: :active} = entry ->
-        StreamCoordinator.upstream_event(
-          state.profile,
-          state.chain,
-          key,
-          entry.transitioning_from,
-          nil,
-          payload,
-          received_at
-        )
+        Map.get(entry, :transitioning_from_instance_id) == instance_id ->
+          StreamCoordinator.upstream_event(
+            state.profile,
+            state.chain_id,
+            pool_key,
+            entry.transitioning_from,
+            nil,
+            payload,
+            received_at
+          )
 
-        {:noreply, state}
+        true ->
+          :ok
+      end
+    end)
 
-      _ ->
-        {:noreply, state}
-    end
+    {:noreply, state}
   end
 
   # Deferred release of old instance subscription after transition
-  def handle_info({:deferred_release, key, old_provider_id, old_instance_id}, state) do
-    case Map.get(state.keys, key) do
+  def handle_info({:deferred_release, pool_key, old_provider_id, old_instance_id}, state) do
+    case Map.get(state.keys, pool_key) do
       %{transitioning_from: ^old_provider_id} = entry ->
-        InstanceSubscriptionManager.release_subscription(old_instance_id, key)
-        InstanceSubscriptionRegistry.unregister_consumer(old_instance_id, key)
+        unless instance_in_use_elsewhere?(
+                 state,
+                 pool_key,
+                 old_instance_id,
+                 entry.subscription_key
+               ) do
+          InstanceSubscriptionRegistry.unregister_consumer(
+            old_instance_id,
+            entry.subscription_key
+          )
+
+          InstanceSubscriptionManager.release_subscription(
+            old_instance_id,
+            entry.subscription_key
+          )
+        end
 
         updated_entry =
           entry
           |> Map.delete(:transitioning_from)
           |> Map.delete(:transitioning_from_instance_id)
 
-        new_state = %{state | keys: Map.put(state.keys, key, updated_entry)}
+        new_state = %{state | keys: Map.put(state.keys, pool_key, updated_entry)}
 
         Logger.debug(
-          "Deferred release of old provider #{old_provider_id} for key #{inspect(key)}"
+          "Deferred release of old provider #{old_provider_id} for key #{inspect(pool_key)}"
         )
 
         {:noreply, new_state}
@@ -463,11 +703,10 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  # Retry establishment after noproc
-  def handle_info({:retry_establish, key}, state) do
-    case Map.get(state.keys, key) do
-      %{status: :establishing} ->
-        GenServer.cast(self(), {:establish_upstream, key, []})
+  def handle_info({:retry_establish, pool_key, generation, excluded_providers}, state) do
+    case Map.get(state.keys, pool_key) do
+      %{status: :establishing, establishment_generation: ^generation} ->
+        GenServer.cast(self(), {:establish_upstream, pool_key, generation, excluded_providers})
         {:noreply, state}
 
       _ ->
@@ -482,39 +721,35 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
              is_struct(evt, Provider.WSDisconnected) do
     provider_id = Map.get(evt, :provider_id)
 
-    for {key, entry} <- state.keys,
-        entry.primary_provider_id == provider_id do
-      StreamCoordinator.provider_unhealthy(
-        state.profile,
-        state.chain,
-        key,
-        provider_id,
-        pick_next_provider(state, provider_id)
-      )
-    end
+    new_state =
+      state.keys
+      |> Enum.filter(fn {_key, entry} -> entry.primary_provider_id == provider_id end)
+      |> Enum.reduce(state, fn {key, _entry}, acc ->
+        dispatch_failover(acc, key, provider_id, pick_next_provider(acc, key, provider_id))
+      end)
 
-    {:noreply, state}
+    {:noreply, new_state}
   end
 
   # Invalidation from InstanceSubscriptionManager
   def handle_info(
-        {:instance_subscription_invalidated, instance_id, key, reason},
+        {:instance_subscription_invalidated, instance_id, subscription_key, reason},
         state
       ) do
     new_state =
-      case Map.get(state.keys, key) do
-        %{instance_id: ^instance_id} = entry ->
+      Enum.reduce(state.keys, state, fn {pool_key, entry}, acc ->
+        if entry.subscription_key == subscription_key and entry.instance_id == instance_id do
           handle_subscription_invalidation(
-            state,
+            acc,
             entry.primary_provider_id,
             instance_id,
-            key,
+            pool_key,
             reason
           )
-
-        _ ->
-          state
-      end
+        else
+          acc
+        end
+      end)
 
     {:noreply, new_state}
   end
@@ -530,7 +765,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     if affected_keys != [] do
       Logger.info(
         "InstanceSubscriptionManager restarted, scheduling re-establishment for #{length(affected_keys)} subscriptions",
-        chain: state.chain,
+        chain_id: state.chain_id,
         instance_id: instance_id
       )
 
@@ -544,107 +779,135 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
   # Async re-establishment after Manager restart (one per key, non-blocking)
   def handle_info({:reestablish_after_restart, key, instance_id}, state) do
-    case Map.get(state.keys, key) do
-      %{instance_id: ^instance_id, status: :active} = entry ->
-        InstanceSubscriptionRegistry.register_consumer(instance_id, key)
+    new_state =
+      case Map.get(state.keys, key) do
+        %{instance_id: ^instance_id, status: :active} = entry ->
+          InstanceSubscriptionRegistry.register_consumer(instance_id, entry.subscription_key)
 
-        case InstanceSubscriptionManager.ensure_subscription(instance_id, key) do
-          {:ok, _status} ->
-            Logger.debug("Re-established subscription after Manager restart",
-              chain: state.chain,
-              key: inspect(key),
-              instance_id: instance_id
-            )
+          case InstanceSubscriptionManager.ensure_subscription(
+                 instance_id,
+                 entry.subscription_key
+               ) do
+            {:ok, _status} ->
+              Logger.debug("Re-established subscription after Manager restart",
+                chain_id: state.chain_id,
+                key: inspect(key),
+                instance_id: instance_id
+              )
 
-          {:error, reason} ->
-            Logger.warning("Failed to re-establish subscription after Manager restart",
-              chain: state.chain,
-              key: inspect(key),
-              instance_id: instance_id,
-              reason: inspect(reason)
-            )
+              state
 
-            StreamCoordinator.provider_unhealthy(
-              state.profile,
-              state.chain,
-              key,
-              entry.primary_provider_id,
-              pick_next_provider(state, entry.primary_provider_id)
-            )
-        end
+            {:error, reason} ->
+              Logger.warning("Failed to re-establish subscription after Manager restart",
+                chain_id: state.chain_id,
+                key: inspect(key),
+                instance_id: instance_id,
+                reason: inspect(reason)
+              )
 
-      _ ->
-        :ok
-    end
+              if entry.provider_constraint and transient_subscription_error?(reason) do
+                retry_constrained_subscription(state, key)
+              else
+                dispatch_failover(
+                  state,
+                  key,
+                  entry.primary_provider_id,
+                  pick_next_provider(state, key, entry.primary_provider_id)
+                )
+              end
+          end
 
+        _ ->
+          state
+      end
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({:ensure_coordinator, key}, state) do
+    _ = start_coordinator_for_key(state, key)
     {:noreply, state}
   end
 
   def handle_info(_, state), do: {:noreply, state}
 
   # Staleness: resubscribe to same instance
-  defp handle_subscription_invalidation(state, provider_id, instance_id, key, :subscription_stale) do
+  defp handle_subscription_invalidation(
+         state,
+         provider_id,
+         instance_id,
+         pool_key,
+         :subscription_stale
+       ) do
+    entry = state.keys[pool_key]
+
     Logger.info("Subscription stale, resubscribing to same instance",
-      chain: state.chain,
+      chain_id: state.chain_id,
       provider_id: provider_id,
       instance_id: instance_id,
-      key: inspect(key)
+      key: inspect(pool_key)
     )
 
-    case InstanceSubscriptionManager.ensure_subscription(instance_id, key) do
+    case InstanceSubscriptionManager.ensure_subscription(instance_id, entry.subscription_key) do
       {:ok, _status} ->
         Logger.debug("Resubscribed after staleness",
-          chain: state.chain,
+          chain_id: state.chain_id,
           instance_id: instance_id,
-          key: inspect(key)
+          key: inspect(pool_key)
         )
 
         state
 
       {:error, reason} ->
         Logger.warning("Resubscription failed after staleness, failing over",
-          chain: state.chain,
+          chain_id: state.chain_id,
           provider_id: provider_id,
-          key: inspect(key),
+          key: inspect(pool_key),
           reason: inspect(reason)
         )
 
-        StreamCoordinator.provider_unhealthy(
-          state.profile,
-          state.chain,
-          key,
+        dispatch_failover(
+          state,
+          pool_key,
           provider_id,
-          pick_next_provider(state, provider_id)
+          pick_next_provider(state, pool_key, provider_id)
         )
-
-        state
     end
   end
 
-  defp handle_subscription_invalidation(state, provider_id, _instance_id, key, reason) do
+  defp handle_subscription_invalidation(state, provider_id, _instance_id, pool_key, reason) do
     Logger.info("Subscription invalidated, failing over",
-      chain: state.chain,
+      chain_id: state.chain_id,
       provider_id: provider_id,
-      key: inspect(key),
+      key: inspect(pool_key),
       reason: reason
     )
 
-    StreamCoordinator.provider_unhealthy(
-      state.profile,
-      state.chain,
-      key,
+    dispatch_failover(
+      state,
+      pool_key,
       provider_id,
-      pick_next_provider(state, provider_id)
+      pick_next_provider(state, pool_key, provider_id)
     )
-
-    state
   end
 
   # Internal helpers
 
-  defp start_coordinator_for_key(state, key) do
+  defp release_overwritten_transition(state, pool_key, entry, key, new_instance_id) do
+    previous_instance_id = Map.get(entry, :transitioning_from_instance_id)
+
+    if previous_instance_id && previous_instance_id != new_instance_id &&
+         not instance_in_use_elsewhere?(state, pool_key, previous_instance_id, key) do
+      InstanceSubscriptionRegistry.unregister_consumer(previous_instance_id, key)
+      InstanceSubscriptionManager.release_subscription(previous_instance_id, key)
+    end
+
+    :ok
+  end
+
+  defp start_coordinator_for_key(state, pool_key) do
     opts = [
-      primary_provider_id: Map.get(state.keys[key] || %{}, :primary_provider_id),
+      primary_provider_id: Map.get(state.keys[pool_key] || %{}, :primary_provider_id),
       dedupe_max_items: state.dedupe_max_items,
       dedupe_max_age_ms: state.dedupe_max_age_ms,
       max_backfill_blocks: state.max_backfill_blocks,
@@ -652,88 +915,199 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
       continuity_policy: :best_effort
     ]
 
-    StreamSupervisor.ensure_coordinator(state.profile, state.chain, key, opts)
+    StreamSupervisor.ensure_coordinator(state.profile, state.chain_id, pool_key, opts)
   end
 
-  defp pick_next_provider(state, failed_provider_id) do
-    case Selection.select_provider(
-           state.profile,
-           state.chain,
-           "eth_subscribe",
-           strategy: :priority,
-           protocol: :ws,
-           exclude: [failed_provider_id]
-         ) do
-      {:ok, provider} -> provider
-      _ -> failed_provider_id
+  defp pick_next_provider(state, pool_key, failed_provider_id) do
+    entry = state.keys[pool_key]
+    failed_instance_id = entry.instance_id
+
+    if entry.provider_constraint do
+      nil
+    else
+      state.profile
+      |> Selection.select_channels(state.chain_id, "eth_subscribe",
+        strategy: :priority,
+        transport: :ws,
+        exclude: [failed_provider_id],
+        requires_subscribe_new_heads: entry.subscription_key == {:newHeads}
+      )
+      |> Enum.find(fn %Channel{provider_id: provider_id} ->
+        candidate_instance_id =
+          Catalog.lookup_instance_id(state.profile, state.chain_id, provider_id)
+
+        not is_nil(candidate_instance_id) and candidate_instance_id != failed_instance_id
+      end)
+      |> case do
+        %Channel{provider_id: provider_id} -> provider_id
+        nil -> nil
+      end
     end
   end
 
-  defp maybe_drop_upstream_when_unref(state, key) do
+  # Routes a failover decision: a valid replacement provider goes to the
+  # StreamCoordinator for handoff; `nil` (no candidate available) marks the
+  # subscription as failed so clients receive a Failed event rather than
+  # silently lingering against a stale upstream.
+  defp dispatch_failover(state, pool_key, _failed_provider_id, nil) do
+    case Map.get(state.keys, pool_key) do
+      %{provider_constraint: provider_constraint} when is_binary(provider_constraint) ->
+        retry_constrained_subscription(state, pool_key)
+
+      _ ->
+        mark_subscription_failed(state, pool_key, "No replacement provider available")
+    end
+  end
+
+  defp dispatch_failover(state, key, failed_provider_id, new_provider_id)
+       when is_binary(new_provider_id) do
+    StreamCoordinator.provider_unhealthy(
+      state.profile,
+      state.chain_id,
+      key,
+      failed_provider_id,
+      new_provider_id
+    )
+
+    state
+  end
+
+  defp maybe_drop_upstream_refs(state, _key, count) when not is_integer(count) or count <= 0,
+    do: state
+
+  defp maybe_drop_upstream_refs(state, key, count) do
     case Map.get(state.keys, key) do
       nil ->
         state
 
-      %{refcount: 1, primary_provider_id: provider_id, instance_id: instance_id}
-      when not is_nil(provider_id) and not is_nil(instance_id) ->
-        InstanceSubscriptionManager.release_subscription(instance_id, key)
-        InstanceSubscriptionRegistry.unregister_consumer(instance_id, key)
+      %{refcount: refcount} = entry when count >= refcount ->
+        one_ref_entry = %{entry | refcount: 1}
 
-        telemetry_upstream(:unsubscribe, state.chain, provider_id, key)
-
-        profile = state.profile
-        Task.start(fn -> StreamSupervisor.stop_coordinator(profile, state.chain, key) end)
-
-        %{state | keys: Map.delete(state.keys, key)}
-
-      %{refcount: 1} ->
-        profile = state.profile
-        Task.start(fn -> StreamSupervisor.stop_coordinator(profile, state.chain, key) end)
-        %{state | keys: Map.delete(state.keys, key)}
+        maybe_drop_upstream_when_unref(
+          %{state | keys: Map.put(state.keys, key, one_ref_entry)},
+          key
+        )
 
       entry ->
-        updated = %{entry | refcount: entry.refcount - 1}
+        updated = %{entry | refcount: entry.refcount - count}
+        telemetry_subscription_status(entry.status, state.chain_id, key, updated.refcount)
         %{state | keys: Map.put(state.keys, key, updated)}
     end
   end
 
-  defp telemetry_upstream(action, chain, provider_id, key) do
+  defp maybe_drop_upstream_when_unref(state, pool_key) do
+    case Map.get(state.keys, pool_key) do
+      nil ->
+        state
+
+      %{refcount: 1} = entry ->
+        release_entry_upstreams(state, pool_key, entry)
+
+        if entry.primary_provider_id do
+          telemetry_upstream(:unsubscribe, state.chain_id, entry.primary_provider_id, pool_key)
+        end
+
+        profile = state.profile
+        Task.start(fn -> StreamSupervisor.stop_coordinator(profile, state.chain_id, pool_key) end)
+        %{state | keys: Map.delete(state.keys, pool_key)}
+
+      entry ->
+        updated = %{entry | refcount: entry.refcount - 1}
+        %{state | keys: Map.put(state.keys, pool_key, updated)}
+    end
+  end
+
+  defp transient_subscription_error?(reason)
+       when reason in [:connection_unknown, :not_connected, :timeout, :noproc],
+       do: true
+
+  defp transient_subscription_error?(%JError{retriable?: true}), do: true
+  defp transient_subscription_error?(_reason), do: false
+
+  defp retry_constrained_subscription(state, pool_key) do
+    case Map.get(state.keys, pool_key) do
+      nil ->
+        state
+
+      entry ->
+        release_entry_upstreams(state, pool_key, entry)
+        generation = make_ref()
+
+        updated = %{
+          entry
+          | status: :establishing,
+            primary_provider_id: nil,
+            instance_id: nil,
+            establishment_generation: generation,
+            readiness_retries: 0,
+            transient_excluded_providers: MapSet.new()
+        }
+
+        Process.send_after(self(), {:retry_establish, pool_key, generation, []}, 100)
+        %{state | keys: Map.put(state.keys, pool_key, updated)}
+    end
+  end
+
+  defp release_entry_upstreams(state, pool_key, entry) do
+    [entry.instance_id, Map.get(entry, :transitioning_from_instance_id)]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.each(fn instance_id ->
+      unless instance_in_use_elsewhere?(state, pool_key, instance_id, entry.subscription_key) do
+        InstanceSubscriptionRegistry.unregister_consumer(instance_id, entry.subscription_key)
+        InstanceSubscriptionManager.release_subscription(instance_id, entry.subscription_key)
+      end
+    end)
+  end
+
+  defp instance_in_use_elsewhere?(state, pool_key, instance_id, subscription_key) do
+    Enum.any?(state.keys, fn {other_key, entry} ->
+      other_key != pool_key and entry.subscription_key == subscription_key and
+        (entry.instance_id == instance_id or
+           Map.get(entry, :transitioning_from_instance_id) == instance_id)
+    end)
+  end
+
+  defp telemetry_upstream(action, chain_id, provider_id, key) do
     :telemetry.execute([:lasso, :subs, :upstream, action], %{count: 1}, %{
-      chain: chain,
+      chain_id: chain_id,
       provider_id: provider_id,
       key: inspect(key)
     })
   end
 
-  defp telemetry_resubscribe_success(chain, key, provider_id) do
+  defp telemetry_resubscribe_success(chain_id, key, provider_id) do
     :telemetry.execute([:lasso, :subs, :resubscribe, :success], %{count: 1}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key),
       provider_id: provider_id
     })
   end
 
-  defp telemetry_resubscribe_failed(chain, key, provider_id, reason) do
+  defp telemetry_resubscribe_failed(chain_id, key, provider_id, reason) do
     :telemetry.execute([:lasso, :subs, :resubscribe, :failed], %{count: 1}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key),
       provider_id: provider_id,
       reason: inspect(reason)
     })
   end
 
-  defp telemetry_subscription_status(status, chain, key, refcount) do
+  defp telemetry_subscription_status(status, chain_id, key, refcount) do
     :telemetry.execute([:lasso, :subs, :status], %{refcount: refcount}, %{
-      chain: chain,
+      chain_id: chain_id,
       key: inspect(key),
       status: status
     })
   end
 
   defp broadcast_subscription_event(state, event) do
-    topic = Subscription.topic(state.profile, state.chain)
+    topic = Lasso.Topics.subscription_event(state.profile, state.chain_id)
     Phoenix.PubSub.broadcast(Lasso.PubSub, topic, event)
   end
+
+  defp pool_key(subscription_key, nil), do: subscription_key
+  defp pool_key(subscription_key, provider_id), do: {:route, provider_id, subscription_key}
 
   defp generate_id, do: :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
 end

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -963,16 +963,16 @@ defmodule Lasso.Core.Support.CircuitBreaker do
           nil
       end
 
-    {chain, refs} =
+    {chain_id, refs} =
       try do
-        chain =
+        chain_id =
           case Catalog.get_instance(state.instance_id) do
-            {:ok, %{chain: c}} -> c
+            {:ok, %{chain_id: id}} when is_integer(id) and id > 0 -> id
             _ -> nil
           end
 
         refs = Catalog.get_instance_refs(state.instance_id)
-        {chain, refs}
+        {chain_id, refs}
       rescue
         ArgumentError ->
           Logger.debug(
@@ -982,28 +982,35 @@ defmodule Lasso.Core.Support.CircuitBreaker do
           {nil, []}
       end
 
-    Enum.each(refs, fn profile ->
-      provider_id = Catalog.reverse_lookup_provider_id(profile, chain, state.instance_id)
+    if is_integer(chain_id) and chain_id > 0 do
+      Enum.each(refs, fn profile ->
+        provider_id = Catalog.reverse_lookup_provider_id(profile, chain_id, state.instance_id)
 
-      event =
-        {:circuit_breaker_event,
-         %{
-           ts: System.system_time(:millisecond),
-           profile: profile,
-           chain: chain,
-           provider_id: provider_id || state.instance_id,
-           instance_id: state.instance_id,
-           transport: state.transport,
-           from: from,
-           to: to,
-           reason: reason,
-           error: error_info,
-           source_node_id: Lasso.Cluster.Topology.get_self_node_id(),
-           source_node: node()
-         }}
+        event =
+          {:circuit_breaker_event,
+           %{
+             ts: System.system_time(:millisecond),
+             profile: profile,
+             chain: chain_id,
+             chain_id: chain_id,
+             provider_id: provider_id || state.instance_id,
+             instance_id: state.instance_id,
+             transport: state.transport,
+             from: from,
+             to: to,
+             reason: reason,
+             error: error_info,
+             source_node_id: Lasso.Cluster.Topology.get_self_node_id(),
+             source_node: node()
+           }}
 
-      Phoenix.PubSub.broadcast(Lasso.PubSub, "circuit:events:#{profile}:#{chain}", event)
-    end)
+        Phoenix.PubSub.broadcast(
+          Lasso.PubSub,
+          Lasso.Topics.circuit_event(profile, chain_id),
+          event
+        )
+      end)
+    end
   end
 
   defp truncate_error_message(msg) when is_binary(msg) do

--- a/lib/lasso/core/support/error_classifier.ex
+++ b/lib/lasso/core/support/error_classifier.ex
@@ -21,7 +21,7 @@ defmodule Lasso.Core.Support.ErrorClassifier do
   def classify(code, message, opts \\ []) do
     provider_id = Keyword.get(opts, :provider_id)
     profile = Keyword.get(opts, :profile)
-    chain = Keyword.get(opts, :chain)
+    chain = Keyword.get(opts, :chain_id) || Keyword.get(opts, :chain)
     data = Keyword.get(opts, :data)
 
     {category, classification_path} =
@@ -100,7 +100,7 @@ defmodule Lasso.Core.Support.ErrorClassifier do
   defp truncate_data(_), do: nil
 
   defp lookup_capabilities(profile, chain, provider_id)
-       when is_binary(profile) and is_binary(chain) do
+       when is_binary(profile) and is_integer(chain) do
     case Lasso.Config.ConfigStore.get_provider(profile, chain, provider_id) do
       {:ok, provider_config} -> provider_config.capabilities
       {:error, :not_found} -> nil

--- a/lib/lasso/core/support/error_normalizer.ex
+++ b/lib/lasso/core/support/error_normalizer.ex
@@ -165,11 +165,9 @@ defmodule Lasso.Core.Support.ErrorNormalizer do
           ErrorClassifier.classify(code, message, provider_id: provider_id)
 
         data =
-          if category == :rate_limit do
-            add_retry_after(payload, payload)
-          else
-            payload
-          end
+          payload
+          |> public_transport_data()
+          |> maybe_add_retry_after_for_category(category, payload)
 
         JError.new(code, message,
           data: data,
@@ -187,13 +185,10 @@ defmodule Lasso.Core.Support.ErrorNormalizer do
         # A compliant JSON-RPC provider would return errors in JSON-RPC format.
         # Non-JSON-RPC 4xx means the RPC handler never processed the request.
         status = Map.get(payload, :status, "4xx")
-        body = Map.get(payload, :body)
-        body_snippet = if is_binary(body), do: String.slice(body, 0, 200), else: ""
 
         Logger.warning("Reclassifying non-JSON-RPC 4xx as server_error",
           provider_id: provider_id,
-          status: status,
-          body: body_snippet
+          status: status
         )
 
         JError.new(-32_002, "Provider infrastructure error (HTTP #{status})",
@@ -663,6 +658,19 @@ defmodule Lasso.Core.Support.ErrorNormalizer do
   defp normalize_code(code) when code >= 400 and code <= 499, do: -32_600
   # JSON-RPC codes pass through
   defp normalize_code(code), do: code
+
+  defp maybe_add_retry_after_for_category(data, :rate_limit, payload),
+    do: add_retry_after(data, payload)
+
+  defp maybe_add_retry_after_for_category(data, _category, _payload), do: data
+
+  defp public_transport_data(payload) when is_map(payload) do
+    payload
+    |> Map.delete(:body)
+    |> Map.delete("body")
+  end
+
+  defp public_transport_data(payload), do: payload
 
   defp maybe_add_provider_id(%JError{provider_id: nil} = jerr, provider_id)
        when is_binary(provider_id),

--- a/lib/lasso/core/support/gap_filler.ex
+++ b/lib/lasso/core/support/gap_filler.ex
@@ -7,15 +7,15 @@ defmodule Lasso.Core.Support.GapFiller do
 
   @type backfill_opts :: [timeout_ms: non_neg_integer()]
 
-  @spec ensure_blocks(String.t(), String.t(), pos_integer(), pos_integer(), backfill_opts) ::
+  @spec ensure_blocks(pos_integer(), String.t(), pos_integer(), pos_integer(), backfill_opts) ::
           {:ok, list()} | {:error, term()}
-  def ensure_blocks(chain, provider_id, from_n, to_n, _opts \\ [])
+  def ensure_blocks(chain_id, provider_id, from_n, to_n, _opts \\ [])
 
-  def ensure_blocks(chain, provider_id, from_n, to_n, _opts) when from_n <= to_n do
+  def ensure_blocks(chain_id, provider_id, from_n, to_n, _opts) when from_n <= to_n do
     blocks =
       Enum.reduce(from_n..to_n, [], fn n, acc ->
         case RequestPipeline.execute_via_channels(
-               chain,
+               chain_id,
                "eth_getBlockByNumber",
                [
                  "0x" <> Integer.to_string(n, 16),
@@ -34,7 +34,7 @@ defmodule Lasso.Core.Support.GapFiller do
       end)
 
     :telemetry.execute([:lasso, :subs, :backfill, :block], %{count: length(blocks)}, %{
-      chain: chain,
+      chain_id: chain_id,
       from: from_n,
       to: to_n,
       provider_id: provider_id
@@ -43,13 +43,20 @@ defmodule Lasso.Core.Support.GapFiller do
     {:ok, blocks}
   end
 
-  def ensure_blocks(_chain, _provider_id, _from, _to, _opts), do: {:ok, []}
+  def ensure_blocks(_chain_id, _provider_id, _from, _to, _opts), do: {:ok, []}
 
-  @spec ensure_logs(String.t(), String.t(), map(), pos_integer(), pos_integer(), backfill_opts) ::
+  @spec ensure_logs(
+          pos_integer(),
+          String.t(),
+          map(),
+          pos_integer(),
+          pos_integer(),
+          backfill_opts
+        ) ::
           {:ok, list()} | {:error, term()}
-  def ensure_logs(chain, provider_id, filter, from_n, to_n, _opts \\ [])
+  def ensure_logs(chain_id, provider_id, filter, from_n, to_n, _opts \\ [])
 
-  def ensure_logs(chain, provider_id, filter, from_n, to_n, _opts) when from_n <= to_n do
+  def ensure_logs(chain_id, provider_id, filter, from_n, to_n, _opts) when from_n <= to_n do
     base_filter = %{
       "fromBlock" => "0x" <> Integer.to_string(from_n, 16),
       "toBlock" => "0x" <> Integer.to_string(to_n, 16)
@@ -58,7 +65,7 @@ defmodule Lasso.Core.Support.GapFiller do
     full_filter = Map.merge(filter, base_filter)
 
     case RequestPipeline.execute_via_channels(
-           chain,
+           chain_id,
            "eth_getLogs",
            [full_filter],
            %RequestOptions{
@@ -75,7 +82,7 @@ defmodule Lasso.Core.Support.GapFiller do
           end)
 
         :telemetry.execute([:lasso, :subs, :backfill, :logs], %{count: length(ordered)}, %{
-          chain: chain,
+          chain_id: chain_id,
           from: from_n,
           to: to_n,
           provider_id: provider_id
@@ -88,7 +95,7 @@ defmodule Lasso.Core.Support.GapFiller do
     end
   end
 
-  def ensure_logs(_chain, _provider_id, _filter, _from, _to, _opts), do: {:ok, []}
+  def ensure_logs(_chain_id, _provider_id, _filter, _from, _to, _opts), do: {:ok, []}
 
   defp decode_hex(nil), do: nil
   defp decode_hex("0x" <> rest), do: String.to_integer(rest, 16)

--- a/lib/lasso/core/transport/channel.ex
+++ b/lib/lasso/core/transport/channel.ex
@@ -16,7 +16,7 @@ defmodule Lasso.RPC.Channel do
 
   @type t :: %__MODULE__{
           profile: String.t(),
-          chain: String.t(),
+          chain_id: pos_integer(),
           provider_id: String.t(),
           transport: :http | :ws,
           raw_channel: term(),
@@ -24,10 +24,10 @@ defmodule Lasso.RPC.Channel do
           capabilities: map() | nil
         }
 
-  @derive {Jason.Encoder, only: [:profile, :chain, :provider_id, :transport]}
+  @derive {Jason.Encoder, only: [:profile, :chain_id, :provider_id, :transport]}
   defstruct [
     :profile,
-    :chain,
+    :chain_id,
     :provider_id,
     :transport,
     :raw_channel,
@@ -38,16 +38,15 @@ defmodule Lasso.RPC.Channel do
   @doc """
   Creates a new Channel wrapper.
   """
-  @spec new(String.t(), String.t(), String.t(), :http | :ws, term(), module()) :: t()
-  def new(profile, chain, provider_id, transport, raw_channel, transport_module) do
+  @spec new(String.t(), pos_integer(), String.t(), :http | :ws, term(), module()) :: t()
+  def new(profile, chain_id, provider_id, transport, raw_channel, transport_module) do
     %__MODULE__{
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       provider_id: provider_id,
       transport: transport,
       raw_channel: raw_channel,
       transport_module: transport_module,
-      # Lazily loaded
       capabilities: nil
     }
   end
@@ -119,7 +118,6 @@ defmodule Lasso.RPC.Channel do
     case Map.get(capabilities, :methods) do
       :all -> true
       method_set when is_struct(method_set, MapSet) -> MapSet.member?(method_set, method)
-      # Default to true if capabilities are unclear
       _ -> true
     end
   end
@@ -147,6 +145,6 @@ defmodule Lasso.RPC.Channel do
   """
   @spec to_string(t()) :: String.t()
   def to_string(%__MODULE__{} = channel) do
-    "#{channel.chain}:#{channel.provider_id}:#{channel.transport}"
+    "#{channel.chain_id}:#{channel.provider_id}:#{channel.transport}"
   end
 end

--- a/lib/lasso/core/transport/http/adapters/finch.ex
+++ b/lib/lasso/core/transport/http/adapters/finch.ex
@@ -6,6 +6,7 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
   @behaviour Lasso.RPC.Transport.HTTP.Client
   require Logger
 
+  alias Lasso.Providers.ProviderHeaders
   alias Lasso.URLMask
 
   @impl true
@@ -94,15 +95,7 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
     end
   end
 
-  defp base_headers(%{api_key: api_key}) when is_binary(api_key) and byte_size(api_key) > 0 do
-    [
-      {"authorization", "Bearer #{api_key}"},
-      {"content-type", "application/json"},
-      {"accept", "application/json"}
-    ]
-  end
-
-  defp base_headers(_), do: [{"content-type", "application/json"}, {"accept", "application/json"}]
+  defp base_headers(provider), do: ProviderHeaders.build(provider)
 
   defp handle_response(status, body) when status in 200..299 do
     # Return raw bytes for passthrough optimization

--- a/lib/lasso/core/transport/http/adapters/finch.ex
+++ b/lib/lasso/core/transport/http/adapters/finch.ex
@@ -6,6 +6,8 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
   @behaviour Lasso.RPC.Transport.HTTP.Client
   require Logger
 
+  alias Lasso.URLMask
+
   @impl true
   def request(%{url: url} = provider, method, params, opts) do
     # Extract options with defaults
@@ -32,7 +34,7 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
       # Handle NimblePool checkout errors specifically
       {:error, {:exit, {{:shutdown, :idle_timeout}, {NimblePool, :checkout, _}}}} ->
         Logger.warning("Finch connection pool idle timeout",
-          provider_url: url,
+          provider_url: URLMask.mask(url),
           request_id: request_id
         )
 
@@ -40,7 +42,7 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
         :telemetry.execute(
           [:lasso, :finch, :pool_idle_timeout],
           %{count: 1},
-          %{provider_url: url, request_id: request_id}
+          %{provider_url: URLMask.mask(url), request_id: request_id}
         )
 
         {:error, {:network_error, "Connection pool idle timeout"}}
@@ -48,7 +50,7 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
       # Handle other NimblePool errors
       {:error, {:exit, {{:shutdown, reason}, {NimblePool, :checkout, _}}}} ->
         Logger.warning("Finch connection pool checkout failed",
-          provider_url: url,
+          provider_url: URLMask.mask(url),
           request_id: request_id,
           shutdown_reason: reason
         )
@@ -57,14 +59,14 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
         :telemetry.execute(
           [:lasso, :finch, :pool_checkout_failed],
           %{count: 1},
-          %{provider_url: url, request_id: request_id, reason: reason}
+          %{provider_url: URLMask.mask(url), request_id: request_id, reason: reason}
         )
 
         {:error, {:network_error, "Connection pool checkout failed: #{reason}"}}
 
       {:error, %Mint.TransportError{reason: reason}} ->
         Logger.debug("Finch request failed - Mint transport error",
-          provider_url: url,
+          provider_url: URLMask.mask(url),
           request_id: request_id,
           reason: reason
         )
@@ -83,7 +85,7 @@ defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
 
       {:error, reason} ->
         Logger.debug("Finch request failed",
-          provider_url: url,
+          provider_url: URLMask.mask(url),
           request_id: request_id,
           error: inspect(reason)
         )

--- a/lib/lasso/core/transport/registry.ex
+++ b/lib/lasso/core/transport/registry.ex
@@ -60,7 +60,6 @@ defmodule Lasso.RPC.TransportRegistry do
   require Logger
 
   alias Lasso.Config.ConfigStore
-  alias Lasso.Config.ProfileValidator
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.RPC.Channel
 
@@ -69,7 +68,7 @@ defmodule Lasso.RPC.TransportRegistry do
 
   defstruct [
     :profile,
-    :chain_name,
+    :chain_id,
     # Map of provider_id => %{http: channel, ws: channel}
     :channels,
     # Map of {provider_id, transport} => capabilities
@@ -77,26 +76,20 @@ defmodule Lasso.RPC.TransportRegistry do
   ]
 
   @type profile :: String.t()
-  @type chain_name :: String.t()
+  @type chain_id :: pos_integer()
   @type provider_id :: String.t()
   @type transport :: :http | :ws
   @type channel_map :: %{transport => Channel.t()}
 
   @doc """
   Starts the TransportRegistry for a profile/chain pair.
-
-  Accepts either `{profile, chain_name, chain_config}` (profile-aware) or
-  `{chain_name, chain_config}` (backward compatible, uses default profile).
   """
-  @spec start_link({profile, chain_name, map()} | {chain_name, map()}) :: GenServer.on_start()
-  def start_link({profile, chain_name, chain_config}) when is_binary(profile) do
-    GenServer.start_link(__MODULE__, {profile, chain_name, chain_config},
-      name: via_name(profile, chain_name)
+  @spec start_link({profile, chain_id, map()}) :: GenServer.on_start()
+  def start_link({profile, chain_id, chain_config})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.start_link(__MODULE__, {profile, chain_id, chain_config},
+      name: via_name(profile, chain_id)
     )
-  end
-
-  def start_link({chain_name, chain_config}) do
-    start_link({ProfileValidator.default_profile(), chain_name, chain_config})
   end
 
   @doc """
@@ -124,28 +117,24 @@ defmodule Lasso.RPC.TransportRegistry do
 
   Returns {:ok, channel} or {:error, reason}.
   """
-  @spec get_channel(profile, chain_name, provider_id, transport, keyword()) ::
+  @spec get_channel(profile, chain_id, provider_id, transport, keyword()) ::
           {:ok, Channel.t()} | {:error, term()}
-  def get_channel(profile, chain_name, provider_id, transport, opts \\ [])
-      when is_binary(profile) and is_binary(chain_name) and is_binary(provider_id) and
-             is_atom(transport) do
-    cache_key = {profile, chain_name, provider_id, transport}
+  def get_channel(profile, chain_id, provider_id, transport, opts \\ [])
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
+             is_binary(provider_id) and is_atom(transport) do
+    cache_key = {profile, chain_id, provider_id, transport}
 
     case :ets.lookup(@channel_cache_table, cache_key) do
       [{^cache_key, channel}] ->
-        # Fast path: channel exists in ETS cache
         {:ok, channel}
 
       [] ->
-        # Slow path: channel not cached, use GenServer to create/fetch
-        # This will also populate the ETS cache for future lookups
-        do_get_channel(profile, chain_name, provider_id, transport, opts)
+        do_get_channel(profile, chain_id, provider_id, transport, opts)
     end
   end
 
-  # GenServer call for channel creation/retrieval. Called on cache miss.
-  defp do_get_channel(profile, chain_name, provider_id, transport, opts) do
-    GenServer.call(via_name(profile, chain_name), {:get_channel, provider_id, transport, opts})
+  defp do_get_channel(profile, chain_id, provider_id, transport, opts) do
+    GenServer.call(via_name(profile, chain_id), {:get_channel, provider_id, transport, opts})
   catch
     :exit, {:noproc, _} -> {:error, :registry_unavailable}
     :exit, {:timeout, _} -> {:error, :registry_timeout}
@@ -159,110 +148,61 @@ defmodule Lasso.RPC.TransportRegistry do
 
   Accepts optional profile as first argument (defaults to the canonical default profile).
   """
-  @spec initialize_provider_channels(chain_name, provider_id, map()) :: :ok | {:error, term()}
-  def initialize_provider_channels(chain_name, provider_id, provider_config) do
-    initialize_provider_channels(
-      ProfileValidator.default_profile(),
-      chain_name,
-      provider_id,
-      provider_config
-    )
-  end
-
-  @spec initialize_provider_channels(profile, chain_name, provider_id, map()) ::
+  @spec initialize_provider_channels(profile, chain_id, provider_id, map()) ::
           :ok | {:error, term()}
-  def initialize_provider_channels(profile, chain_name, provider_id, provider_config)
-      when is_binary(profile) do
+  def initialize_provider_channels(profile, chain_id, provider_id, provider_config)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
     GenServer.call(
-      via_name(profile, chain_name),
+      via_name(profile, chain_id),
       {:initialize_provider_channels, provider_id, provider_config}
     )
   end
 
-  @doc """
-  Lists all available channels for a provider.
-
-  Accepts optional profile as first argument (defaults to the canonical default profile).
-
-  Returns a list of {transport, channel} tuples.
-  """
-  @spec list_provider_channels(chain_name, provider_id) :: [{transport, Channel.t()}]
-  def list_provider_channels(chain_name, provider_id) do
-    list_provider_channels(ProfileValidator.default_profile(), chain_name, provider_id)
+  @spec list_provider_channels(profile, chain_id, provider_id) :: [{transport, Channel.t()}]
+  def list_provider_channels(profile, chain_id, provider_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(via_name(profile, chain_id), {:list_provider_channels, provider_id})
   end
 
-  @spec list_provider_channels(profile, chain_name, provider_id) :: [{transport, Channel.t()}]
-  def list_provider_channels(profile, chain_name, provider_id) when is_binary(profile) do
-    GenServer.call(via_name(profile, chain_name), {:list_provider_channels, provider_id})
+  @spec get_candidate_channels(profile, chain_id, map()) :: [Channel.t()]
+  def get_candidate_channels(profile, chain_id, filters)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_map(filters) do
+    GenServer.call(via_name(profile, chain_id), {:get_candidate_channels, filters})
   end
 
-  @doc """
-  Gets all candidate channels that match the given filters.
-
-  Filters can include:
-  - protocol: :http | :ws | :both
-  - exclude: [provider_id]
-  - method: String.t() (for capability filtering)
-
-  Accepts optional profile as first argument (defaults to the canonical default profile).
-
-  Returns a list of Channel structs with transport and capability information.
-  """
-  @spec get_candidate_channels(chain_name, map()) :: [Channel.t()]
-  def get_candidate_channels(chain_name, filters \\ %{}) do
-    get_candidate_channels(ProfileValidator.default_profile(), chain_name, filters)
+  @spec refresh_capabilities(profile, chain_id, provider_id, transport) :: :ok
+  def refresh_capabilities(profile, chain_id, provider_id, transport)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.cast(via_name(profile, chain_id), {:refresh_capabilities, provider_id, transport})
   end
 
-  @spec get_candidate_channels(profile, chain_name, map()) :: [Channel.t()]
-  def get_candidate_channels(profile, chain_name, filters)
-      when is_binary(profile) and is_map(filters) do
-    GenServer.call(via_name(profile, chain_name), {:get_candidate_channels, filters})
+  @spec close_channel(profile, chain_id, provider_id, transport) :: :ok
+  def close_channel(profile, chain_id, provider_id, transport)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.cast(via_name(profile, chain_id), {:close_channel, provider_id, transport})
   end
 
-  @doc """
-  Forces refresh of capabilities for a provider/transport combination.
-
-  Accepts optional profile as first argument (defaults to the canonical default profile).
-  """
-  @spec refresh_capabilities(chain_name, provider_id, transport) :: :ok
-  def refresh_capabilities(chain_name, provider_id, transport) do
-    refresh_capabilities(ProfileValidator.default_profile(), chain_name, provider_id, transport)
-  end
-
-  @spec refresh_capabilities(profile, chain_name, provider_id, transport) :: :ok
-  def refresh_capabilities(profile, chain_name, provider_id, transport) when is_binary(profile) do
-    GenServer.cast(via_name(profile, chain_name), {:refresh_capabilities, provider_id, transport})
-  end
-
-  @doc """
-  Closes and removes a channel from the registry.
-
-  Accepts optional profile as first argument (defaults to the canonical default profile).
-  """
-  @spec close_channel(chain_name, provider_id, transport) :: :ok
-  def close_channel(chain_name, provider_id, transport) do
-    close_channel(ProfileValidator.default_profile(), chain_name, provider_id, transport)
-  end
-
-  @spec close_channel(profile, chain_name, provider_id, transport) :: :ok
-  def close_channel(profile, chain_name, provider_id, transport) when is_binary(profile) do
-    GenServer.cast(via_name(profile, chain_name), {:close_channel, provider_id, transport})
+  @spec close_channel_sync(profile, chain_id, provider_id, transport) :: :ok
+  def close_channel_sync(profile, chain_id, provider_id, transport)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.call(via_name(profile, chain_id), {:close_channel, provider_id, transport})
+  catch
+    :exit, {:noproc, _} -> :ok
   end
 
   # GenServer implementation
 
   @impl true
-  def init({profile, chain_name, _chain_config})
-      when is_binary(profile) and is_binary(chain_name) do
+  def init({profile, chain_id, _chain_config})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
     state = %__MODULE__{
       profile: profile,
-      chain_name: chain_name,
+      chain_id: chain_id,
       channels: %{},
       capabilities: %{}
     }
 
-    # Subscribe to profile-scoped WS connection events
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:conn:#{profile}:#{chain_name}")
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.ws_connection(profile, chain_id))
 
     {:ok, state}
   end
@@ -340,6 +280,12 @@ defmodule Lasso.RPC.TransportRegistry do
   end
 
   @impl true
+  def handle_call({:close_channel, provider_id, transport}, _from, state) do
+    new_state = remove_channel(state, provider_id, transport)
+    {:reply, :ok, new_state}
+  end
+
+  @impl true
   def handle_call({:get_candidate_channels, filters}, _from, state) do
     candidates = build_candidate_list(state, filters)
     {:reply, candidates, state}
@@ -411,17 +357,15 @@ defmodule Lasso.RPC.TransportRegistry do
   end
 
   defp create_channel(state, provider_id, transport, opts) do
-    # Try to get provider config from opts first (for dynamic providers),
-    # fallback to ConfigStore for config-file providers
     provider_config_result =
       case Keyword.get(opts, :provider_config) do
         config when is_map(config) ->
           {:ok, config}
 
         _ ->
-          case ConfigStore.get_provider(state.profile, state.chain_name, provider_id) do
+          case ConfigStore.get_provider(state.profile, state.chain_id, provider_id) do
             {:ok, _} = ok -> ok
-            _ -> get_provider_config_from_store(state.profile, state.chain_name, provider_id)
+            _ -> get_provider_config_from_store(state.profile, state.chain_id, provider_id)
           end
       end
 
@@ -433,9 +377,8 @@ defmodule Lasso.RPC.TransportRegistry do
           opts
           |> Keyword.put(:provider_id, provider_id)
           |> Keyword.put(:profile, state.profile)
-          |> Keyword.put(:chain, state.chain_name)
+          |> Keyword.put(:chain_id, state.chain_id)
 
-        # Only attempt to open channels that are actually configured
         case transport do
           :http ->
             if is_binary(Map.get(provider_config, :url)) or
@@ -454,11 +397,10 @@ defmodule Lasso.RPC.TransportRegistry do
         end
         |> case do
           {:ok, raw_channel} ->
-            # Wrap in Channel struct
             channel =
               Channel.new(
                 state.profile,
-                state.chain_name,
+                state.chain_id,
                 provider_id,
                 transport,
                 raw_channel,
@@ -501,8 +443,8 @@ defmodule Lasso.RPC.TransportRegistry do
     end
   end
 
-  defp get_provider_config_from_store(profile, chain_name, provider_id) do
-    case ConfigStore.get_provider(profile, chain_name, provider_id) do
+  defp get_provider_config_from_store(profile, chain_id, provider_id) do
+    case ConfigStore.get_provider(profile, chain_id, provider_id) do
       {:error, :not_found} -> {:error, :provider_not_found}
       result -> result
     end
@@ -601,33 +543,19 @@ defmodule Lasso.RPC.TransportRegistry do
   defp get_transport_module(:http), do: Lasso.RPC.Transports.HTTP
   defp get_transport_module(:ws), do: Lasso.RPC.Transports.WebSocket
 
-  @doc """
-  Returns the via tuple for the TransportRegistry GenServer.
-
-  Accepts optional profile as first argument (defaults to the canonical default profile).
-  """
-  @spec via_name(String.t()) :: {:via, Registry, {atom(), tuple()}}
-  def via_name(chain_name) when is_binary(chain_name) do
-    via_name(ProfileValidator.default_profile(), chain_name)
+  @spec via_name(String.t(), pos_integer()) :: {:via, Registry, {atom(), tuple()}}
+  def via_name(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    {:via, Registry, {Lasso.Registry, {:transport_registry, profile, chain_id}}}
   end
 
-  @spec via_name(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
-  def via_name(profile, chain_name) when is_binary(profile) and is_binary(chain_name) do
-    {:via, Registry, {Lasso.Registry, {:transport_registry, profile, chain_name}}}
-  end
-
-  # ETS cache management for lockless hot-path reads
-
-  # Updates the ETS channel cache. Called internally when channels are created.
-  # Cache key includes profile for isolation.
   defp cache_channel(state, provider_id, transport, channel) do
-    cache_key = {state.profile, state.chain_name, provider_id, transport}
+    cache_key = {state.profile, state.chain_id, provider_id, transport}
     :ets.insert(@channel_cache_table, {cache_key, channel})
   end
 
-  # Removes a channel from ETS cache. Called internally when channels are closed.
   defp uncache_channel(state, provider_id, transport) do
-    cache_key = {state.profile, state.chain_name, provider_id, transport}
+    cache_key = {state.profile, state.chain_id, provider_id, transport}
     :ets.delete(@channel_cache_table, cache_key)
   end
 end

--- a/lib/lasso/core/transport/registry.ex
+++ b/lib/lasso/core/transport/registry.ex
@@ -75,8 +75,11 @@ defmodule Lasso.RPC.TransportRegistry do
     :capabilities
   ]
 
+  @default_profile "public"
+
   @type profile :: String.t()
   @type chain_id :: pos_integer()
+  @type chain_identifier :: chain_id | String.t()
   @type provider_id :: String.t()
   @type transport :: :http | :ws
   @type channel_map :: %{transport => Channel.t()}
@@ -84,12 +87,35 @@ defmodule Lasso.RPC.TransportRegistry do
   @doc """
   Starts the TransportRegistry for a profile/chain pair.
   """
-  @spec start_link({profile, chain_id, map()}) :: GenServer.on_start()
+  @spec start_link(
+          {profile, chain_id, map()}
+          | {profile, String.t(), map()}
+          | {String.t(), map()}
+        ) :: GenServer.on_start()
   def start_link({profile, chain_id, chain_config})
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    profile = canonical_profile(profile)
+
     GenServer.start_link(__MODULE__, {profile, chain_id, chain_config},
       name: via_name(profile, chain_id)
     )
+  end
+
+  def start_link({profile, chain_identifier, chain_config})
+      when is_binary(profile) and is_binary(chain_identifier) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier, chain_config) do
+      GenServer.start_link(
+        __MODULE__,
+        {profile, chain_id, chain_config, chain_identifier},
+        name: via_name(profile, chain_id)
+      )
+    end
+  end
+
+  def start_link({chain_identifier, chain_config}) when is_binary(chain_identifier) do
+    start_link({@default_profile, chain_identifier, chain_config})
   end
 
   @doc """
@@ -120,8 +146,11 @@ defmodule Lasso.RPC.TransportRegistry do
   @spec get_channel(profile, chain_id, provider_id, transport, keyword()) ::
           {:ok, Channel.t()} | {:error, term()}
   def get_channel(profile, chain_id, provider_id, transport, opts \\ [])
+
+  def get_channel(profile, chain_id, provider_id, transport, opts)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
              is_binary(provider_id) and is_atom(transport) do
+    profile = canonical_profile(profile)
     cache_key = {profile, chain_id, provider_id, transport}
 
     case :ets.lookup(@channel_cache_table, cache_key) do
@@ -130,6 +159,16 @@ defmodule Lasso.RPC.TransportRegistry do
 
       [] ->
         do_get_channel(profile, chain_id, provider_id, transport, opts)
+    end
+  end
+
+  def get_channel(profile, chain_identifier, provider_id, transport, opts)
+      when is_binary(profile) and is_binary(chain_identifier) and is_binary(provider_id) and
+             is_atom(transport) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      get_channel(profile, chain_id, provider_id, transport, opts)
     end
   end
 
@@ -152,34 +191,123 @@ defmodule Lasso.RPC.TransportRegistry do
           :ok | {:error, term()}
   def initialize_provider_channels(profile, chain_id, provider_id, provider_config)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    profile = canonical_profile(profile)
+
     GenServer.call(
       via_name(profile, chain_id),
       {:initialize_provider_channels, provider_id, provider_config}
     )
   end
 
+  def initialize_provider_channels(profile, chain_identifier, provider_id, provider_config)
+      when is_binary(profile) and is_binary(chain_identifier) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      initialize_provider_channels(profile, chain_id, provider_id, provider_config)
+    end
+  end
+
+  @spec initialize_provider_channels(pos_integer() | String.t(), provider_id, map()) ::
+          :ok | {:error, term()}
+  def initialize_provider_channels(chain_identifier, provider_id, provider_config) do
+    initialize_provider_channels(@default_profile, chain_identifier, provider_id, provider_config)
+  end
+
   @spec list_provider_channels(profile, chain_id, provider_id) :: [{transport, Channel.t()}]
   def list_provider_channels(profile, chain_id, provider_id)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
-    GenServer.call(via_name(profile, chain_id), {:list_provider_channels, provider_id})
+    GenServer.call(
+      via_name(canonical_profile(profile), chain_id),
+      {:list_provider_channels, provider_id}
+    )
+  end
+
+  def list_provider_channels(profile, chain_identifier, provider_id)
+      when is_binary(profile) and is_binary(chain_identifier) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      list_provider_channels(profile, chain_id, provider_id)
+    end
+  end
+
+  @spec list_provider_channels(pos_integer() | String.t(), provider_id) ::
+          [{transport, Channel.t()}] | {:error, term()}
+  def list_provider_channels(chain_identifier, provider_id) do
+    list_provider_channels(@default_profile, chain_identifier, provider_id)
   end
 
   @spec get_candidate_channels(profile, chain_id, map()) :: [Channel.t()]
   def get_candidate_channels(profile, chain_id, filters)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_map(filters) do
-    GenServer.call(via_name(profile, chain_id), {:get_candidate_channels, filters})
+    GenServer.call(
+      via_name(canonical_profile(profile), chain_id),
+      {:get_candidate_channels, filters}
+    )
+  end
+
+  def get_candidate_channels(profile, chain_identifier, filters)
+      when is_binary(profile) and is_binary(chain_identifier) and is_map(filters) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      get_candidate_channels(profile, chain_id, filters)
+    end
+  end
+
+  @spec get_candidate_channels(pos_integer() | String.t(), map()) ::
+          [Channel.t()] | {:error, term()}
+  def get_candidate_channels(chain_identifier, filters \\ %{}) do
+    get_candidate_channels(@default_profile, chain_identifier, filters)
   end
 
   @spec refresh_capabilities(profile, chain_id, provider_id, transport) :: :ok
   def refresh_capabilities(profile, chain_id, provider_id, transport)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
-    GenServer.cast(via_name(profile, chain_id), {:refresh_capabilities, provider_id, transport})
+    GenServer.cast(
+      via_name(canonical_profile(profile), chain_id),
+      {:refresh_capabilities, provider_id, transport}
+    )
+  end
+
+  def refresh_capabilities(profile, chain_identifier, provider_id, transport)
+      when is_binary(profile) and is_binary(chain_identifier) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      refresh_capabilities(profile, chain_id, provider_id, transport)
+    end
+  end
+
+  @spec refresh_capabilities(pos_integer() | String.t(), provider_id, transport) ::
+          :ok | {:error, term()}
+  def refresh_capabilities(chain_identifier, provider_id, transport) do
+    refresh_capabilities(@default_profile, chain_identifier, provider_id, transport)
   end
 
   @spec close_channel(profile, chain_id, provider_id, transport) :: :ok
   def close_channel(profile, chain_id, provider_id, transport)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
-    GenServer.cast(via_name(profile, chain_id), {:close_channel, provider_id, transport})
+    GenServer.cast(
+      via_name(canonical_profile(profile), chain_id),
+      {:close_channel, provider_id, transport}
+    )
+  end
+
+  def close_channel(profile, chain_identifier, provider_id, transport)
+      when is_binary(profile) and is_binary(chain_identifier) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      close_channel(profile, chain_id, provider_id, transport)
+    end
+  end
+
+  @spec close_channel(pos_integer() | String.t(), provider_id, transport) ::
+          :ok | {:error, term()}
+  def close_channel(chain_identifier, provider_id, transport) do
+    close_channel(@default_profile, chain_identifier, provider_id, transport)
   end
 
   @spec close_channel_sync(profile, chain_id, provider_id, transport) :: :ok
@@ -193,6 +321,19 @@ defmodule Lasso.RPC.TransportRegistry do
   # GenServer implementation
 
   @impl true
+  def init({profile, chain_id, chain_config, legacy_chain_name})
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
+             is_binary(legacy_chain_name) do
+    {:ok, _} =
+      Registry.register(
+        Lasso.Registry,
+        {:transport_registry, profile, legacy_chain_name},
+        nil
+      )
+
+    init({profile, chain_id, chain_config})
+  end
+
   def init({profile, chain_id, _chain_config})
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
     state = %__MODULE__{
@@ -241,16 +382,15 @@ defmodule Lasso.RPC.TransportRegistry do
   @impl true
   def handle_call({:initialize_provider_channels, provider_id, provider_config}, _from, state) do
     # HTTP pre-warm if configured
-    state =
+    {result, state} =
       if is_binary(Map.get(provider_config, :url)) or
            is_binary(Map.get(provider_config, :http_url)) do
         case create_channel(state, provider_id, :http, provider_config: provider_config) do
-          {:ok, _chan, s} ->
+          {:ok, _chan, updated_state} ->
             Logger.info("TransportRegistry: HTTP channel created for #{provider_id}")
-            s
+            {:ok, updated_state}
 
           {:error, reason} ->
-            # Log actual failures as warnings, missing configs as debug
             case reason do
               :no_http_config ->
                 Logger.debug("TransportRegistry: No HTTP URL configured for #{provider_id}")
@@ -261,15 +401,15 @@ defmodule Lasso.RPC.TransportRegistry do
                 )
             end
 
-            state
+            {{:error, reason}, state}
         end
       else
         Logger.debug("TransportRegistry: No HTTP URL configured for #{provider_id}")
-        state
+        {:ok, state}
       end
 
     # WS channels are created on ws_connected events to avoid races
-    {:reply, :ok, state}
+    {:reply, result, state}
   end
 
   @impl true
@@ -546,7 +686,41 @@ defmodule Lasso.RPC.TransportRegistry do
   @spec via_name(String.t(), pos_integer()) :: {:via, Registry, {atom(), tuple()}}
   def via_name(profile, chain_id)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
-    {:via, Registry, {Lasso.Registry, {:transport_registry, profile, chain_id}}}
+    {:via, Registry,
+     {Lasso.Registry, {:transport_registry, canonical_profile(profile), chain_id}}}
+  end
+
+  @spec via_name(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
+  def via_name(profile, chain_identifier)
+      when is_binary(profile) and is_binary(chain_identifier) do
+    profile = canonical_profile(profile)
+
+    case resolve_chain_id(profile, chain_identifier) do
+      {:ok, chain_id} ->
+        via_name(profile, chain_id)
+
+      {:error, :chain_not_found} ->
+        {:via, Registry, {Lasso.Registry, {:transport_registry, profile, chain_identifier}}}
+    end
+  end
+
+  @spec via_name(pos_integer() | String.t()) :: {:via, Registry, {atom(), tuple()}}
+  def via_name(chain_identifier), do: via_name(@default_profile, chain_identifier)
+
+  defp canonical_profile(profile), do: Lasso.Config.ProfileValidator.resolve_alias(profile)
+
+  defp resolve_chain_id(profile, chain_identifier, chain_config) do
+    case Map.get(chain_config, :chain_id) do
+      chain_id when is_integer(chain_id) and chain_id > 0 -> {:ok, chain_id}
+      _ -> resolve_chain_id(profile, chain_identifier)
+    end
+  end
+
+  defp resolve_chain_id(profile, chain_identifier) when is_binary(chain_identifier) do
+    case ConfigStore.lookup_chain_id_in_profile(profile, chain_identifier) do
+      {:ok, chain_id} -> {:ok, chain_id}
+      :not_found -> {:error, :chain_not_found}
+    end
   end
 
   defp cache_channel(state, provider_id, transport, channel) do

--- a/lib/lasso/core/transport/websocket/connection.ex
+++ b/lib/lasso/core/transport/websocket/connection.ex
@@ -70,7 +70,6 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   use GenServer, restart: :permanent
   require Logger
 
-  alias Lasso.Config.ConfigStore
   alias Lasso.Core.Support.CircuitBreaker
   alias Lasso.Core.Support.{ErrorClassifier, ErrorNormalizer}
   alias Lasso.JSONRPC.Error, as: JError
@@ -119,8 +118,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
             get_in(instance, [:canonical_config, :name]) ||
               "Shared WebSocket #{instance_id}",
           ws_url: instance.ws_url,
-          chain_id: resolve_chain_id(instance.chain),
-          chain_name: instance.chain
+          chain_id: instance.chain_id
         }
 
         GenServer.start_link(__MODULE__, endpoint, name: via_instance_name(instance_id))
@@ -151,8 +149,6 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
   @impl true
   def init(%Endpoint{} = endpoint) do
-    # Trap exits so we receive :EXIT messages from linked WebSockex processes
-    # This ensures we handle disconnects even if WebSockex crashes abnormally
     Process.flag(:trap_exit, true)
 
     instance_id = endpoint_instance_id(endpoint)
@@ -160,7 +156,6 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     state = %{
       endpoint: endpoint,
       profile: endpoint.profile,
-      chain_name: endpoint.chain_name,
       instance_id: instance_id,
       connection: nil,
       connected: false,
@@ -253,7 +248,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
           %{},
           %{
             provider_id: state.endpoint.id,
-            chain: state.chain_name,
+            chain_id: state.endpoint.chain_id,
             error_code: jerr.code,
             error_message: jerr.message,
             retriable: true,
@@ -321,7 +316,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
           %{},
           %{
             provider_id: state.endpoint.id,
-            chain: state.chain_name,
+            chain_id: state.endpoint.chain_id,
             error_code: jerr.code,
             error_message: jerr.message,
             retriable: jerr.retriable?,
@@ -436,7 +431,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       %{},
       %{
         provider_id: state.endpoint.id,
-        chain: state.chain_name,
+        chain_id: state.endpoint.chain_id,
         reconnect_attempt: state.reconnect_attempts,
         connection_id: connection_id
       }
@@ -589,7 +584,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       %{},
       %{
         provider_id: state.endpoint.id,
-        chain: state.chain_name,
+        chain_id: state.endpoint.chain_id,
         reason: reason,
         code: code,
         had_active_traffic: had_pending,
@@ -684,7 +679,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
         %{},
         %{
           provider_id: state.endpoint.id,
-          chain: state.chain_name,
+          chain_id: state.endpoint.chain_id,
           reason: reason,
           had_active_traffic: had_pending,
           was_stable: false,
@@ -917,7 +912,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       %{},
       %{
         provider_id: state.endpoint.id,
-        chain: state.chain_name,
+        chain_id: state.endpoint.chain_id,
         reason: {:exit, reason},
         had_active_traffic: had_pending,
         was_stable: was_stable,
@@ -1414,23 +1409,24 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
   defp endpoint_instance_id(%Endpoint{profile: @shared_profile, id: instance_id}), do: instance_id
 
-  defp endpoint_instance_id(%Endpoint{profile: profile, chain_name: chain, id: provider_id})
-       when is_binary(profile) and is_binary(chain) and is_binary(provider_id) do
-    Catalog.lookup_instance_id(profile, chain, provider_id) || "#{chain}:#{provider_id}"
+  defp endpoint_instance_id(%Endpoint{profile: profile, chain_id: chain_id, id: provider_id})
+       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
+              is_binary(provider_id) do
+    Catalog.lookup_instance_id(profile, chain_id, provider_id) || "#{chain_id}:#{provider_id}"
   end
 
   defp broadcast_conn_event(state, event_builder) when is_function(event_builder, 1) do
     for {profile, provider_id} <- profile_provider_refs(state) do
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
-        "ws:conn:#{profile}:#{state.chain_name}",
+        Lasso.Topics.ws_connection(profile, state.endpoint.chain_id),
         event_builder.(provider_id)
       )
     end
 
     Phoenix.PubSub.broadcast(
       Lasso.PubSub,
-      "ws:conn:instance:#{state.instance_id}",
+      Lasso.Topics.ws_conn_instance(state.instance_id),
       event_builder.(state.instance_id)
     )
   end
@@ -1438,21 +1434,21 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   defp broadcast_subscription_event(state, sub_id, payload, received_at) do
     Phoenix.PubSub.broadcast(
       Lasso.PubSub,
-      "ws:subs:instance:#{state.instance_id}",
+      Lasso.Topics.ws_subs_instance(state.instance_id),
       {:subscription_event, state.instance_id, sub_id, payload, received_at}
     )
   end
 
   defp profile_provider_refs(%{
          profile: @shared_profile,
-         chain_name: chain_name,
+         endpoint: %Endpoint{chain_id: chain_id},
          instance_id: instance_id
        }) do
     case Catalog.get_instance_refs(instance_id) do
       refs when is_list(refs) and refs != [] ->
         Enum.map(refs, fn profile ->
           provider_id =
-            Catalog.reverse_lookup_provider_id(profile, chain_name, instance_id) || instance_id
+            Catalog.reverse_lookup_provider_id(profile, chain_id, instance_id) || instance_id
 
           {profile, provider_id}
         end)
@@ -1483,13 +1479,6 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
       {:error, _} = err ->
         err
-    end
-  end
-
-  defp resolve_chain_id(chain_name) do
-    case ConfigStore.get_chain("public", chain_name) do
-      {:ok, chain} when is_integer(chain.chain_id) -> chain.chain_id
-      _ -> 0
     end
   end
 

--- a/lib/lasso/core/transport/websocket/connection.ex
+++ b/lib/lasso/core/transport/websocket/connection.ex
@@ -118,6 +118,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
             get_in(instance, [:canonical_config, :name]) ||
               "Shared WebSocket #{instance_id}",
           ws_url: instance.ws_url,
+          headers: Map.get(instance, :headers, []),
           chain_id: instance.chain_id
         }
 
@@ -1117,7 +1118,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     # Start a separate WebSocket handler process
     # Pass connection_id in opts for test-mode failure injection (MockWSClient)
     # WebSockex ignores unknown opts, so this is safe for production
-    opts = [connection_id: endpoint.id]
+    opts = [connection_id: endpoint.id, extra_headers: endpoint.headers]
 
     case ws_client().start_link(
            endpoint.ws_url,

--- a/lib/lasso/core/transport/websocket/endpoint.ex
+++ b/lib/lasso/core/transport/websocket/endpoint.ex
@@ -6,6 +6,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Endpoint do
   than HTTP endpoints. This struct includes WebSocket-specific configuration.
   """
 
+  @derive {Inspect, except: [:headers]}
   @type t :: %__MODULE__{
           profile: String.t() | nil,
           id: String.t(),
@@ -15,6 +16,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Endpoint do
 
           # WebSocket specific fields
           ws_url: String.t(),
+          headers: [{String.t(), String.t()}],
           reconnect_interval: non_neg_integer(),
           heartbeat_interval: non_neg_integer(),
           max_reconnect_attempts: non_neg_integer() | :infinity,
@@ -30,6 +32,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Endpoint do
     :chain_id,
     :chain_name,
     :ws_url,
+    headers: [],
 
     # WebSocket specific fields
     reconnect_interval: 5_000,

--- a/lib/lasso/core/transport/websocket/websocket.ex
+++ b/lib/lasso/core/transport/websocket/websocket.ex
@@ -33,7 +33,7 @@ defmodule Lasso.RPC.Transports.WebSocket do
   def open(provider_config, opts \\ []) do
     provider_id = Keyword.get(opts, :provider_id, Map.get(provider_config, :id, "unknown"))
     profile = Keyword.get(opts, :profile, Map.get(provider_config, :profile))
-    chain = Keyword.get(opts, :chain, Map.get(provider_config, :chain))
+    chain_id = Keyword.get(opts, :chain_id, Map.get(provider_config, :chain_id))
 
     case get_ws_url(provider_config) do
       nil ->
@@ -44,7 +44,7 @@ defmodule Lasso.RPC.Transports.WebSocket do
          )}
 
       ws_url ->
-        instance_id = resolve_instance_id(profile, chain, provider_id)
+        instance_id = resolve_instance_id(profile, chain_id, provider_id)
 
         connection_pid =
           GenServer.whereis(WSConnection.via_instance_name(instance_id))
@@ -60,7 +60,7 @@ defmodule Lasso.RPC.Transports.WebSocket do
           connection_pid when is_pid(connection_pid) ->
             channel = %{
               profile: profile,
-              chain: chain,
+              chain_id: chain_id,
               ws_url: ws_url,
               provider_id: provider_id,
               instance_id: instance_id,
@@ -92,18 +92,17 @@ defmodule Lasso.RPC.Transports.WebSocket do
 
   @impl true
   def request(channel, rpc_request, timeout \\ 30_000) do
-    %{profile: profile, chain: chain, provider_id: provider_id} = channel
+    %{profile: profile, chain_id: chain_id, provider_id: provider_id} = channel
 
     method = Map.get(rpc_request, "method")
     params = Map.get(rpc_request, "params", [])
     request_id = Map.get(rpc_request, "id")
 
-    # Start timing for I/O latency measurement
     io_start_us = System.monotonic_time(:microsecond)
 
     result =
       case WSConnection.request(
-             resolve_instance_id(profile, chain, provider_id),
+             resolve_instance_id(profile, chain_id, provider_id),
              method,
              params,
              timeout,
@@ -140,7 +139,7 @@ defmodule Lasso.RPC.Transports.WebSocket do
 
   @impl true
   def subscribe(channel, rpc_request, handler_pid) when is_pid(handler_pid) do
-    %{profile: profile, chain: chain, provider_id: provider_id} = channel
+    %{profile: profile, chain_id: chain_id, provider_id: provider_id} = channel
 
     method = Map.get(rpc_request, "method")
     params = Map.get(rpc_request, "params", [])
@@ -148,7 +147,7 @@ defmodule Lasso.RPC.Transports.WebSocket do
     case method do
       "eth_subscribe" ->
         case WSConnection.request(
-               resolve_instance_id(profile, chain, provider_id),
+               resolve_instance_id(profile, chain_id, provider_id),
                method,
                params,
                30_000

--- a/lib/lasso/events/routing_decision.ex
+++ b/lib/lasso/events/routing_decision.ex
@@ -2,8 +2,7 @@ defmodule Lasso.Events.RoutingDecision do
   @moduledoc """
   Typed struct for routing decision events.
 
-  Published to profile-scoped PubSub topics to enable multi-tenant
-  dashboard subscriptions without cross-tenant data leakage.
+  Published to profile-scoped PubSub topics for the read-only dashboard.
 
   ## Event Source Fields
 
@@ -17,11 +16,10 @@ defmodule Lasso.Events.RoutingDecision do
   @type t :: %__MODULE__{
           ts: pos_integer(),
           request_id: String.t(),
-          account_id: String.t() | nil,
           profile: String.t(),
           source_node: node(),
           source_node_id: String.t(),
-          chain: String.t(),
+          chain_id: pos_integer(),
           method: String.t(),
           strategy: String.t(),
           provider_id: String.t(),
@@ -35,11 +33,10 @@ defmodule Lasso.Events.RoutingDecision do
   defstruct [
     :ts,
     :request_id,
-    :account_id,
     :profile,
     :source_node,
     :source_node_id,
-    :chain,
+    :chain_id,
     :method,
     :strategy,
     :provider_id,
@@ -58,11 +55,10 @@ defmodule Lasso.Events.RoutingDecision do
     %__MODULE__{
       ts: attrs[:ts] || System.system_time(:millisecond),
       request_id: attrs[:request_id],
-      account_id: attrs[:account_id],
       profile: attrs[:profile] || ProfileValidator.default_profile(),
       source_node: node(),
       source_node_id: get_source_node_id(),
-      chain: attrs[:chain],
+      chain_id: attrs[:chain_id],
       method: attrs[:method],
       strategy: to_string(attrs[:strategy]),
       provider_id: attrs[:provider_id],

--- a/lib/lasso/logging.ex
+++ b/lib/lasso/logging.ex
@@ -1,0 +1,42 @@
+defmodule Lasso.Logging do
+  @moduledoc """
+  Logging helpers shared across the codebase.
+
+  Profile identity in logs and telemetry events should always carry
+  both the opaque routing key (`profile_id`, stable across rename) and
+  the user-facing `profile_slug` (current display value). Callers use
+  `profile_metadata/1` to derive the merged keyword list from a
+  `profile_id`.
+  """
+
+  alias Lasso.Config.{ConfigStore, ProfileMeta}
+
+  @doc """
+  Returns Logger/telemetry metadata for a profile.
+
+  Accepts either a `profile_id` (string), a `ProfileMeta` struct, or a
+  spec map carrying `profile_id`, `slug`, and `name`. The string form
+  reads display fields from `ConfigStore` and falls back to just
+  `profile_id` if the profile is no longer addressable (e.g. mid-removal).
+  Struct/map forms read directly — useful during inject when the profile
+  is not yet in `ConfigStore`.
+  """
+  @spec profile_metadata(ConfigStore.profile_id() | ProfileMeta.t() | map()) :: keyword()
+  def profile_metadata(profile_id) when is_binary(profile_id) do
+    base = [profile_id: profile_id]
+
+    case ConfigStore.get_profile(profile_id) do
+      {:ok, %ProfileMeta{slug: slug, name: name}} ->
+        Keyword.merge(base, profile_slug: slug, profile_name: name)
+
+      {:error, :not_found} ->
+        base
+    end
+  end
+
+  def profile_metadata(%ProfileMeta{profile_id: profile_id, slug: slug, name: name}),
+    do: [profile_id: profile_id, profile_slug: slug, profile_name: name]
+
+  def profile_metadata(%{profile_id: profile_id, slug: slug, name: name}),
+    do: [profile_id: profile_id, profile_slug: slug, profile_name: name]
+end

--- a/lib/lasso/observability/observability.ex
+++ b/lib/lasso/observability/observability.ex
@@ -16,6 +16,7 @@ defmodule Lasso.RPC.Observability do
   """
 
   require Logger
+  alias Lasso.Config.ChainAlias
   alias Lasso.RPC.RequestContext
 
   @default_config [
@@ -71,7 +72,7 @@ defmodule Lasso.RPC.Observability do
       version: "1.0",
       request_id: ctx.request_id,
       strategy: to_string(ctx.strategy),
-      chain: ctx.chain,
+      chain_id: ctx.chain_id,
       transport: to_string(ctx.transport),
       candidate_providers: format_candidate_providers(ctx.candidate_providers),
       selected_provider: ctx.selected_provider,
@@ -112,7 +113,7 @@ defmodule Lasso.RPC.Observability do
       event: "rpc.request.completed",
       request_id: ctx.request_id,
       strategy: to_string(ctx.strategy),
-      chain: ctx.chain,
+      chain_id: ctx.chain_id,
       transport: to_string(ctx.transport),
       jsonrpc_method: ctx.method,
       params_present: ctx.params != [] and not is_nil(ctx.params)
@@ -180,6 +181,7 @@ defmodule Lasso.RPC.Observability do
 
     retry_str = if ctx.retries > 0, do: " retries=#{ctx.retries}", else: ""
     batch_str = if batch_size, do: " batch=#{batch_size}", else: ""
+    chain = chain_label(ctx.chain_id)
 
     case ctx.status do
       :success ->
@@ -190,7 +192,7 @@ defmodule Lasso.RPC.Observability do
             ""
           end
 
-        "RPC [#{ctx.chain}] #{ctx.method} -> #{provider}#{latency_str}#{retry_str}#{batch_str} OK#{result_info}"
+        "RPC [#{chain}] #{ctx.method} -> #{provider}#{latency_str}#{retry_str}#{batch_str} OK#{result_info}"
 
       :error ->
         error_msg =
@@ -199,12 +201,17 @@ defmodule Lasso.RPC.Observability do
             _ -> ""
           end
 
-        "RPC [#{ctx.chain}] #{ctx.method} -> #{provider}#{latency_str}#{retry_str}#{batch_str} ERR#{error_msg}"
+        "RPC [#{chain}] #{ctx.method} -> #{provider}#{latency_str}#{retry_str}#{batch_str} ERR#{error_msg}"
 
       _ ->
-        "RPC [#{ctx.chain}] #{ctx.method} -> #{provider}#{retry_str}#{batch_str}"
+        "RPC [#{chain}] #{ctx.method} -> #{provider}#{retry_str}#{batch_str}"
     end
   end
+
+  defp chain_label(chain_id) when is_integer(chain_id) and chain_id > 0,
+    do: ChainAlias.canonical_slug(chain_id)
+
+  defp chain_label(_), do: "unknown"
 
   # Format timing in compact notation: (e2e: 45ms, io: 40ms)
   defp format_compact_timing(ctx) do

--- a/lib/lasso/profile_chain_supervisor.ex
+++ b/lib/lasso/profile_chain_supervisor.ex
@@ -2,32 +2,9 @@ defmodule Lasso.ProfileChainSupervisor do
   @moduledoc """
   DynamicSupervisor for profile-scoped chain instances.
 
-  Manages ChainSupervisor processes for each (profile, chain) pair. Each profile
+  Manages ChainSupervisor processes for each (profile, chain_id) pair. Each profile
   gets its own set of chain supervisors with full isolation. All components
-  (BlockSync, WebSocket connections) are scoped per (profile, chain).
-
-  ## Architecture
-
-  ```
-  ProfileChainSupervisor (DynamicSupervisor)
-  ├── ChainSupervisor {default, ethereum}
-  ├── ChainSupervisor {default, polygon}
-  ├── ChainSupervisor {premium, ethereum}
-  └── ChainSupervisor {premium, arbitrum}
-  ```
-
-  ## Usage
-
-  ```elixir
-  # Start a chain for a profile
-  ProfileChainSupervisor.start_profile_chain("managed", "ethereum", chain_config)
-
-  # Stop a chain for a profile
-  ProfileChainSupervisor.stop_profile_chain("managed", "ethereum")
-
-  # List all chains for a profile
-  ProfileChainSupervisor.list_profile_chains("managed")
-  ```
+  (BlockSync, WebSocket connections) are scoped per (profile, chain_id).
   """
 
   use DynamicSupervisor
@@ -43,21 +20,21 @@ defmodule Lasso.ProfileChainSupervisor do
   @doc """
   Start a ChainSupervisor for a specific profile and chain.
 
-  Creates a complete supervisor tree for the (profile, chain) pair, including
+  Creates a complete supervisor tree for the (profile, chain_id) pair, including
   all providers, BlockSync, HealthProbe, and subscription management.
 
   Returns `{:ok, pid}` on success or `{:error, reason}` on failure.
   """
-  @spec start_profile_chain(String.t(), String.t(), map()) :: {:ok, pid()} | {:error, term()}
-  def start_profile_chain(profile, chain_name, chain_config)
-      when is_binary(profile) and is_binary(chain_name) do
-    spec = {Lasso.RPC.ChainSupervisor, {profile, chain_name, chain_config}}
+  @spec start_profile_chain(String.t(), pos_integer(), map()) :: {:ok, pid()} | {:error, term()}
+  def start_profile_chain(profile_id, chain_id, chain_config)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    spec = {Lasso.RPC.ChainSupervisor, {profile_id, chain_id, chain_config}}
 
     case DynamicSupervisor.start_child(__MODULE__, spec) do
       {:ok, pid} ->
-        Logger.info("Started chain supervisor",
-          profile: profile,
-          chain: chain_name
+        Logger.info(
+          "Started chain supervisor",
+          Lasso.Logging.profile_metadata(profile_id) ++ [chain_id: chain_id]
         )
 
         {:ok, pid}
@@ -66,10 +43,10 @@ defmodule Lasso.ProfileChainSupervisor do
         {:ok, pid}
 
       {:error, reason} = error ->
-        Logger.error("Failed to start chain supervisor",
-          profile: profile,
-          chain: chain_name,
-          reason: inspect(reason)
+        Logger.error(
+          "Failed to start chain supervisor",
+          Lasso.Logging.profile_metadata(profile_id) ++
+            [chain_id: chain_id, reason: inspect(reason)]
         )
 
         error
@@ -81,19 +58,19 @@ defmodule Lasso.ProfileChainSupervisor do
 
   This gracefully terminates the chain supervisor and all its children.
   """
-  @spec stop_profile_chain(String.t(), String.t()) :: :ok
-  def stop_profile_chain(profile, chain_name)
-      when is_binary(profile) and is_binary(chain_name) do
-    case GenServer.whereis(chain_supervisor_via(profile, chain_name)) do
+  @spec stop_profile_chain(String.t(), pos_integer()) :: :ok
+  def stop_profile_chain(profile_id, chain_id)
+      when is_binary(profile_id) and is_integer(chain_id) and chain_id > 0 do
+    case GenServer.whereis(chain_supervisor_via(profile_id, chain_id)) do
       nil ->
         :ok
 
       pid ->
         case DynamicSupervisor.terminate_child(__MODULE__, pid) do
           :ok ->
-            Logger.info("Stopped chain supervisor",
-              profile: profile,
-              chain: chain_name
+            Logger.info(
+              "Stopped chain supervisor",
+              Lasso.Logging.profile_metadata(profile_id) ++ [chain_id: chain_id]
             )
 
             :ok
@@ -102,10 +79,10 @@ defmodule Lasso.ProfileChainSupervisor do
             :ok
 
           {:error, reason} ->
-            Logger.warning("Failed to terminate chain supervisor",
-              profile: profile,
-              chain: chain_name,
-              reason: inspect(reason)
+            Logger.warning(
+              "Failed to terminate chain supervisor",
+              Lasso.Logging.profile_metadata(profile_id) ++
+                [chain_id: chain_id, reason: inspect(reason)]
             )
 
             {:error, reason}
@@ -114,16 +91,14 @@ defmodule Lasso.ProfileChainSupervisor do
   end
 
   @doc """
-  List all running chain supervisors for a profile.
-
-  Returns a list of chain names that have running supervisors for the profile.
+  List all running chain_ids that have running supervisors for a profile.
   """
-  @spec list_profile_chains(String.t()) :: [String.t()]
+  @spec list_profile_chains(String.t()) :: [pos_integer()]
   def list_profile_chains(profile) when is_binary(profile) do
     DynamicSupervisor.which_children(__MODULE__)
     |> Enum.flat_map(fn {_, pid, _, _} ->
       case Registry.keys(Lasso.Registry, pid) do
-        [{:chain_supervisor, ^profile, chain_name}] -> [chain_name]
+        [{:chain_supervisor, ^profile, chain_id}] -> [chain_id]
         _ -> []
       end
     end)
@@ -132,14 +107,14 @@ defmodule Lasso.ProfileChainSupervisor do
   @doc """
   List all running profile-chain pairs.
 
-  Returns a list of `{profile, chain_name}` tuples.
+  Returns a list of `{profile, chain_id}` tuples.
   """
-  @spec list_all() :: [{String.t(), String.t()}]
+  @spec list_all() :: [{String.t(), pos_integer()}]
   def list_all do
     DynamicSupervisor.which_children(__MODULE__)
     |> Enum.flat_map(fn {_, pid, _, _} ->
       case Registry.keys(Lasso.Registry, pid) do
-        [{:chain_supervisor, profile, chain_name}] -> [{profile, chain_name}]
+        [{:chain_supervisor, profile, chain_id}] -> [{profile, chain_id}]
         _ -> []
       end
     end)
@@ -148,9 +123,10 @@ defmodule Lasso.ProfileChainSupervisor do
   @doc """
   Check if a chain supervisor is running for a profile.
   """
-  @spec running?(String.t(), String.t()) :: boolean()
-  def running?(profile, chain_name) do
-    GenServer.whereis(chain_supervisor_via(profile, chain_name)) != nil
+  @spec running?(String.t(), pos_integer()) :: boolean()
+  def running?(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.whereis(chain_supervisor_via(profile, chain_id)) != nil
   end
 
   ## DynamicSupervisor Callbacks
@@ -162,7 +138,7 @@ defmodule Lasso.ProfileChainSupervisor do
 
   ## Private Functions
 
-  defp chain_supervisor_via(profile, chain_name) do
-    {:via, Registry, {Lasso.Registry, {:chain_supervisor, profile, chain_name}}}
+  defp chain_supervisor_via(profile, chain_id) do
+    {:via, Registry, {Lasso.Registry, {:chain_supervisor, profile, chain_id}}}
   end
 end

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -2,7 +2,7 @@ defmodule Lasso.Providers.CandidateListing do
   @moduledoc """
   Pure ETS reads for provider candidate selection.
 
-  Implements an 8-stage filter pipeline using shared ETS state:
+  Implements a 9-stage filter pipeline using shared ETS state:
   1. Transport availability (provider config has url/ws_url)
   2. WS liveness (channel cache for WS presence)
   3. Circuit breaker state
@@ -10,7 +10,8 @@ defmodule Lasso.Providers.CandidateListing do
   5. Lag filtering (BlockSync.Registry + ChainState)
   6. Min block height filtering (block-height-aware routing)
   7. Archival filtering
-  8. Exclude list
+  8. `subscribe_new_heads` capability filtering (newHeads-only)
+  9. Exclude list
 
   Return shape: `%{id, config, availability, circuit_state, rate_limited}`.
   """
@@ -22,40 +23,43 @@ defmodule Lasso.Providers.CandidateListing do
   alias Lasso.RPC.SelectionFilters
 
   @doc """
-  Lists provider candidates for a (profile, chain) pair, filtered by selection criteria.
+  Lists provider candidates for a (profile, chain_id) pair, filtered by selection criteria.
   """
-  @spec list_candidates(String.t(), String.t(), SelectionFilters.t() | map()) :: [map()]
-  def list_candidates(profile, chain, %SelectionFilters{} = filters) do
-    list_candidates(profile, chain, SelectionFilters.to_map(filters))
+  @spec list_candidates(String.t(), pos_integer(), SelectionFilters.t() | map()) :: [map()]
+  def list_candidates(profile, chain_id, %SelectionFilters{} = filters) do
+    list_candidates(profile, chain_id, SelectionFilters.to_map(filters))
   end
 
-  def list_candidates(profile, chain, filters) when is_map(filters) do
+  def list_candidates(profile, chain_id, filters)
+      when is_map(filters) and is_integer(chain_id) and chain_id > 0 do
     protocol = Map.get(filters, :protocol)
     include_half_open = Map.get(filters, :include_half_open, false)
 
-    profile_providers = Catalog.get_profile_providers(profile, chain)
+    profile_providers = Catalog.get_profile_providers(profile, chain_id)
 
     profile_providers
     |> Enum.map(&build_candidate/1)
     |> Enum.filter(fn c ->
-      transport_available?(c, protocol, profile, chain) and
+      transport_available?(c, protocol, profile, chain_id) and
         circuit_breaker_ready?(c, protocol, include_half_open) and
         rate_limit_ok?(c, protocol, filters)
     end)
-    |> filter_by_lag(profile, chain, Map.get(filters, :max_lag_blocks))
-    |> filter_by_min_block(profile, chain, Map.get(filters, :min_block))
+    |> filter_by_lag(profile, chain_id, Map.get(filters, :max_lag_blocks))
+    |> filter_by_min_block(profile, chain_id, Map.get(filters, :min_block))
     |> filter_by_archival(Map.get(filters, :requires_archival))
+    |> filter_by_subscribe_new_heads(Map.get(filters, :requires_subscribe_new_heads))
     |> filter_excluded(filters)
   end
 
   @doc """
-  Returns the minimum recovery time across all open circuits for a (profile, chain) pair.
+  Returns the minimum recovery time across all open circuits for a (profile, chain_id) pair.
   """
-  @spec get_min_recovery_time(String.t(), String.t(), keyword()) ::
+  @spec get_min_recovery_time(String.t(), pos_integer(), keyword()) ::
           {:ok, non_neg_integer() | nil} | {:error, term()}
-  def get_min_recovery_time(profile, chain, opts \\ []) do
+  def get_min_recovery_time(profile, chain_id, opts \\ [])
+      when is_integer(chain_id) and chain_id > 0 do
     transport_filter = Keyword.get(opts, :transport, :both)
-    profile_providers = Catalog.get_profile_providers(profile, chain)
+    profile_providers = Catalog.get_profile_providers(profile, chain_id)
     now_ms = System.monotonic_time(:millisecond)
 
     times =
@@ -103,6 +107,7 @@ defmodule Lasso.Providers.CandidateListing do
       priority: profile_provider.priority,
       capabilities: profile_provider.capabilities,
       archival: profile_provider.archival,
+      subscribe_new_heads: Map.get(profile_provider, :subscribe_new_heads, false),
       name: profile_provider[:name] || profile_provider.provider_id
     }
 
@@ -121,7 +126,7 @@ defmodule Lasso.Providers.CandidateListing do
     }
   end
 
-  defp transport_available?(candidate, protocol, profile, chain) do
+  defp transport_available?(candidate, protocol, profile, chain_id) do
     config = candidate.config
 
     case protocol do
@@ -129,19 +134,19 @@ defmodule Lasso.Providers.CandidateListing do
         is_binary(config.url)
 
       :ws ->
-        is_binary(config.ws_url) and ws_channel_live?(profile, chain, candidate.id)
+        is_binary(config.ws_url) and ws_channel_live?(profile, chain_id, candidate.id)
 
       :both ->
         is_binary(config.url) or
-          (is_binary(config.ws_url) and ws_channel_live?(profile, chain, candidate.id))
+          (is_binary(config.ws_url) and ws_channel_live?(profile, chain_id, candidate.id))
 
       nil ->
         is_binary(config.url) or is_binary(config.ws_url)
     end
   end
 
-  defp ws_channel_live?(profile, chain, provider_id) do
-    case :ets.lookup(:transport_channel_cache, {profile, chain, provider_id, :ws}) do
+  defp ws_channel_live?(profile, chain_id, provider_id) do
+    case :ets.lookup(:transport_channel_cache, {profile, chain_id, provider_id, :ws}) do
       [{_, _channel}] -> true
       [] -> false
     end
@@ -188,15 +193,19 @@ defmodule Lasso.Providers.CandidateListing do
     end
   end
 
-  defp filter_by_lag(candidates, _profile, _chain, nil), do: candidates
+  defp filter_by_lag(candidates, _profile, _chain_id, nil), do: candidates
 
-  defp filter_by_lag(candidates, profile, chain, max_lag_blocks)
+  defp filter_by_lag(candidates, profile, chain_id, max_lag_blocks)
        when is_integer(max_lag_blocks) do
-    block_time_ms = LagCalculation.get_block_time_ms(chain, profile)
+    block_time_ms = LagCalculation.get_block_time_ms(chain_id, profile)
 
     filtered =
       Enum.filter(candidates, fn candidate ->
-        case LagCalculation.calculate_optimistic_lag(chain, candidate.instance_id, block_time_ms) do
+        case LagCalculation.calculate_optimistic_lag(
+               chain_id,
+               candidate.instance_id,
+               block_time_ms
+             ) do
           {:ok, optimistic_lag, _raw_lag} -> optimistic_lag >= -max_lag_blocks
           {:error, _} -> true
         end
@@ -204,21 +213,21 @@ defmodule Lasso.Providers.CandidateListing do
 
     if candidates != [] and filtered == [] do
       Logger.warning(
-        "All providers for #{chain} excluded due to lag (threshold: -#{max_lag_blocks} blocks)"
+        "All providers for chain_id #{chain_id} excluded due to lag (threshold: -#{max_lag_blocks} blocks)"
       )
     end
 
     filtered
   end
 
-  defp filter_by_min_block(candidates, _profile, _chain, nil), do: candidates
+  defp filter_by_min_block(candidates, _profile, _chain_id, nil), do: candidates
 
-  defp filter_by_min_block(candidates, profile, chain, min_block) when is_integer(min_block) do
-    block_time_ms = LagCalculation.get_block_time_ms(chain, profile)
+  defp filter_by_min_block(candidates, profile, chain_id, min_block) when is_integer(min_block) do
+    block_time_ms = LagCalculation.get_block_time_ms(chain_id, profile)
 
     {capable, rest} =
       Enum.split_with(candidates, fn candidate ->
-        case BlockSyncRegistry.get_height(chain, candidate.instance_id) do
+        case BlockSyncRegistry.get_height(chain_id, candidate.instance_id) do
           {:ok, {height, timestamp, _source, _meta}} ->
             elapsed_ms = System.system_time(:millisecond) - timestamp
             staleness_credit = if block_time_ms > 0, do: div(elapsed_ms, block_time_ms), else: 0
@@ -239,6 +248,12 @@ defmodule Lasso.Providers.CandidateListing do
   end
 
   defp filter_by_archival(candidates, _), do: candidates
+
+  defp filter_by_subscribe_new_heads(candidates, true) do
+    Enum.filter(candidates, fn c -> c.config.subscribe_new_heads == true end)
+  end
+
+  defp filter_by_subscribe_new_heads(candidates, _), do: candidates
 
   defp filter_excluded(candidates, filters) do
     case Map.get(filters, :exclude) do

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -33,7 +33,7 @@ defmodule Lasso.Providers.Catalog do
   require Logger
 
   alias Lasso.Config.{ChainConfig, ConfigStore}
-  alias Lasso.Providers.InstanceId
+  alias Lasso.Providers.{InstanceId, ProviderHeaders}
 
   @persistent_term_key :lasso_catalog_active
 
@@ -253,6 +253,8 @@ defmodule Lasso.Providers.Catalog do
       block_time_ms: chain_config.block_time_ms,
       url: provider.url,
       ws_url: provider.ws_url,
+      headers: ProviderHeaders.build(provider),
+      mock?: provider.__mock__ == true,
       canonical_config: %{
         id: provider.id,
         name: provider.name,

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -7,11 +7,21 @@ defmodule Lasso.Providers.Catalog do
 
   ## ETS Key Structure
 
-      {:instance, instance_id}                                -> %{chain, url, ws_url, archival, canonical_config}
-      {:profile_providers, profile, chain}                    -> [%{instance_id, provider_id, priority, capabilities, archival}]
-      {:instance_refs, instance_id}                           -> [profile]
-      {:provider_instance_id, profile, chain, provider_id}    -> instance_id (reverse index for O(1) lookup)
-      {:chain_instances, chain}                               -> [instance_id] (all instances for a chain)
+      {:instance, instance_id}                                   -> %{chain_id, url, ws_url, canonical_config}
+      {:profile_providers, profile, chain_id}                    -> [%{instance_id, provider_id, priority, capabilities, archival, subscribe_new_heads}]
+
+  Capabilities (archival, subscribe_new_heads, etc.) are profile-scoped and
+  live only on `{:profile_providers, p, chain_id}`. The same upstream URL can be
+  classified differently by different profiles, so capabilities must never
+  be read from the shared `{:instance, id}` entry.
+      {:instance_refs, instance_id}                              -> [profile]
+      {:provider_instance_id, profile, chain_id, provider_id}   -> instance_id (reverse index for O(1) lookup)
+      {:chain_instances, chain_id}                               -> [instance_id] (all instances for a chain)
+
+  All chain keys use `chain_id :: pos_integer()` (EIP-155 integer). Instance identity
+  is derived from the normalized HTTP URL, normalized WS URL, chain_id, and auth scope;
+  catalog writes refuse to overwrite an existing instance row with divergent endpoint
+  URLs for the same derived ID.
 
   ## Concurrency
 
@@ -20,11 +30,12 @@ defmodule Lasso.Providers.Catalog do
   The old table is deleted after a grace period to cover in-flight reads.
   """
 
-  alias Lasso.Config.ConfigStore
+  require Logger
+
+  alias Lasso.Config.{ChainConfig, ConfigStore}
   alias Lasso.Providers.InstanceId
 
   @persistent_term_key :lasso_catalog_active
-  @grace_period_ms 2_000
 
   @doc """
   Atomically rebuilds the catalog from ConfigStore.
@@ -34,23 +45,35 @@ defmodule Lasso.Providers.Catalog do
   """
   @spec build_from_config() :: :ok
   def build_from_config do
-    new_table =
-      :ets.new(:lasso_provider_catalog, [
-        :public,
-        :set,
-        read_concurrency: true
-      ])
+    Lasso.Providers.Catalog.Owner.rebuild()
+  end
 
+  @doc """
+  Populates a freshly-created ETS table with catalog entries derived
+  from current `ConfigStore` state.
+
+  Called by `Lasso.Providers.Catalog.Owner` from inside the owner
+  GenServer so the table belongs to a long-lived process. External
+  callers should use `build_from_config/0`.
+  """
+  @spec populate(:ets.tid()) :: :ok
+  def populate(new_table) do
     profiles = ConfigStore.list_profiles()
 
     chain_instances_acc =
       Enum.reduce(profiles, %{}, fn profile, acc ->
-        chains = ConfigStore.list_chains_for_profile(profile)
+        chain_ids = ConfigStore.list_chains_for_profile(profile)
 
-        Enum.reduce(chains, acc, fn chain, chain_acc ->
-          case ConfigStore.get_chain(profile, chain) do
+        Enum.reduce(chain_ids, acc, fn chain_id, chain_acc ->
+          case ConfigStore.get_chain(profile, chain_id) do
             {:ok, chain_config} ->
-              build_chain_entries(new_table, profile, chain, chain_config, chain_acc)
+              build_chain_entries(
+                new_table,
+                profile,
+                chain_id,
+                chain_config,
+                chain_acc
+              )
 
             {:error, _} ->
               chain_acc
@@ -58,24 +81,19 @@ defmodule Lasso.Providers.Catalog do
         end)
       end)
 
-    Enum.each(chain_instances_acc, fn {chain, instance_ids} ->
-      :ets.insert(new_table, {{:chain_instances, chain}, Enum.uniq(instance_ids)})
+    Enum.each(chain_instances_acc, fn {chain_id, instance_ids} ->
+      :ets.insert(new_table, {{:chain_instances, chain_id}, Enum.uniq(instance_ids)})
     end)
-
-    old_table =
-      case :persistent_term.get(@persistent_term_key, :not_set) do
-        :not_set -> nil
-        table -> table
-      end
-
-    :persistent_term.put(@persistent_term_key, new_table)
-
-    if old_table do
-      schedule_table_deletion(old_table)
-    end
 
     :ok
   end
+
+  @doc false
+  # The `:persistent_term` key under which the active catalog ETS table
+  # reference is published. Public so `Catalog.Owner` can swap it; not
+  # part of the external API.
+  @spec persistent_term_key() :: atom()
+  def persistent_term_key, do: @persistent_term_key
 
   @doc """
   Gets instance config by instance_id.
@@ -102,20 +120,20 @@ defmodule Lasso.Providers.Catalog do
   @doc """
   Gets the provider list for a profile+chain with instance_id cross-references.
   """
-  @spec get_profile_providers(String.t(), String.t()) :: [map()]
-  def get_profile_providers(profile, chain) do
-    case safe_lookup({:profile_providers, profile, chain}) do
+  @spec get_profile_providers(String.t(), pos_integer()) :: [map()]
+  def get_profile_providers(profile, chain_id) do
+    case safe_lookup({:profile_providers, profile, chain_id}) do
       [{_, providers}] -> providers
       _ -> []
     end
   end
 
   @doc """
-  Resolves (profile, chain, provider_id) to an instance_id via O(1) ETS lookup.
+  Resolves (profile, chain_id, provider_id) to an instance_id via O(1) ETS lookup.
   """
-  @spec lookup_instance_id(String.t(), String.t(), String.t()) :: String.t() | nil
-  def lookup_instance_id(profile, chain, provider_id) do
-    case safe_lookup({:provider_instance_id, profile, chain, provider_id}) do
+  @spec lookup_instance_id(String.t(), pos_integer(), String.t()) :: String.t() | nil
+  def lookup_instance_id(profile, chain_id, provider_id) do
+    case safe_lookup({:provider_instance_id, profile, chain_id, provider_id}) do
       [{_, instance_id}] -> instance_id
       _ -> nil
     end
@@ -135,21 +153,21 @@ defmodule Lasso.Providers.Catalog do
   @doc """
   Returns all instance_ids for a given chain.
   """
-  @spec list_instances_for_chain(String.t()) :: [String.t()]
-  def list_instances_for_chain(chain) do
-    case safe_lookup({:chain_instances, chain}) do
+  @spec list_instances_for_chain(pos_integer()) :: [String.t()]
+  def list_instances_for_chain(chain_id) do
+    case safe_lookup({:chain_instances, chain_id}) do
       [{_, ids}] -> ids
       _ -> []
     end
   end
 
   @doc """
-  Given (profile, chain, instance_id), returns the provider_id for that profile.
+  Given (profile, chain_id, instance_id), returns the provider_id for that profile.
   """
-  @spec reverse_lookup_provider_id(String.t(), String.t(), String.t()) :: String.t() | nil
-  def reverse_lookup_provider_id(profile, chain, instance_id) do
+  @spec reverse_lookup_provider_id(String.t(), pos_integer(), String.t()) :: String.t() | nil
+  def reverse_lookup_provider_id(profile, chain_id, instance_id) do
     profile
-    |> get_profile_providers(chain)
+    |> get_profile_providers(chain_id)
     |> Enum.find_value(fn
       %{instance_id: ^instance_id, provider_id: pid} -> pid
       _ -> nil
@@ -185,36 +203,31 @@ defmodule Lasso.Providers.Catalog do
     ArgumentError -> []
   end
 
-  defp build_chain_entries(ets_table, profile, chain, chain_config, chain_instances_acc) do
+  defp build_chain_entries(
+         ets_table,
+         profile,
+         chain_id,
+         chain_config,
+         chain_instances_acc
+       ) do
     provider_entries =
       Enum.map(chain_config.providers, fn provider ->
+        subscribe_new_heads =
+          ChainConfig.should_subscribe_new_heads?(chain_config, provider)
+
         instance_id =
-          InstanceId.derive(chain, provider,
-            profile: profile,
+          InstanceId.derive(chain_id, provider,
+            profile_id: profile,
             sharing_mode: provider.sharing_mode
           )
 
-        :ets.insert(ets_table, {
-          {:instance, instance_id},
-          %{
-            chain: chain,
-            url: provider.url,
-            ws_url: provider.ws_url,
-            archival: provider.archival,
-            canonical_config: %{
-              id: provider.id,
-              name: provider.name,
-              url: provider.url,
-              ws_url: provider.ws_url
-            }
-          }
-        })
+        insert_instance_config(ets_table, instance_id, profile, chain_id, chain_config, provider)
 
         update_instance_refs(ets_table, instance_id, profile)
 
         :ets.insert(
           ets_table,
-          {{:provider_instance_id, profile, chain, provider.id}, instance_id}
+          {{:provider_instance_id, profile, chain_id, provider.id}, instance_id}
         )
 
         %{
@@ -223,14 +236,76 @@ defmodule Lasso.Providers.Catalog do
           name: provider.name,
           priority: provider.priority,
           capabilities: provider.capabilities,
-          archival: provider.archival
+          archival: provider.archival,
+          subscribe_new_heads: subscribe_new_heads
         }
       end)
 
-    :ets.insert(ets_table, {{:profile_providers, profile, chain}, provider_entries})
+    :ets.insert(ets_table, {{:profile_providers, profile, chain_id}, provider_entries})
 
     instance_ids = Enum.map(provider_entries, & &1.instance_id)
-    Map.update(chain_instances_acc, chain, instance_ids, &(&1 ++ instance_ids))
+    Map.update(chain_instances_acc, chain_id, instance_ids, &(&1 ++ instance_ids))
+  end
+
+  defp insert_instance_config(ets_table, instance_id, profile, chain_id, chain_config, provider) do
+    config = %{
+      chain_id: chain_id,
+      block_time_ms: chain_config.block_time_ms,
+      url: provider.url,
+      ws_url: provider.ws_url,
+      canonical_config: %{
+        id: provider.id,
+        name: provider.name,
+        url: provider.url,
+        ws_url: provider.ws_url
+      }
+    }
+
+    case :ets.lookup(ets_table, {:instance, instance_id}) do
+      [] ->
+        :ets.insert(ets_table, {{:instance, instance_id}, config})
+
+      [{_, existing}] ->
+        if endpoint_identity_match?(existing, config) do
+          :ok
+        else
+          emit_identity_collision(instance_id, profile, chain_id, provider, existing, config)
+        end
+    end
+  end
+
+  defp endpoint_identity_match?(existing, new) do
+    normalize_endpoint_url(existing.url) == normalize_endpoint_url(new.url) and
+      normalize_endpoint_url(Map.get(existing, :ws_url)) ==
+        normalize_endpoint_url(Map.get(new, :ws_url))
+  end
+
+  defp normalize_endpoint_url(url), do: InstanceId.optional_normalize_url(url)
+
+  defp emit_identity_collision(instance_id, profile, chain_id, provider, existing, new) do
+    Logger.error("Provider instance identity collision; keeping existing catalog entry",
+      instance_id: instance_id,
+      profile: profile,
+      chain_id: chain_id,
+      provider_id: provider.id,
+      existing_url: Lasso.URLMask.mask(existing.url),
+      existing_ws_url: Lasso.URLMask.mask(Map.get(existing, :ws_url)),
+      new_url: Lasso.URLMask.mask(new.url),
+      new_ws_url: Lasso.URLMask.mask(Map.get(new, :ws_url))
+    )
+
+    :telemetry.execute(
+      [:lasso, :provider_catalog, :identity_collision],
+      %{count: 1},
+      %{
+        instance_id: instance_id,
+        chain_id: chain_id,
+        profile: profile,
+        provider_id: provider.id
+      }
+    )
+
+    :ok
   end
 
   defp update_instance_refs(ets_table, instance_id, profile) do
@@ -243,17 +318,5 @@ defmodule Lasso.Providers.Catalog do
     unless profile in current_refs do
       :ets.insert(ets_table, {{:instance_refs, instance_id}, [profile | current_refs]})
     end
-  end
-
-  defp schedule_table_deletion(old_table) do
-    Task.start(fn ->
-      Process.sleep(@grace_period_ms)
-
-      try do
-        :ets.delete(old_table)
-      rescue
-        ArgumentError -> :ok
-      end
-    end)
   end
 end

--- a/lib/lasso/providers/catalog/owner.ex
+++ b/lib/lasso/providers/catalog/owner.ex
@@ -1,0 +1,123 @@
+defmodule Lasso.Providers.Catalog.Owner do
+  @moduledoc """
+  Long-lived owner of the `Lasso.Providers.Catalog` ETS tables.
+
+  Catalog reads stay lockless via `:persistent_term`. Writes (atomic-swap
+  rebuilds) are serialized through this GenServer so that:
+
+    1. The freshly-built ETS table is owned by a stable process. ETS
+       tables die with their owner; without a long-lived owner, callers
+       like test processes or transient Tasks leave `:persistent_term`
+       pointing at a dead tid.
+    2. Old tables can be deleted properly. `:ets.delete/1` requires the
+       calling process to be the owner — only this GenServer satisfies
+       that for tables it created.
+  """
+
+  use GenServer
+  require Logger
+
+  alias Lasso.Providers.{Catalog, RestartCounter}
+
+  @grace_period_ms 2_000
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_opts \\ []) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @doc """
+  Rebuilds the catalog from current `ConfigStore` state.
+
+  Synchronous: the caller blocks until the new table is published.
+  """
+  @spec rebuild() :: :ok
+  def rebuild do
+    GenServer.call(__MODULE__, :rebuild, :infinity)
+  end
+
+  ## GenServer callbacks
+
+  @impl true
+  def init(_) do
+    RestartCounter.init_table()
+    {:ok, %{}, {:continue, :self_heal_catalog}}
+  end
+
+  # If the previous Owner crashed, `:persistent_term` still points at
+  # the dead ETS tid. Reads via `Catalog.safe_lookup/1` would silently
+  # return empty until a profile config change triggers a rebuild —
+  # which can be hours of degraded routing in the worst case. On a
+  # fresh boot (no persistent_term entry) `InfrastructureStarter`
+  # handles the initial population, so this self-heal is a no-op.
+  # Rebuild attempts are tolerated to fail (ConfigStore may not be up
+  # yet on a co-restart) — the InfrastructureStarter path still runs
+  # afterwards on first boot.
+  @impl true
+  def handle_continue(:self_heal_catalog, state) do
+    key = Catalog.persistent_term_key()
+
+    case :persistent_term.get(key, nil) do
+      nil ->
+        :ok
+
+      tid ->
+        try do
+          _ = :ets.info(tid, :size)
+          :ok
+        rescue
+          ArgumentError ->
+            try do
+              do_rebuild()
+              Logger.info("Catalog.Owner self-healed catalog after a crash restart")
+            rescue
+              e ->
+                Logger.warning(
+                  "Catalog.Owner self-heal deferred to InfrastructureStarter: " <>
+                    Exception.message(e)
+                )
+            end
+        end
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_call(:rebuild, _from, state) do
+    do_rebuild()
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info({:delete_table, table}, state) do
+    try do
+      :ets.delete(table)
+    rescue
+      ArgumentError -> :ok
+    end
+
+    {:noreply, state}
+  end
+
+  defp do_rebuild do
+    new_table = :ets.new(:lasso_provider_catalog, [:public, :set, read_concurrency: true])
+
+    try do
+      Catalog.populate(new_table)
+    rescue
+      e ->
+        # Drop the half-built table so it doesn't leak; `:persistent_term`
+        # still points at the previous good table, so readers are unaffected.
+        :ets.delete(new_table)
+        reraise e, __STACKTRACE__
+    end
+
+    key = Catalog.persistent_term_key()
+    old_table = :persistent_term.get(key, nil)
+    :persistent_term.put(key, new_table)
+
+    if old_table, do: Process.send_after(self(), {:delete_table, old_table}, @grace_period_ms)
+    :ok
+  end
+end

--- a/lib/lasso/providers/instance_id.ex
+++ b/lib/lasso/providers/instance_id.ex
@@ -3,10 +3,16 @@ defmodule Lasso.Providers.InstanceId do
   Deterministic identity derivation for physical upstream connections.
 
   A `provider_instance_id` uniquely identifies a physical upstream connection.
-  Two profiles using the same URL with the same credentials produce the same
-  instance_id and will share infrastructure in later phases.
+  Identity is keyed by `(chain_id, normalized_url, normalized_ws_url, auth)`.
+  The optional `:isolated` sharing mode additionally salts the identity with a
+  profile ID; otherwise matching authenticated endpoints are shared across
+  profiles.
 
-  Format: `"chain:host_hint:hash_12"` (e.g., `"ethereum:drpc:a3f2b1c4e5d6"`)
+  Format: `"chain_id:host_hint:hash_12"` (e.g., `"1:drpc:a3f2b1c4e5d6"`).
+
+  HTTP and WebSocket endpoint URLs are both identity-relevant, so profiles with
+  the same HTTP endpoint but different WebSocket configuration do not share an
+  instance.
   """
 
   alias Lasso.Config.ChainConfig.Provider
@@ -16,32 +22,33 @@ defmodule Lasso.Providers.InstanceId do
   @doc """
   Derives a deterministic instance_id for a provider.
 
-  Same URL + same auth + same chain = same instance_id.
-  With `sharing_mode: :isolated`, the profile slug is salted in to force uniqueness.
+  Same `(chain_id, URL, WS URL, auth)` tuple → same instance ID → shared worker.
 
   ## Options
-    * `:profile` - Profile slug (required when `sharing_mode` is `:isolated`)
-    * `:sharing_mode` - `:auto` (default) or `:isolated`
+    * `:profile_id` or `:profile` — deterministic profile scope used when
+      `sharing_mode: :isolated` is set.
+    * `:sharing_mode` — `:auto` shares by transport identity; `:isolated`
+      salts the hash with the profile id and forces per-profile isolation.
   """
-  @spec derive(String.t(), Provider.t(), keyword()) :: String.t()
-  def derive(chain, provider_config, opts \\ []) do
+  @spec derive(pos_integer(), Provider.t(), keyword()) :: String.t()
+  def derive(chain_id, provider_config, opts \\ []) when is_integer(chain_id) and chain_id > 0 do
     sharing_mode = Keyword.get(opts, :sharing_mode, :auto)
-    profile = Keyword.get(opts, :profile)
-
-    if sharing_mode == :isolated and not is_binary(profile) do
-      raise ArgumentError, "profile is required when sharing_mode is :isolated"
-    end
+    profile_id = Keyword.get(opts, :profile_id) || Keyword.get(opts, :profile)
 
     url = normalize_url(provider_config.url)
-    auth_fp = auth_fingerprint(provider_config)
+    ws_url = optional_normalize_url(Map.get(provider_config, :ws_url))
+    auth = auth_fingerprint(provider_config)
 
     hash_input =
-      case sharing_mode do
-        :isolated ->
-          :erlang.term_to_binary({chain, url, auth_fp, profile})
+      cond do
+        sharing_mode == :isolated and is_binary(profile_id) ->
+          :erlang.term_to_binary({chain_id, url, ws_url, auth, {:profile, profile_id}})
 
-        _ ->
-          :erlang.term_to_binary({chain, url, auth_fp})
+        sharing_mode == :isolated ->
+          raise ArgumentError, "sharing_mode :isolated requires :profile_id or :profile"
+
+        true ->
+          :erlang.term_to_binary({chain_id, url, ws_url, auth})
       end
 
     hash_suffix =
@@ -51,7 +58,39 @@ defmodule Lasso.Providers.InstanceId do
 
     host_hint = extract_host_hint(provider_config.url)
 
-    "#{chain}:#{host_hint}:#{hash_suffix}"
+    "#{chain_id}:#{host_hint}:#{hash_suffix}"
+  end
+
+  @doc """
+  Returns a stable fingerprint for credentials that affect upstream access.
+
+  The fingerprint intentionally contains no profile or account identity. It is
+  only used to prevent health, circuit, rate-limit, and WebSocket state from
+  being shared by providers configured with different authentication.
+  """
+  @spec auth_fingerprint(Provider.t() | map()) :: String.t() | nil
+  def auth_fingerprint(provider_config) when is_map(provider_config) do
+    auth =
+      provider_config
+      |> Map.take([:api_key, :credentials, :headers, :auth_headers, :authorization])
+      |> Map.merge(%{
+        api_key: Map.get(provider_config, :api_key) || Map.get(provider_config, "api_key"),
+        credentials:
+          Map.get(provider_config, :credentials) || Map.get(provider_config, "credentials"),
+        headers: Map.get(provider_config, :headers) || Map.get(provider_config, "headers"),
+        auth_headers:
+          Map.get(provider_config, :auth_headers) || Map.get(provider_config, "auth_headers"),
+        authorization:
+          Map.get(provider_config, :authorization) || Map.get(provider_config, "authorization")
+      })
+      |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+      |> Enum.map(fn {key, value} -> {key, canonical_auth_value(value)} end)
+      |> Enum.sort()
+
+    case auth do
+      [] -> nil
+      _ -> :crypto.hash(:sha256, :erlang.term_to_binary(auth)) |> Base.encode16(case: :lower)
+    end
   end
 
   @doc """
@@ -80,29 +119,38 @@ defmodule Lasso.Providers.InstanceId do
   end
 
   @doc """
-  Computes a 12-character hex fingerprint of provider auth configuration.
+  Normalizes an optional URL to canonical form for identity comparison.
 
-  Returns `nil` when no explicit auth is configured.
-  Does NOT extract keys from URLs (the URL itself differentiates key-in-path providers).
+  Returns `nil` for nil, non-binary, or blank values.
   """
-  @spec auth_fingerprint(Provider.t()) :: String.t() | nil
-  def auth_fingerprint(%{api_key: key}) when is_binary(key) and key != "" do
-    :crypto.hash(:sha256, key) |> Base.encode16(case: :lower) |> binary_part(0, 12)
+  @spec optional_normalize_url(term()) :: String.t() | nil
+  def optional_normalize_url(url) when is_binary(url) do
+    case String.trim(url) do
+      "" -> nil
+      trimmed -> normalize_url(trimmed)
+    end
   end
 
-  def auth_fingerprint(%{auth_headers: headers})
-      when is_map(headers) and map_size(headers) > 0 do
-    headers
-    |> Enum.sort()
-    |> :erlang.term_to_binary()
-    |> then(&:crypto.hash(:sha256, &1))
-    |> Base.encode16(case: :lower)
-    |> binary_part(0, 12)
-  end
-
-  def auth_fingerprint(_), do: nil
+  def optional_normalize_url(_), do: nil
 
   # Private helpers
+
+  defp canonical_auth_value(value) when is_map(value) do
+    value
+    |> Enum.map(fn {key, nested} -> {to_string(key), canonical_auth_value(nested)} end)
+    |> Enum.sort()
+  end
+
+  defp canonical_auth_value(value) when is_list(value) do
+    value
+    |> Enum.map(fn
+      {key, nested} -> {to_string(key), canonical_auth_value(nested)}
+      nested -> canonical_auth_value(nested)
+    end)
+    |> Enum.sort()
+  end
+
+  defp canonical_auth_value(value), do: value
 
   defp normalize_port("https", 443), do: nil
   defp normalize_port("https", nil), do: nil

--- a/lib/lasso/providers/instance_state.ex
+++ b/lib/lasso/providers/instance_state.ex
@@ -159,6 +159,37 @@ defmodule Lasso.Providers.InstanceState do
   def status_to_availability(:disconnected), do: :down
   def status_to_availability(_), do: :up
 
+  @doc """
+  Deletes every `:lasso_instance_state` row for the given `instance_id`.
+
+  Called when the last `Catalog` reference to an instance is removed (instance
+  is being torn down). Without this, deterministic-instance-id rebinding on
+  re-activation would resurrect stale health/circuit/rate-limit verdicts —
+  e.g. a previously-`:unhealthy` instance would start life unhealthy on the
+  next activation, before any probe has run.
+  """
+  @spec clear(String.t()) :: :ok
+  def clear(instance_id) when is_binary(instance_id) do
+    keys = [
+      {:health_probe, instance_id},
+      {:health_block_sync, instance_id},
+      {:health_routing, instance_id},
+      {:circuit, instance_id, :http},
+      {:circuit, instance_id, :ws},
+      {:rate_limit, instance_id, :http},
+      {:rate_limit, instance_id, :ws},
+      {:ws_status, instance_id}
+    ]
+
+    Enum.each(keys, fn key ->
+      try do
+        :ets.delete(:lasso_instance_state, key)
+      rescue
+        ArgumentError -> :ok
+      end
+    end)
+  end
+
   defp safe_lookup(key) do
     :ets.lookup(:lasso_instance_state, key)
   rescue

--- a/lib/lasso/providers/instance_supervisor.ex
+++ b/lib/lasso/providers/instance_supervisor.ex
@@ -36,7 +36,7 @@ defmodule Lasso.Providers.InstanceSupervisor do
           |> maybe_add_circuit(:http, instance_id, instance.url, circuit_config)
           |> maybe_add_circuit(:ws, instance_id, instance.ws_url, circuit_config)
           |> maybe_add_ws_connection(instance_id, instance.ws_url)
-          |> maybe_add_subscription_manager(instance_id, instance.chain, instance.ws_url)
+          |> maybe_add_subscription_manager(instance_id, instance.chain_id, instance.ws_url)
 
         Supervisor.init(children, strategy: :one_for_one)
 
@@ -77,11 +77,11 @@ defmodule Lasso.Providers.InstanceSupervisor do
     children
   end
 
-  defp maybe_add_subscription_manager(children, instance_id, chain, ws_url)
+  defp maybe_add_subscription_manager(children, instance_id, chain_id, ws_url)
        when is_binary(ws_url) do
     child = %{
       id: {:subscription_manager, instance_id},
-      start: {InstanceSubscriptionManager, :start_link, [{chain, instance_id}]},
+      start: {InstanceSubscriptionManager, :start_link, [{chain_id, instance_id}]},
       type: :worker,
       restart: :permanent,
       shutdown: 5_000
@@ -90,7 +90,7 @@ defmodule Lasso.Providers.InstanceSupervisor do
     [child | children]
   end
 
-  defp maybe_add_subscription_manager(children, _instance_id, _chain, _ws_url), do: children
+  defp maybe_add_subscription_manager(children, _instance_id, _chain_id, _ws_url), do: children
 
   @spec via_name(String.t()) :: {:via, Registry, {Lasso.Registry, term()}}
   def via_name(instance_id) do

--- a/lib/lasso/providers/lag_calculation.ex
+++ b/lib/lasso/providers/lag_calculation.ex
@@ -8,12 +8,13 @@ defmodule Lasso.Providers.LagCalculation do
   alias Lasso.Config.ConfigStore
   alias Lasso.RPC.ChainState
 
-  @spec calculate_optimistic_lag(String.t(), String.t(), non_neg_integer()) ::
+  @spec calculate_optimistic_lag(pos_integer(), String.t(), non_neg_integer()) ::
           {:ok, integer(), integer()} | {:error, term()}
-  def calculate_optimistic_lag(chain, provider_or_instance_id, block_time_ms) do
+  def calculate_optimistic_lag(chain_id, provider_or_instance_id, block_time_ms)
+      when is_integer(chain_id) and chain_id > 0 do
     with {:ok, {height, timestamp, _source, _meta}} <-
-           BlockSyncRegistry.get_height(chain, provider_or_instance_id),
-         {:ok, consensus} <- ChainState.consensus_height(chain) do
+           BlockSyncRegistry.get_height(chain_id, provider_or_instance_id),
+         {:ok, consensus} <- ChainState.consensus_height(chain_id) do
       now = System.system_time(:millisecond)
       elapsed_ms = now - timestamp
       raw_lag = height - consensus
@@ -33,27 +34,27 @@ defmodule Lasso.Providers.LagCalculation do
     end
   end
 
-  @spec get_block_time_ms(String.t(), String.t() | nil) :: non_neg_integer()
-  def get_block_time_ms(chain, profile \\ nil) do
-    case BlockSyncRegistry.get_block_time_ms(chain) do
+  @spec get_block_time_ms(pos_integer(), String.t() | nil) :: non_neg_integer()
+  def get_block_time_ms(chain_id, profile \\ nil) when is_integer(chain_id) and chain_id > 0 do
+    case BlockSyncRegistry.get_block_time_ms(chain_id) do
       ms when is_integer(ms) and ms > 0 ->
         ms
 
       _ ->
-        case resolve_chain_config(chain, profile) do
+        case resolve_chain_config(chain_id, profile) do
           {:ok, config} -> config.block_time_ms || 12_000
           _ -> 12_000
         end
     end
   end
 
-  defp resolve_chain_config(chain, profile) when is_binary(profile) do
-    ConfigStore.get_chain(profile, chain)
+  defp resolve_chain_config(chain_id, profile) when is_binary(profile) do
+    ConfigStore.get_chain(profile, chain_id)
   end
 
-  defp resolve_chain_config(chain, _) do
-    case ConfigStore.list_profiles_for_chain(chain) do
-      [profile | _] -> ConfigStore.get_chain(profile, chain)
+  defp resolve_chain_config(chain_id, _) do
+    case ConfigStore.list_profiles_for_chain(chain_id) do
+      [profile | _] -> ConfigStore.get_chain(profile, chain_id)
       [] -> {:error, :not_found}
     end
   end

--- a/lib/lasso/providers/probe_coordinator.ex
+++ b/lib/lasso/providers/probe_coordinator.ex
@@ -27,9 +27,9 @@ defmodule Lasso.Providers.ProbeCoordinator do
   use GenServer
   require Logger
 
-  alias Lasso.Config.ChainValidator
+  alias Lasso.Config.{ConfigStore, MonitoringDefaults}
   alias Lasso.Core.Support.CircuitBreaker
-  alias Lasso.Providers.Catalog
+  alias Lasso.Providers.{Catalog, RestartCounter}
 
   @tick_interval_ms 200
   @default_timeout_ms 5_000
@@ -37,7 +37,6 @@ defmodule Lasso.Providers.ProbeCoordinator do
   @max_backoff_ms 30_000
   @rate_limit_backoff_ms 30_000
   @auth_backoff_ms 120_000
-  @min_probe_interval_ms 10_000
   @probe_rate_limit_ttl_ms 60_000
   @jitter_percent 0.2
 
@@ -45,42 +44,63 @@ defmodule Lasso.Providers.ProbeCoordinator do
           instance_id: String.t(),
           consecutive_failures: non_neg_integer(),
           last_probe_monotonic: integer() | nil,
-          current_backoff_ms: non_neg_integer()
+          current_backoff_ms: non_neg_integer(),
+          cached_interval_ms: pos_integer() | nil,
+          cached_at: integer() | nil
         }
 
   defstruct [
-    :chain,
+    :chain_id,
     :tick_ref,
     instances: %{},
     probe_order: [],
-    probe_index: 0
+    probe_index: 0,
+    last_reload_at: 0,
+    subscribed_instances: [],
+    restart_count_cleared: false
   ]
 
-  @spec start_link(String.t()) :: GenServer.on_start()
-  def start_link(chain) do
-    GenServer.start_link(__MODULE__, chain, name: via_name(chain))
+  @spec start_link(pos_integer()) :: GenServer.on_start()
+  def start_link(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    GenServer.start_link(__MODULE__, chain_id, name: via_name(chain_id))
   end
 
   @doc """
   Tells the coordinator to reload its instance list from the catalog.
   """
-  @spec reload_instances(String.t()) :: :ok
-  def reload_instances(chain) do
-    GenServer.cast(via_name(chain), :reload_instances)
+  @spec reload_instances(pos_integer()) :: :ok
+  def reload_instances(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    GenServer.cast(via_name(chain_id), :reload_instances)
   end
 
   @impl true
-  def init(chain) do
-    state = %__MODULE__{chain: chain}
-    state = do_reload_instances(state)
-    tick_ref = schedule_tick()
+  def init(chain_id) do
+    state = %__MODULE__{chain_id: chain_id, last_reload_at: System.monotonic_time(:millisecond)}
+    {:ok, state, {:continue, :deferred_start}}
+  end
 
-    {:ok, %{state | tick_ref: tick_ref}}
+  @impl true
+  def handle_continue(:deferred_start, state) do
+    backoff = RestartCounter.backoff_for(RestartCounter.bump({:probe_coord, state.chain_id}))
+    Process.send_after(self(), :load_instances, backoff)
+    {:noreply, state}
   end
 
   @impl true
   def handle_cast(:reload_instances, state) do
     {:noreply, do_reload_instances(state)}
+  end
+
+  @impl true
+  def handle_info(:instance_config_updated, state) do
+    {:noreply, %{state | last_reload_at: System.monotonic_time(:millisecond)}}
+  end
+
+  @impl true
+  def handle_info(:load_instances, state) do
+    state = do_reload_instances(state)
+    tick_ref = schedule_tick()
+    {:noreply, %{state | tick_ref: tick_ref}}
   end
 
   @impl true
@@ -129,12 +149,30 @@ defmodule Lasso.Providers.ProbeCoordinator do
               %{inst | consecutive_failures: new_failures, current_backoff_ms: backoff}
           end
 
-        {:noreply, %{state | instances: Map.put(state.instances, instance_id, updated)}}
+        state =
+          state
+          |> Map.put(:instances, Map.put(state.instances, instance_id, updated))
+          |> maybe_clear_restart_count(result)
+
+        {:noreply, state}
     end
   end
 
+  # First successful probe after a (re)start clears the restart
+  # counter. A coordinator that crashes before any provider responds
+  # keeps its count (genuine flap signal).
+  defp maybe_clear_restart_count(%{restart_count_cleared: true} = state, _result), do: state
+
+  defp maybe_clear_restart_count(state, :success) do
+    RestartCounter.clear({:probe_coord, state.chain_id})
+    %{state | restart_count_cleared: true}
+  end
+
+  defp maybe_clear_restart_count(state, _result), do: state
+
   defp do_reload_instances(state) do
-    instance_ids = Catalog.list_instances_for_chain(state.chain)
+    instance_ids = Catalog.list_instances_for_chain(state.chain_id)
+    now = System.monotonic_time(:millisecond)
 
     new_instances =
       Map.new(instance_ids, fn id ->
@@ -146,13 +184,39 @@ defmodule Lasso.Providers.ProbeCoordinator do
               instance_id: id,
               consecutive_failures: 0,
               last_probe_monotonic: nil,
-              current_backoff_ms: 0
+              current_backoff_ms: 0,
+              cached_interval_ms: nil,
+              cached_at: nil
             }
 
         {id, inst_state}
       end)
 
-    %{state | instances: new_instances, probe_order: instance_ids, probe_index: 0}
+    state = manage_instance_subscriptions(state, instance_ids)
+
+    %{
+      state
+      | instances: new_instances,
+        probe_order: instance_ids,
+        probe_index: 0,
+        last_reload_at: now
+    }
+  end
+
+  defp manage_instance_subscriptions(state, new_instance_ids) do
+    old_subscribed = state.subscribed_instances
+    added = new_instance_ids -- old_subscribed
+    removed = old_subscribed -- new_instance_ids
+
+    for id <- added do
+      Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.instance_config_updated(id))
+    end
+
+    for id <- removed do
+      Phoenix.PubSub.unsubscribe(Lasso.PubSub, Lasso.Topics.instance_config_updated(id))
+    end
+
+    %{state | subscribed_instances: new_instance_ids}
   end
 
   defp do_tick(state) do
@@ -167,34 +231,89 @@ defmodule Lasso.Providers.ProbeCoordinator do
 
         inst = Map.get(state.instances, instance_id)
 
+        {probe?, effective_ms} = should_probe?(inst, now, state)
+
         state =
-          if should_probe?(inst, now) do
-            probe_instance(state, instance_id, inst, now)
-          else
-            state
+          cond do
+            probe? ->
+              probe_instance(state, instance_id, inst, now)
+
+            not is_nil(effective_ms) and not is_nil(inst) and
+                (is_nil(inst.cached_interval_ms) or
+                   is_nil(inst.cached_at) or
+                   inst.cached_at < state.last_reload_at) ->
+              updated_inst = %{inst | cached_interval_ms: effective_ms, cached_at: now}
+              %{state | instances: Map.put(state.instances, instance_id, updated_inst)}
+
+            true ->
+              state
           end
 
         %{state | probe_index: index + 1}
     end
   end
 
-  defp should_probe?(nil, _now), do: false
+  defp should_probe?(nil, _now, _state), do: {false, nil}
 
-  defp should_probe?(inst, now) do
+  defp should_probe?(inst, now, state) do
+    effective_ms = effective_probe_interval_ms(state, inst.instance_id)
+
     case inst.last_probe_monotonic do
-      nil -> true
-      last -> now - last >= max(inst.current_backoff_ms, @min_probe_interval_ms)
+      nil -> {true, effective_ms}
+      last -> {now - last >= max(inst.current_backoff_ms, effective_ms), effective_ms}
+    end
+  end
+
+  defp effective_probe_interval_ms(state, instance_id) do
+    inst = Map.get(state.instances, instance_id)
+
+    cached_valid =
+      not is_nil(inst) and
+        not is_nil(inst.cached_interval_ms) and
+        not is_nil(inst.cached_at) and
+        inst.cached_at >= state.last_reload_at
+
+    if cached_valid do
+      inst.cached_interval_ms
+    else
+      compute_interval(state, instance_id)
+    end
+  end
+
+  defp compute_interval(state, instance_id) do
+    refs = Catalog.get_instance_refs(instance_id)
+
+    intervals =
+      refs
+      |> Enum.map(&ConfigStore.get_chain(&1, state.chain_id))
+      |> Enum.filter(&match?({:ok, _}, &1))
+      |> Enum.map(fn {:ok, cc} -> cc.monitoring.probe_interval_ms end)
+
+    case intervals do
+      [] ->
+        block_time_ms = instance_block_time_ms(instance_id)
+        MonitoringDefaults.default_probe_interval_ms(block_time_ms)
+
+      _ ->
+        Enum.min(intervals)
+    end
+  end
+
+  defp instance_block_time_ms(instance_id) do
+    case Catalog.get_instance(instance_id) do
+      {:ok, %{block_time_ms: bt}} when is_integer(bt) and bt > 0 -> bt
+      _ -> nil
     end
   end
 
   defp probe_instance(state, instance_id, inst, now) do
-    chain = state.chain
+    chain_id = state.chain_id
     coordinator = self()
 
     case Catalog.get_instance(instance_id) do
       {:ok, %{url: url}} when is_binary(url) ->
         Task.Supervisor.start_child(Lasso.TaskSupervisor, fn ->
-          {^instance_id, result} = do_http_probe(instance_id, url, chain)
+          {^instance_id, result} = do_http_probe(instance_id, url, chain_id)
           send(coordinator, {:probe_result, instance_id, result})
         end)
 
@@ -202,11 +321,19 @@ defmodule Lasso.Providers.ProbeCoordinator do
         :skip
     end
 
-    updated_inst = %{inst | last_probe_monotonic: now}
+    effective_ms = effective_probe_interval_ms(state, instance_id)
+
+    updated_inst = %{
+      inst
+      | last_probe_monotonic: now,
+        cached_interval_ms: effective_ms,
+        cached_at: now
+    }
+
     %{state | instances: Map.put(state.instances, instance_id, updated_inst)}
   end
 
-  defp do_http_probe(instance_id, url, chain) do
+  defp do_http_probe(instance_id, url, chain_id) do
     body =
       Jason.encode!(%{"jsonrpc" => "2.0", "method" => "eth_chainId", "params" => [], "id" => 1})
 
@@ -215,7 +342,7 @@ defmodule Lasso.Providers.ProbeCoordinator do
 
     case Finch.request(request, Lasso.Finch, receive_timeout: @default_timeout_ms) do
       {:ok, %{status: status, body: resp_body}} when status in 200..299 ->
-        case classify_response_body(resp_body, chain) do
+        case classify_response_body(resp_body, chain_id) do
           :ok ->
             write_probe_success(instance_id)
             CircuitBreaker.signal_recovery_cast({instance_id, :http})
@@ -257,9 +384,9 @@ defmodule Lasso.Providers.ProbeCoordinator do
     end
   end
 
-  @rate_limit_codes [-32_005, -32_097]
+  @rate_limit_codes [-32_005, -32_007, -32_029]
 
-  defp classify_response_body(body, chain) when is_binary(body) do
+  defp classify_response_body(body, chain_id) when is_binary(body) do
     case Jason.decode(body) do
       {:ok, %{"error" => %{"code" => code, "message" => msg}}} when code in @rate_limit_codes ->
         {:rate_limited, "#{code}: #{msg}"}
@@ -271,7 +398,7 @@ defmodule Lasso.Providers.ProbeCoordinator do
         {:error, msg}
 
       {:ok, %{"result" => hex_chain_id}} ->
-        validate_chain_id(hex_chain_id, chain)
+        validate_chain_id_response(hex_chain_id, chain_id)
 
       {:ok, _} ->
         {:error, "unexpected JSON-RPC response shape"}
@@ -281,23 +408,18 @@ defmodule Lasso.Providers.ProbeCoordinator do
     end
   end
 
-  defp classify_response_body(_, _chain), do: {:error, "empty response body"}
+  defp classify_response_body(_, _chain_id), do: {:error, "empty response body"}
 
-  defp validate_chain_id(hex, chain) when is_binary(hex) do
-    case ChainValidator.expected_chain_id(chain) do
-      nil ->
-        :ok
-
-      expected ->
-        case Integer.parse(String.trim_leading(hex, "0x"), 16) do
-          {actual, ""} when actual == expected -> :ok
-          {actual, ""} -> {:error, "wrong chain_id: got #{actual}, expected #{expected}"}
-          _ -> {:error, "invalid chain_id response: #{hex}"}
-        end
+  defp validate_chain_id_response(hex, expected_chain_id)
+       when is_binary(hex) and is_integer(expected_chain_id) do
+    case Integer.parse(String.trim_leading(hex, "0x"), 16) do
+      {actual, ""} when actual == expected_chain_id -> :ok
+      {actual, ""} -> {:error, "wrong chain_id: got #{actual}, expected #{expected_chain_id}"}
+      _ -> {:error, "invalid chain_id response: #{hex}"}
     end
   end
 
-  defp validate_chain_id(_, _chain), do: :ok
+  defp validate_chain_id_response(_, _), do: :ok
 
   defp rate_limit_in_body?(body) when is_binary(body) do
     lower = String.downcase(body)
@@ -305,10 +427,6 @@ defmodule Lasso.Providers.ProbeCoordinator do
   end
 
   defp rate_limit_in_body?(_), do: false
-
-  # ETS writers — write to {:health_probe, instance_id} (exclusively owned by ProbeCoordinator).
-  # HttpStrategy writes to {:health_block_sync, instance_id} separately.
-  # Runs inside Task.Supervisor children; if ETS is missing, the task crashes (expected).
 
   defp write_probe_success(instance_id) do
     existing = read_existing_probe(instance_id)
@@ -413,8 +531,8 @@ defmodule Lasso.Providers.ProbeCoordinator do
     Process.send_after(self(), :tick, @tick_interval_ms)
   end
 
-  @spec via_name(String.t()) :: {:via, Registry, {Lasso.Registry, term()}}
-  def via_name(chain) do
-    {:via, Registry, {Lasso.Registry, {:probe_coordinator, chain}}}
+  @spec via_name(pos_integer()) :: {:via, Registry, {Lasso.Registry, term()}}
+  def via_name(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    {:via, Registry, {Lasso.Registry, {:probe_coordinator, chain_id}}}
   end
 end

--- a/lib/lasso/providers/probe_coordinator.ex
+++ b/lib/lasso/providers/probe_coordinator.ex
@@ -311,16 +311,25 @@ defmodule Lasso.Providers.ProbeCoordinator do
     coordinator = self()
 
     case Catalog.get_instance(instance_id) do
-      {:ok, %{url: url}} when is_binary(url) ->
+      {:ok, %{mock?: true}} ->
+        state
+
+      {:ok, %{url: url} = instance} when is_binary(url) ->
+        headers = Map.get(instance, :headers, [{"content-type", "application/json"}])
+
         Task.Supervisor.start_child(Lasso.TaskSupervisor, fn ->
-          {^instance_id, result} = do_http_probe(instance_id, url, chain_id)
+          {^instance_id, result} = do_http_probe(instance_id, url, chain_id, headers)
           send(coordinator, {:probe_result, instance_id, result})
         end)
 
-      _ ->
-        :skip
-    end
+        mark_probe_attempt(state, instance_id, inst, now)
 
+      _ ->
+        state
+    end
+  end
+
+  defp mark_probe_attempt(state, instance_id, inst, now) do
     effective_ms = effective_probe_interval_ms(state, instance_id)
 
     updated_inst = %{
@@ -333,12 +342,11 @@ defmodule Lasso.Providers.ProbeCoordinator do
     %{state | instances: Map.put(state.instances, instance_id, updated_inst)}
   end
 
-  defp do_http_probe(instance_id, url, chain_id) do
+  defp do_http_probe(instance_id, url, chain_id, headers) do
     body =
       Jason.encode!(%{"jsonrpc" => "2.0", "method" => "eth_chainId", "params" => [], "id" => 1})
 
-    request =
-      Finch.build(:post, url, [{"content-type", "application/json"}], body)
+    request = Finch.build(:post, url, headers, body)
 
     case Finch.request(request, Lasso.Finch, receive_timeout: @default_timeout_ms) do
       {:ok, %{status: status, body: resp_body}} when status in 200..299 ->

--- a/lib/lasso/providers/provider_headers.ex
+++ b/lib/lasso/providers/provider_headers.ex
@@ -1,0 +1,51 @@
+defmodule Lasso.Providers.ProviderHeaders do
+  @moduledoc false
+
+  @spec build(map()) :: [{String.t(), String.t()}]
+  def build(provider) when is_map(provider) do
+    defaults = [
+      {"content-type", "application/json"},
+      {"accept", "application/json"}
+    ]
+
+    api_key_headers =
+      case Map.get(provider, :api_key) || Map.get(provider, "api_key") do
+        api_key when is_binary(api_key) and byte_size(api_key) > 0 ->
+          [{"authorization", "Bearer #{api_key}"}]
+
+        _ ->
+          []
+      end
+
+    defaults
+    |> merge(api_key_headers)
+    |> merge(normalize(Map.get(provider, :headers) || Map.get(provider, "headers")))
+    |> merge(normalize(Map.get(provider, :auth_headers) || Map.get(provider, "auth_headers")))
+  end
+
+  defp normalize(headers) when is_map(headers), do: normalize(Map.to_list(headers))
+
+  defp normalize(headers) when is_list(headers) do
+    Enum.flat_map(headers, fn
+      {key, value} when (is_binary(key) or is_atom(key)) and not is_nil(value) ->
+        [{key |> to_string() |> String.downcase(), to_string(value)}]
+
+      _ ->
+        []
+    end)
+  end
+
+  defp normalize(_headers), do: []
+
+  defp merge(existing, additions) do
+    Enum.reduce(additions, existing, fn {key, value}, headers ->
+      key = String.downcase(key)
+
+      [
+        {key, value}
+        | Enum.reject(headers, fn {current, _} -> String.downcase(current) == key end)
+      ]
+    end)
+    |> Enum.reverse()
+  end
+end

--- a/lib/lasso/providers/restart_counter.ex
+++ b/lib/lasso/providers/restart_counter.ex
@@ -1,0 +1,97 @@
+defmodule Lasso.Providers.RestartCounter do
+  @moduledoc """
+  Per-child restart counter for the BlockSync.Worker and ProbeCoordinator
+  supervision subtrees.
+
+  See `docs/internal/custom-profiles/CHAIN_ARCHITECTURE_V2.md` §6 for the
+  full rationale. Summary:
+
+    * `BlockSync.DynamicSupervisor` and `Providers.ProbeSupervisor` keep
+      the OTP default `max_restarts: 3, max_seconds: 5`. A flapping child
+      would otherwise take the whole `DynamicSupervisor` down within
+      seconds, blocking block-sync cluster-wide.
+    * Per-child backoff is implemented here, applied from
+      `handle_continue(:deferred_start, …)` so init returns immediately
+      and the restart window doesn't fill up.
+
+  ## Key shapes
+
+    * `{:block_sync, instance_id :: String.t()}` — BlockSync.Worker
+    * `{:probe_coord, chain_id :: pos_integer()}` — ProbeCoordinator
+
+  ## Ownership
+
+  The ETS table `:lasso_restart_counts` is owned by
+  `Lasso.Providers.Catalog.Owner` (a long-lived GenServer that already
+  owns the Catalog persistent_term-backed table). Owning ETS from a
+  process that outlives every worker means counters survive worker
+  restarts but die cleanly with the application.
+
+  ## Why ETS over persistent_term
+
+  Restart counts are high-churn under burst conditions (cluster-wide
+  config push triggers many worker crashes simultaneously).
+  `:persistent_term.put/2` triggers a global GC on every write — OTP
+  flags it for "rarely-changing data." ETS writes are cheap.
+  """
+
+  @table :lasso_restart_counts
+
+  @type key :: {:block_sync, String.t()} | {:probe_coord, pos_integer()}
+
+  @doc """
+  Creates the restart-counter ETS table. Called by `Catalog.Owner.init/1`.
+
+  Idempotent: a duplicate create from a test reload is a no-op.
+  """
+  @spec init_table() :: :ok
+  def init_table do
+    case :ets.whereis(@table) do
+      :undefined ->
+        :ets.new(@table, [:set, :public, :named_table, write_concurrency: true])
+        :ok
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc """
+  Atomically increments the counter for `key`, creating it with a base
+  of 0 if absent. Returns the post-increment value.
+  """
+  @spec bump(key()) :: pos_integer()
+  def bump(key) do
+    :ets.update_counter(@table, key, 1, {key, 0})
+  end
+
+  @doc """
+  Deletes the counter for `key`. Idempotent.
+  """
+  @spec clear(key()) :: :ok
+  def clear(key) do
+    :ets.delete(@table, key)
+    :ok
+  end
+
+  @doc """
+  Per-child backoff schedule.
+
+  Counts:
+
+    * 1   — cold start jitter (100–300ms)
+    * 2   — ~1–2s
+    * 3   — ~5–10s
+    * <10 — ~15–30s
+    * 10+ — ~60–120s (capped)
+
+  The first call after a clean spawn returns 100–300ms so a healthy
+  first start is barely slower than the previous fixed 2s delay.
+  """
+  @spec backoff_for(pos_integer()) :: pos_integer()
+  def backoff_for(1), do: 100 + :rand.uniform(200)
+  def backoff_for(2), do: 1_000 + :rand.uniform(1_000)
+  def backoff_for(3), do: 5_000 + :rand.uniform(5_000)
+  def backoff_for(n) when n < 10, do: 15_000 + :rand.uniform(15_000)
+  def backoff_for(_), do: 60_000 + :rand.uniform(60_000)
+end

--- a/lib/lasso/topics.ex
+++ b/lib/lasso/topics.ex
@@ -1,0 +1,76 @@
+defmodule Lasso.Topics do
+  @moduledoc """
+  Centralized PubSub topic schema.
+
+  Every `Phoenix.PubSub.broadcast/3`, `subscribe/2`, and `unsubscribe/2`
+  call should reference a function in this module rather than
+  constructing topic strings inline. The single point of definition lets
+  us change topic shape without grepping callsites and avoids fragile
+  topic encodings such as `inspect/1`.
+
+  All `profile_id` parameters are opaque strings (D19) — plain string
+  interpolation is safe; no `inspect/1` encoding needed.
+  """
+
+  @type profile_id :: String.t()
+  @type chain_id :: pos_integer()
+  @type instance_id :: String.t()
+
+  ## Profile-scoped
+
+  @spec routing_decision(profile_id()) :: String.t()
+  def routing_decision(profile_id), do: "routing:decisions:#{profile_id}"
+
+  @spec sync_updates(profile_id()) :: String.t()
+  def sync_updates(profile_id), do: "sync:updates:#{profile_id}"
+
+  @spec block_cache_updates(profile_id()) :: String.t()
+  def block_cache_updates(profile_id), do: "block_cache:updates:#{profile_id}"
+
+  @spec config_profile_updated(profile_id()) :: String.t()
+  def config_profile_updated(profile_id), do: "config:profile_updated:#{profile_id}"
+
+  ## Profile + chain
+
+  @spec circuit_event(profile_id(), chain_id()) :: String.t()
+  def circuit_event(profile_id, chain_id), do: "circuit:events:#{profile_id}:#{chain_id}"
+
+  @spec block_sync(profile_id(), chain_id()) :: String.t()
+  def block_sync(profile_id, chain_id), do: "block_sync:#{profile_id}:#{chain_id}"
+
+  @spec provider_event(profile_id(), chain_id()) :: String.t()
+  def provider_event(profile_id, chain_id), do: "provider:events:#{profile_id}:#{chain_id}"
+
+  @spec subscription_event(profile_id(), chain_id()) :: String.t()
+  def subscription_event(profile_id, chain_id),
+    do: "subscription:lifecycle:#{profile_id}:#{chain_id}"
+
+  @spec ws_connection(profile_id(), chain_id()) :: String.t()
+  def ws_connection(profile_id, chain_id), do: "ws:conn:#{profile_id}:#{chain_id}"
+
+  ## Instance-scoped
+
+  @spec instance_config_updated(instance_id()) :: String.t()
+  def instance_config_updated(instance_id), do: "instance_config_updated:#{instance_id}"
+
+  @spec ws_subs_instance(instance_id()) :: String.t()
+  def ws_subs_instance(instance_id), do: "ws:subs:instance:#{instance_id}"
+
+  @spec ws_conn_instance(instance_id()) :: String.t()
+  def ws_conn_instance(instance_id), do: "ws:conn:instance:#{instance_id}"
+
+  @spec instance_sub_manager_restarted(chain_id()) :: String.t()
+  def instance_sub_manager_restarted(chain_id),
+    do: "instance_sub_manager:restarted:#{chain_id}"
+
+  ## Global
+
+  @spec cluster_topology() :: String.t()
+  def cluster_topology, do: "cluster:topology"
+
+  @spec metrics_store_cache_warmed() :: String.t()
+  def metrics_store_cache_warmed, do: "metrics_store:cache_warmed"
+
+  @spec config_profile_changes() :: String.t()
+  def config_profile_changes, do: "config:profile_changes"
+end

--- a/lib/lasso/url_mask.ex
+++ b/lib/lasso/url_mask.ex
@@ -1,0 +1,141 @@
+defmodule Lasso.URLMask do
+  @moduledoc """
+  URL credential masking shared across leak surfaces.
+
+  Provider URLs frequently embed credentials in the path
+  (`https://eth-mainnet.g.alchemy.com/v2/<KEY>`,
+  `https://mainnet.infura.io/v3/<KEY>`) or as query params. Anywhere a
+  URL might end up in a log line, a Sentry event, a YAML export, or a
+  rendered template, it should be threaded through `mask/1` first.
+
+  The mask preserves the scheme + host (operationally useful for
+  diagnosis) and elides any path segment or query value that looks
+  high-entropy. Idempotent — masking an already-masked URL is a no-op.
+  """
+
+  @doc """
+  Returns the URL with high-entropy path segments and long query values
+  replaced by a 4-char prefix + `***`.
+
+  Returns `nil` for `nil` and the original value for non-binary input
+  so callers can pass arbitrary values defensively.
+  """
+  @spec mask(any()) :: any()
+  def mask(nil), do: nil
+
+  def mask(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: nil} ->
+        url
+
+      %URI{} = uri ->
+        uri
+        |> Map.put(:path, mask_path(uri.path))
+        |> Map.put(:query, mask_query(uri.query))
+        |> URI.to_string()
+    end
+  rescue
+    # Any URI parse oddity → return as-is rather than risk crashing the
+    # caller (typically a logging or Sentry path that must not raise).
+    _ -> url
+  end
+
+  def mask(other), do: other
+
+  @doc """
+  Scans a freeform string for embedded `http(s)://` and `ws(s)://` URLs and
+  replaces each with its masked form via `mask/1`.
+
+  Use this on exception messages, log lines, and other text where a URL may
+  appear inline among other content. Returns the input unchanged when it
+  contains no recognizable URL.
+  """
+  @url_pattern ~r{(?:https?|wss?)://[^\s\"\'<>\)\]\}]+}
+
+  @spec mask_in_string(any()) :: any()
+  def mask_in_string(string) when is_binary(string) do
+    Regex.replace(@url_pattern, string, fn matched -> mask(matched) end)
+  end
+
+  def mask_in_string(other), do: other
+
+  @doc """
+  Extracts just the host portion of a URL — returning a fallback when
+  the input isn't parseable.
+
+  Use this anywhere a URL is rendered to the user (UI, logs, headers,
+  telemetry) and you only want the host. Falling back to the raw URL
+  on parse failure (a common ad-hoc pattern) leaks credentials when
+  the URL is malformed; this helper falls back to a safe placeholder
+  instead.
+  """
+  @spec host(any(), String.t() | nil) :: String.t() | nil
+  def host(url, fallback \\ nil)
+
+  def host(url, fallback) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{host: h} when is_binary(h) and h != "" -> h
+      _ -> fallback
+    end
+  end
+
+  def host(_, fallback), do: fallback
+
+  defp mask_path(nil), do: nil
+
+  defp mask_path(path) do
+    path
+    |> String.split("/")
+    |> Enum.map_join("/", fn segment ->
+      if maskable_path_segment?(segment) do
+        String.slice(segment, 0, 4) <> "***"
+      else
+        segment
+      end
+    end)
+  end
+
+  # Lowered from >20 to >8: real provider keys often live in shorter
+  # path slots (QuickNode `/8-char/32-char/`, Tenderly node ids ≤20,
+  # Ankr `/<key>` directly under host). Keep the no-dot guard so we
+  # don't elide hostnames or filename-like segments accidentally
+  # matched by a routing-style URL.
+  defp maskable_path_segment?(segment) when is_binary(segment) do
+    len = String.length(segment)
+
+    len > 8 and
+      not String.contains?(segment, ".") and
+      Regex.match?(~r/^[A-Za-z0-9_-]+$/, segment)
+  end
+
+  defp mask_query(nil), do: nil
+
+  defp mask_query(query) do
+    query
+    |> URI.decode_query()
+    |> Enum.map(fn {k, v} ->
+      if maskable_query_value?(k, v) do
+        {k, String.slice(v, 0, 4) <> "***"}
+      else
+        {k, v}
+      end
+    end)
+    |> URI.encode_query()
+  end
+
+  # Names that almost always carry a credential — mask regardless of
+  # length so `?key=foo` doesn't slip through. Also still mask any
+  # value > 4 chars defensively (was 10).
+  @credential_param_names ~w(
+    key apikey api_key apiKey api-key access_token accessToken
+    auth authorization token secret pass password
+  )
+
+  defp maskable_query_value?(_, ""), do: false
+
+  defp maskable_query_value?(name, value) when is_binary(name) and is_binary(value) do
+    String.downcase(name) in @credential_param_names or String.length(value) > 4
+  end
+
+  defp maskable_query_value?(_, _), do: false
+end

--- a/lib/lasso_web/controllers/chain_controller.ex
+++ b/lib/lasso_web/controllers/chain_controller.ex
@@ -1,18 +1,20 @@
 defmodule LassoWeb.ChainController do
   use LassoWeb, :controller
 
-  alias Lasso.Config.ConfigStore
+  alias Lasso.Config.{ChainAlias, ConfigStore}
 
   @spec index(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def index(conn, _params) do
     all_chains = ConfigStore.get_all_chains()
 
     chains =
-      Enum.map(all_chains, fn {chain_name, chain_config} ->
+      Enum.map(all_chains, fn {chain_id, chain_config} ->
+        chain_slug = ChainAlias.canonical_slug(chain_id, chain_config.url_aliases)
+
         %{
-          chain_id: to_string(chain_config.chain_id),
-          name: chain_config.name,
-          chain_name: chain_name,
+          chain_id: to_string(chain_id),
+          name: ChainAlias.display_name(chain_id, chain_config.display_name),
+          chain_name: chain_slug,
           supported: true
         }
       end)

--- a/lib/lasso_web/controllers/metrics_controller.ex
+++ b/lib/lasso_web/controllers/metrics_controller.ex
@@ -4,7 +4,7 @@ defmodule LassoWeb.MetricsController do
   require Logger
 
   alias Lasso.Benchmarking.BenchmarkStore
-  alias Lasso.Config.ConfigStore
+  alias Lasso.Config.{ChainAlias, ConfigStore}
   alias Lasso.Config.ProfileValidator
   alias LassoWeb.Dashboard.MetricsHelpers
 
@@ -16,21 +16,17 @@ defmodule LassoWeb.MetricsController do
     Logger.info("Metrics requested for chain: #{chain_name}")
     profile = ProfileValidator.default_profile()
 
-    # Check if chain is configured
-    case ConfigStore.get_chain(profile, chain_name) do
-      {:ok, _chain_config} ->
-        # Chain exists, collect metrics
-        metrics_data = collect_chain_metrics(chain_name)
-        json(conn, metrics_data)
+    case ConfigStore.lookup_chain_id_in_profile(profile, chain_name) do
+      {:ok, chain_id} ->
+        json(conn, collect_chain_metrics(chain_id))
 
-      {:error, :not_found} ->
-        # Chain not found
+      :not_found ->
         conn
         |> put_status(:not_found)
         |> json(%{
           error: "Chain not found",
           chain: chain_name,
-          available_chains: ConfigStore.list_chains()
+          available_chains: available_chain_aliases(profile)
         })
     end
   end
@@ -42,21 +38,20 @@ defmodule LassoWeb.MetricsController do
     |> json(%{
       error: "Chain parameter required",
       usage: "/api/metrics/{chain_name}",
-      available_chains: ConfigStore.list_chains()
+      available_chains: available_chain_aliases(ProfileValidator.default_profile())
     })
   end
 
-  defp collect_chain_metrics(chain_name, profile \\ ProfileValidator.default_profile()) do
-    # Get basic chain information
-    {:ok, chain_config} = ConfigStore.get_chain(profile, chain_name)
-    {:ok, provider_configs} = ConfigStore.get_providers(profile, chain_name)
+  defp collect_chain_metrics(chain_id, profile \\ ProfileValidator.default_profile()) do
+    {:ok, chain_config} = ConfigStore.get_chain(profile, chain_id)
+    {:ok, provider_configs} = ConfigStore.get_providers(profile, chain_id)
 
     # Get performance data from BenchmarkStore
-    chain_stats = BenchmarkStore.get_chain_wide_stats(profile, chain_name)
-    realtime_stats = BenchmarkStore.get_realtime_stats(profile, chain_name)
+    chain_stats = BenchmarkStore.get_chain_wide_stats(profile, chain_id)
+    realtime_stats = BenchmarkStore.get_realtime_stats(profile, chain_id)
 
     # Get provider leaderboard
-    provider_leaderboard = BenchmarkStore.get_provider_leaderboard(profile, chain_name)
+    provider_leaderboard = BenchmarkStore.get_provider_leaderboard(profile, chain_id)
 
     # Calculate VM/system metrics
     vm_metrics = MetricsHelpers.collect_vm_metrics()
@@ -92,7 +87,7 @@ defmodule LassoWeb.MetricsController do
           avg_latency_ms: Float.round(provider.avg_latency_ms || 0.0, 2),
           calls_last_minute:
             Map.get(
-              BenchmarkStore.get_real_time_stats(profile, chain_name, provider.provider_id),
+              BenchmarkStore.get_real_time_stats(profile, chain_id, provider.provider_id),
               :calls_last_minute,
               0
             )
@@ -107,7 +102,7 @@ defmodule LassoWeb.MetricsController do
     rpc_performance_by_provider =
       collect_rpc_performance_by_provider(
         profile,
-        chain_name,
+        chain_id,
         provider_ids,
         rpc_methods,
         provider_configs
@@ -117,7 +112,7 @@ defmodule LassoWeb.MetricsController do
     rpc_performance_by_method =
       collect_rpc_performance_by_method(
         profile,
-        chain_name,
+        chain_id,
         provider_ids,
         rpc_methods,
         provider_configs
@@ -125,7 +120,7 @@ defmodule LassoWeb.MetricsController do
 
     # Build comprehensive response
     %{
-      chain: chain_name,
+      chain: ChainAlias.canonical_slug(chain_id, chain_config.url_aliases),
       chain_id: chain_config.chain_id,
       timestamp: System.system_time(:millisecond),
       system_metrics: %{
@@ -242,6 +237,17 @@ defmodule LassoWeb.MetricsController do
           last_updated: metrics.last_updated
         }
     end
+  end
+
+  defp available_chain_aliases(profile) do
+    profile
+    |> ConfigStore.list_chains_for_profile()
+    |> Enum.map(fn chain_id ->
+      case ConfigStore.get_chain(profile, chain_id) do
+        {:ok, chain_config} -> ChainAlias.canonical_slug(chain_id, chain_config.url_aliases)
+        {:error, :not_found} -> ChainAlias.canonical_slug(chain_id)
+      end
+    end)
   end
 
   defp round_float(nil, _precision), do: nil

--- a/lib/lasso_web/controllers/rpc_controller.ex
+++ b/lib/lasso_web/controllers/rpc_controller.ex
@@ -60,17 +60,19 @@ defmodule LassoWeb.RPCController do
         |> json(JError.to_response(error, nil))
 
       chain_id ->
-        # ProfileResolverPlug guarantees :profile_slug is set and validated
-        # No fallback needed - if plug didn't run, we should fail fast
-        profile = conn.assigns.profile_slug
+        profile = routing_profile(conn)
 
-        case resolve_chain_name(profile, chain_id) do
-          {:ok, chain_name} ->
-            strategy = strategy_from(conn, params)
-            conn = assign(conn, :provider_strategy, strategy)
+        with {:ok, resolved_chain_id} <- resolve_chain(profile, chain_id),
+             :ok <- validate_provider_override(profile, resolved_chain_id, conn, params) do
+          requested_strategy = strategy_from(conn, params)
 
-            handle_chain_rpc(conn, chain_name)
+          conn =
+            conn
+            |> assign(:requested_provider_strategy, requested_strategy)
+            |> assign(:provider_strategy, requested_strategy)
 
+          handle_chain_rpc(conn, resolved_chain_id)
+        else
           {:error, reason} ->
             error = JError.new(-32_602, "Unsupported chain: #{reason}")
 
@@ -227,8 +229,8 @@ defmodule LassoWeb.RPCController do
     else
       # Select a batch provider for consistency across batch items.
       # All items prefer this provider, but can failover independently.
-      profile = conn.assigns[:profile_slug] || ProfileValidator.default_profile()
-      strategy = strategy_from(conn, %{})
+      profile = routing_profile(conn)
+      strategy = conn.assigns[:provider_strategy] || strategy_from(conn, %{})
 
       batch_provider =
         case Selection.select_provider(profile, chain, "eth_blockNumber", strategy: strategy) do
@@ -371,34 +373,29 @@ defmodule LassoWeb.RPCController do
   defp validate_json_rpc_request(_), do: {:error, JError.new(-32_600, "Invalid Request")}
 
   defp process_json_rpc_request(
-         %{"method" => "eth_chainId", "params" => [], "id" => req_id},
-         chain,
+         %{"method" => "eth_chainId", "params" => [], "id" => req_id} = request,
+         chain_id,
          conn
-       ) do
-    Logger.debug("Getting chain ID", chain: chain)
-    profile = conn.assigns[:profile_slug] || ProfileValidator.default_profile()
+       )
+       when is_integer(chain_id) and chain_id > 0 do
+    if provider_override_requested?(conn) do
+      forward_rpc_request(chain_id, "eth_chainId", Map.get(request, "params", []),
+        conn: conn,
+        jsonrpc_id: req_id
+      )
+    else
+      Logger.debug("Getting chain ID", chain_id: chain_id)
+      hex_chain_id = "0x" <> Integer.to_string(chain_id, 16)
+      raw_bytes = Jason.encode!(%{"jsonrpc" => "2.0", "id" => req_id, "result" => hex_chain_id})
 
-    case get_chain_id(profile, chain) do
-      {:ok, chain_id} ->
-        raw_bytes = Jason.encode!(%{"jsonrpc" => "2.0", "id" => req_id, "result" => chain_id})
+      ctx =
+        Lasso.RPC.RequestContext.new(chain_id, "eth_chainId", [],
+          strategy: conn.assigns[:provider_strategy],
+          plug_start_time: conn.private[:plug_start_time]
+        )
 
-        ctx =
-          Lasso.RPC.RequestContext.new(chain, "eth_chainId", [],
-            strategy: conn.assigns[:provider_strategy],
-            plug_start_time: conn.private[:plug_start_time]
-          )
-
-        ctx = %{ctx | status: :success}
-
-        {:ok,
-         %Response.Success{
-           id: req_id,
-           jsonrpc: "2.0",
-           raw_bytes: raw_bytes
-         }, ctx}
-
-      {:error, reason} ->
-        {:error, JError.new(-32_603, "Failed to get chain ID: #{reason}")}
+      {:ok, %Response.Success{id: req_id, jsonrpc: "2.0", raw_bytes: raw_bytes},
+       %{ctx | status: :success}}
     end
   end
 
@@ -480,19 +477,10 @@ defmodule LassoWeb.RPCController do
   end
 
   defp strategy_from(conn, params) do
-    case conn.assigns[:provider_strategy] do
-      nil ->
-        case params["strategy"] do
-          "load_balanced" -> :load_balanced
-          "round_robin" -> :load_balanced
-          "fastest" -> :fastest
-          "latency_weighted" -> :latency_weighted
-          _ -> default_provider_strategy()
-        end
-
-      existing_strategy ->
-        existing_strategy
-    end
+    conn.assigns[:requested_provider_strategy] ||
+      conn.assigns[:provider_strategy] ||
+      Helpers.normalize_strategy_token(params["strategy"]) ||
+      default_provider_strategy()
   end
 
   # Determine provider override from opts, params, or header.
@@ -542,41 +530,40 @@ defmodule LassoWeb.RPCController do
     end
   end
 
-  defp resolve_chain_name(profile, chain_identifier) do
-    # Try to get chain by name from the specified profile
-    case ConfigStore.get_chain(profile, chain_identifier) do
-      {:ok, _chain_config} ->
-        {:ok, chain_identifier}
+  defp routing_profile(conn) do
+    conn.assigns[:profile_id] || conn.assigns[:profile_slug] || ProfileValidator.default_profile()
+  end
 
-      {:error, :not_found} ->
-        # Not found by name - try parsing as numeric chain ID and search within profile
-        case Integer.parse(chain_identifier) do
-          {chain_id, ""} ->
-            find_chain_by_id_in_profile(profile, chain_id)
+  defp resolve_chain(profile, chain_identifier) when is_binary(chain_identifier) do
+    case ConfigStore.lookup_chain_id_in_profile(profile, chain_identifier) do
+      {:ok, chain_id} ->
+        {:ok, chain_id}
 
-          _ ->
-            {:error, "Chain '#{chain_identifier}' not found in profile '#{profile}'"}
+      :not_found ->
+        {:error, "Unknown chain '#{chain_identifier}' in profile '#{profile}'"}
+    end
+  end
+
+  defp validate_provider_override(_profile, _chain_id, _conn, %{"provider_override" => nil}),
+    do: :ok
+
+  defp validate_provider_override(profile, chain_id, conn, _params) do
+    case extract_provider_override(conn, []) do
+      nil ->
+        :ok
+
+      provider_id ->
+        case ConfigStore.get_provider(profile, chain_id, provider_id) do
+          {:ok, _provider} ->
+            :ok
+
+          {:error, :not_found} ->
+            {:error, "Provider '#{provider_id}' is not configured for this chain"}
         end
     end
   end
 
-  # Find a chain by numeric ID within a specific profile (never crosses profiles)
-  defp find_chain_by_id_in_profile(profile, chain_id) do
-    case ConfigStore.get_profile_chains(profile) do
-      {:ok, chains} ->
-        case Enum.find(chains, fn {_name, config} -> config.chain_id == chain_id end) do
-          {chain_name, _config} -> {:ok, chain_name}
-          nil -> {:error, "Chain ID #{chain_id} not found in profile '#{profile}'"}
-        end
-
-      {:error, :not_found} ->
-        {:error, "Profile '#{profile}' not found"}
-    end
-  end
-
-  defp get_chain_id(profile, chain_name) do
-    Helpers.get_chain_id(profile, chain_name)
-  end
+  defp provider_override_requested?(conn), do: not is_nil(extract_provider_override(conn, []))
 
   defp maybe_inject_observability_metadata(conn, ctx) do
     case conn.assigns[:include_meta] do

--- a/lib/lasso_web/dashboard/event_stream.ex
+++ b/lib/lasso_web/dashboard/event_stream.ex
@@ -36,7 +36,7 @@ defmodule LassoWeb.Dashboard.EventStream do
 
   All event types are buffered and flushed as a single structured batch per tick.
   Latest-wins coalescing applies to health, circuit_states, block_states, cluster, and metrics.
-  List events are accumulated in order. Account filtering applies to routing_events only.
+  List events are accumulated in order for each read-only dashboard profile.
   """
 
   use GenServer, restart: :transient
@@ -44,7 +44,7 @@ defmodule LassoWeb.Dashboard.EventStream do
 
   alias Lasso.Cluster.Topology
   alias Lasso.Config.ConfigStore
-  alias Lasso.Events.{Provider, RoutingDecision, Subscription}
+  alias Lasso.Events.{RoutingDecision, Subscription}
 
   @batch_interval_ms 175
   @max_batch_size 100
@@ -62,6 +62,8 @@ defmodule LassoWeb.Dashboard.EventStream do
 
   defstruct [
     :profile,
+    # Subscribed chains (for detecting config changes)
+    subscribed_chains: MapSet.new(),
     # Event processing
     event_windows: %{},
     pending_events: [],
@@ -84,8 +86,8 @@ defmodule LassoWeb.Dashboard.EventStream do
     },
     # Subscriber management
     subscribers: MapSet.new(),
-    # Account filtering: pid -> account_id (nil = no filter, sees all events)
-    subscriber_accounts: %{},
+    # Activity feed scope: pid -> :profile
+    subscriber_scopes: %{},
     # Timing
     last_tick: 0,
     last_cleanup: 0,
@@ -158,15 +160,20 @@ defmodule LassoWeb.Dashboard.EventStream do
   @doc """
   Subscribe the calling process to receive updates.
 
-  ## Options
-  - `account_id` - Filter routing events to only show this account's traffic.
-    Events with nil account_id are visible to all. Subscribers with nil
-    account_id see all events (no filtering).
+  The read-only dashboard receives sanitized profile-wide activity.
   """
-  def subscribe(profile, account_id \\ nil) do
+  @spec subscribe(String.t()) :: :ok | {:error, term()}
+  def subscribe(profile), do: subscribe(profile, :profile)
+
+  def subscribe(profile, :profile) do
     case ensure_started(profile) do
       {:ok, pid} ->
-        GenServer.cast(pid, {:subscribe, self(), account_id})
+        :telemetry.execute([:lasso, :dashboard, :event_stream, :subscribe], %{}, %{
+          profile: profile,
+          subscriber: self()
+        })
+
+        GenServer.cast(pid, {:subscribe, self(), :profile})
         :ok
 
       {:error, reason} ->
@@ -211,26 +218,21 @@ defmodule LassoWeb.Dashboard.EventStream do
     Logger.info("[EventStream] Starting for profile: #{profile}")
 
     # Subscribe to topology events (NOT net_kernel directly)
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "cluster:topology")
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.cluster_topology())
 
     # Subscribe to routing decisions for this profile
-    Phoenix.PubSub.subscribe(Lasso.PubSub, RoutingDecision.topic(profile))
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.routing_decision(profile))
+
+    # Subscribe to per-profile config update notifications
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.config_profile_updated(profile))
 
     # Subscribe to circuit and block events for each chain
     chains = ConfigStore.list_chains_for_profile(profile)
-
-    for chain <- chains do
-      Phoenix.PubSub.subscribe(Lasso.PubSub, "circuit:events:#{profile}:#{chain}")
-      Phoenix.PubSub.subscribe(Lasso.PubSub, "block_sync:#{profile}:#{chain}")
-      # Provider health events (Healthy, Unhealthy, WSConnected, etc.)
-      Phoenix.PubSub.subscribe(Lasso.PubSub, Provider.topic(profile, chain))
-      # Subscription lifecycle events (Established, Failed, Failover, Stale)
-      Phoenix.PubSub.subscribe(Lasso.PubSub, Subscription.topic(profile, chain))
-    end
+    subscribed_chains = subscribe_to_chains(profile, chains)
 
     # Profile-scoped global topics
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "sync:updates:#{profile}")
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "block_cache:updates:#{profile}")
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.sync_updates(profile))
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.block_cache_updates(profile))
 
     # Don't start tick timer until subscribers join (lazy ticking)
     now = now()
@@ -238,6 +240,7 @@ defmodule LassoWeb.Dashboard.EventStream do
     {:ok,
      %__MODULE__{
        profile: profile,
+       subscribed_chains: subscribed_chains,
        cluster_state: default_cluster_state(),
        last_tick: now,
        last_heartbeat: now - @heartbeat_interval_ms,
@@ -433,7 +436,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   end
 
   # Sync updates - buffer for next batch flush
-  def handle_info(%{chain: _, provider_id: _, block_height: _} = evt, state) do
+  def handle_info(%{chain_id: _, provider_id: _, block_height: _} = evt, state) do
     {:noreply, %{state | pending_sync_updates: [evt | state.pending_sync_updates]}}
   end
 
@@ -445,9 +448,9 @@ defmodule LassoWeb.Dashboard.EventStream do
   # Subscriber died
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
     new_subscribers = MapSet.delete(state.subscribers, pid)
-    new_accounts = Map.delete(state.subscriber_accounts, pid)
+    new_scopes = Map.delete(state.subscriber_scopes, pid)
 
-    state = %{state | subscribers: new_subscribers, subscriber_accounts: new_accounts}
+    state = %{state | subscribers: new_subscribers, subscriber_scopes: new_scopes}
 
     state =
       if MapSet.size(new_subscribers) == 0 do
@@ -469,29 +472,46 @@ defmodule LassoWeb.Dashboard.EventStream do
     end
   end
 
+  # Profile config updated — re-subscribe to any new chain topics
+  def handle_info({:profile_config_updated, profile}, %{profile: profile} = state) do
+    current_chains = ConfigStore.list_chains_for_profile(profile)
+    new_chains = MapSet.difference(MapSet.new(current_chains), state.subscribed_chains)
+
+    if MapSet.size(new_chains) > 0 do
+      new_chain_list = MapSet.to_list(new_chains)
+
+      Logger.info(
+        "[EventStream] Subscribing to #{length(new_chain_list)} new chain(s) for #{profile}"
+      )
+
+      subscribe_to_chains(profile, new_chain_list)
+      {:noreply, %{state | subscribed_chains: MapSet.union(state.subscribed_chains, new_chains)}}
+    else
+      {:noreply, state}
+    end
+  end
+
   # Ignore unknown messages
   def handle_info(_msg, state) do
     {:noreply, state}
   end
 
-  # Subscribe a process with optional account filtering
+  # Subscribe a process with an explicit activity feed scope
   @impl true
-  def handle_cast({:subscribe, pid, account_id}, state) do
+  def handle_cast({:subscribe, pid, scope}, state) do
     Process.monitor(pid)
 
     state = cancel_idle_termination(state)
 
     was_empty = MapSet.size(state.subscribers) == 0
     subscribers = MapSet.put(state.subscribers, pid)
-    subscriber_accounts = Map.put(state.subscriber_accounts, pid, account_id)
+    subscriber_scopes = Map.put(state.subscriber_scopes, pid, scope)
 
     recent_events =
       state.event_windows
       |> get_recent_events(100)
-      |> Enum.filter(fn event ->
-        filter_event_for_account(event, account_id)
-      end)
-      |> Enum.map(&struct_to_map/1)
+      |> Enum.filter(&event_visible_for_scope?(&1, scope))
+      |> Enum.map(&sanitize_routing_event/1)
 
     snapshot = %{
       metrics: state.provider_metrics,
@@ -503,7 +523,7 @@ defmodule LassoWeb.Dashboard.EventStream do
 
     send(pid, {:dashboard_snapshot, snapshot})
 
-    state = %{state | subscribers: subscribers, subscriber_accounts: subscriber_accounts}
+    state = %{state | subscribers: subscribers, subscriber_scopes: subscriber_scopes}
 
     state = if was_empty, do: schedule_tick(state), else: state
 
@@ -512,9 +532,9 @@ defmodule LassoWeb.Dashboard.EventStream do
 
   def handle_cast({:unsubscribe, pid}, state) do
     new_subscribers = MapSet.delete(state.subscribers, pid)
-    new_accounts = Map.delete(state.subscriber_accounts, pid)
+    new_scopes = Map.delete(state.subscriber_scopes, pid)
 
-    state = %{state | subscribers: new_subscribers, subscriber_accounts: new_accounts}
+    state = %{state | subscribers: new_subscribers, subscriber_scopes: new_scopes}
 
     state =
       if MapSet.size(new_subscribers) == 0 do
@@ -584,7 +604,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   end
 
   defp add_event_to_window(event, state) do
-    key = {event.provider_id, event.chain, event.source_node_id}
+    key = {event.provider_id, event.chain_id, event.source_node_id}
     window = Map.get(state.event_windows, key, [])
     new_window = [event | window] |> Enum.take(@max_events_per_key)
     %{state | event_windows: Map.put(state.event_windows, key, new_window)}
@@ -741,7 +761,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   end
 
   defp compute_provider_metrics(provider_id, all_events, _windows, chain_totals, state) do
-    chain = all_events |> List.first() |> then(&(&1 && &1.chain))
+    chain = all_events |> List.first() |> then(&(&1 && Map.get(&1, :chain_id)))
 
     events_by_region = Enum.group_by(all_events, & &1.source_node_id)
 
@@ -794,7 +814,7 @@ defmodule LassoWeb.Dashboard.EventStream do
 
     %{
       provider_id: provider_id,
-      chain: chain,
+      chain_id: chain,
       aggregate: aggregate,
       by_region: by_region,
       updated_at: System.system_time(:millisecond)
@@ -854,11 +874,11 @@ defmodule LassoWeb.Dashboard.EventStream do
   defp find_chain_from_config(profile, provider_id) do
     case ConfigStore.get_profile_chains(profile) do
       {:ok, chains} ->
-        Enum.find_value(chains, fn {chain_name, chain_config} ->
+        Enum.find_value(chains, fn {chain_id, chain_config} ->
           providers = chain_config.providers || []
 
           if Enum.any?(providers, fn p -> p.id == provider_id end) do
-            chain_name
+            chain_id
           end
         end)
 
@@ -973,8 +993,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   defp queue_routing_events(state, events) when events == [], do: state
 
   defp queue_routing_events(state, events) do
-    map_events = Enum.map(events, &struct_to_map/1)
-    %{state | pending_routing_events: Enum.reverse(map_events) ++ state.pending_routing_events}
+    %{state | pending_routing_events: Enum.reverse(events) ++ state.pending_routing_events}
   end
 
   defp struct_to_map(%{__struct__: _} = struct), do: Map.from_struct(struct)
@@ -994,14 +1013,14 @@ defmodule LassoWeb.Dashboard.EventStream do
     %{state | pending_circuit_states: Map.put(state.pending_circuit_states, key, circuit)}
   end
 
-  defp queue_block_update(state, provider_id, node_id, height, chain) do
+  defp queue_block_update(state, provider_id, node_id, height, chain_id) do
     key = {provider_id, node_id}
-    lag = get_block_lag(state, provider_id, chain, node_id)
+    lag = get_block_lag(state, provider_id, chain_id, node_id)
 
     block_data = %{provider_id: provider_id, node_id: node_id, height: height, lag: lag}
 
     block_event = %{
-      chain: chain,
+      chain_id: chain_id,
       block_number: height,
       provider_first: provider_id,
       margin_ms: nil
@@ -1023,8 +1042,8 @@ defmodule LassoWeb.Dashboard.EventStream do
       reset_pending(state)
     else
       for pid <- state.subscribers do
-        account_filter = Map.get(state.subscriber_accounts, pid)
-        send(pid, {:dashboard_batch, filter_batch(batch, account_filter)})
+        scope = Map.get(state.subscriber_scopes, pid)
+        send(pid, {:dashboard_batch, filter_batch(batch, scope)})
       end
 
       reset_pending(state)
@@ -1067,11 +1086,14 @@ defmodule LassoWeb.Dashboard.EventStream do
       batch.block_cache_updates == []
   end
 
-  defp filter_batch(batch, account_filter) do
+  defp filter_batch(batch, scope) do
     %{
       batch
       | routing_events:
-          Enum.filter(batch.routing_events, &filter_event_for_account(&1, account_filter))
+          batch.routing_events
+          |> Enum.filter(&event_visible_for_scope?(&1, scope))
+          |> Enum.map(&sanitize_routing_event/1),
+        subscription_events: batch.subscription_events
     }
   end
 
@@ -1105,7 +1127,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   defp default_provider_metrics do
     %{
       provider_id: nil,
-      chain: nil,
+      chain_id: nil,
       aggregate: %{
         total_calls: 0,
         success_rate: 0.0,
@@ -1165,15 +1187,39 @@ defmodule LassoWeb.Dashboard.EventStream do
     System.monotonic_time(:millisecond)
   end
 
-  # Filter events by account_id for account-scoped dashboard visibility.
-  # - subscriber_account_id nil = no filter, see all events
-  # - otherwise, event must belong to the subscriber's account (nil account_id events are excluded)
-  defp filter_event_for_account(_event, nil), do: true
+  defp event_visible_for_scope?(_event, :profile), do: true
+  defp event_visible_for_scope?(_event, _scope), do: false
 
-  defp filter_event_for_account(event, subscriber_account_id) do
-    get_event_account_id(event) == subscriber_account_id
+  defp sanitize_routing_event(event) do
+    event
+    |> struct_to_map()
+    |> Map.take([
+      :request_id,
+      :chain_id,
+      :method,
+      :strategy,
+      :provider_id,
+      :source_node_id,
+      :duration_ms,
+      :result,
+      :failovers,
+      :failover_count,
+      :ts,
+      :ts_ms,
+      :type,
+      :event,
+      :subscription_type
+    ])
   end
 
-  defp get_event_account_id(%{account_id: account_id}), do: account_id
-  defp get_event_account_id(_), do: nil
+  defp subscribe_to_chains(profile, chains) do
+    for chain <- chains do
+      Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.circuit_event(profile, chain))
+      Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.block_sync(profile, chain))
+      Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.provider_event(profile, chain))
+      Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.subscription_event(profile, chain))
+    end
+
+    MapSet.new(chains)
+  end
 end

--- a/lib/lasso_web/dashboard/helpers.ex
+++ b/lib/lasso_web/dashboard/helpers.ex
@@ -3,7 +3,7 @@ defmodule LassoWeb.Dashboard.Helpers do
   General utility functions for the Dashboard LiveView.
   """
 
-  alias Lasso.Config.ConfigStore
+  alias Lasso.Config.{ChainAlias, ConfigStore}
 
   @doc "Convert various number types to float"
   def to_float(value) when is_integer(value), do: value * 1.0
@@ -101,24 +101,29 @@ defmodule LassoWeb.Dashboard.Helpers do
   @doc "Get available chains from configuration"
   def get_available_chains do
     ConfigStore.get_all_chains()
-    |> Enum.map(fn {chain_name, chain_config} ->
+    |> Enum.map(fn {chain_id, chain_config} ->
       %{
-        id: to_string(chain_config.chain_id),
-        name: chain_name,
-        display_name: chain_config.name
+        id: to_string(chain_id),
+        name: ChainAlias.canonical_slug(chain_id, chain_config.url_aliases),
+        display_name: chain_config.display_name || ChainAlias.display_name(chain_id)
       }
     end)
   end
 
   @doc "Get human-readable display name for a chain from config"
-  def get_chain_display_name(profile, chain_name) do
-    case ConfigStore.get_chain(profile, chain_name) do
-      {:ok, %{name: display_name}} when is_binary(display_name) ->
+  def get_chain_display_name(profile, chain_identifier) do
+    case ConfigStore.get_chain(profile, chain_identifier) do
+      {:ok, %{display_name: display_name}} when is_binary(display_name) ->
         display_name
 
+      {:ok, %{chain_id: chain_id}} when is_integer(chain_id) ->
+        ChainAlias.display_name(chain_id)
+
+      _ when is_binary(chain_identifier) ->
+        String.capitalize(chain_identifier)
+
       _ ->
-        # Fallback to capitalized chain name if not found in config
-        chain_name |> String.capitalize()
+        to_string(chain_identifier)
     end
   end
 

--- a/lib/lasso_web/dashboard/message_handlers.ex
+++ b/lib/lasso_web/dashboard/message_handlers.ex
@@ -26,14 +26,14 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
       when is_struct(evt, Provider.Healthy) or is_struct(evt, Provider.Unhealthy) or
              is_struct(evt, Provider.HealthCheckFailed) or is_struct(evt, Provider.WSConnected) or
              is_struct(evt, Provider.WSClosed) or is_struct(evt, Provider.WSDisconnected) do
-    {chain, pid, event_type, details, ts} = extract_provider_event_data(evt)
+    {chain_id, pid, event_type, details, ts} = extract_provider_event_data(evt)
 
-    if chain in Map.get(socket.assigns, :profile_chains, []) and
+    if chain_id in Map.get(socket.assigns, :profile_chains, []) and
          valid_provider?(socket, pid) do
       entry = %{
         ts: DateTime.utc_now() |> DateTime.to_time() |> to_string(),
         ts_ms: ts,
-        chain: chain,
+        chain_id: chain_id,
         provider_id: pid,
         event: event_type,
         details: details
@@ -41,7 +41,7 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
 
       uev =
         Helpers.as_event(:provider,
-          chain: chain,
+          chain_id: chain_id,
           provider_id: pid,
           severity: :info,
           message: to_string(event_type),
@@ -52,7 +52,7 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
       |> update(:provider_events, &[entry | Enum.take(&1, Constants.provider_events_limit() - 1)])
       |> buffer_event_fn.(uev)
       |> maybe_refresh_provider(pid, fetch_connections_fn, update_provider_fn)
-      |> maybe_update_chain(chain, update_chain_fn)
+      |> maybe_update_chain(chain_id, update_chain_fn)
     else
       socket
     end
@@ -60,22 +60,22 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
 
   defp extract_provider_event_data(evt) do
     case evt do
-      %Provider.Healthy{chain: c, provider_id: p, ts: t} ->
+      %Provider.Healthy{chain_id: c, provider_id: p, ts: t} ->
         {c, p, :healthy, nil, t}
 
-      %Provider.Unhealthy{chain: c, provider_id: p, ts: t} ->
+      %Provider.Unhealthy{chain_id: c, provider_id: p, ts: t} ->
         {c, p, :unhealthy, nil, t}
 
-      %Provider.HealthCheckFailed{chain: c, provider_id: p, reason: r, ts: t} ->
+      %Provider.HealthCheckFailed{chain_id: c, provider_id: p, reason: r, ts: t} ->
         {c, p, :health_check_failed, %{reason: r}, t}
 
-      %Provider.WSConnected{chain: c, provider_id: p, ts: t} ->
+      %Provider.WSConnected{chain_id: c, provider_id: p, ts: t} ->
         {c, p, :ws_connected, nil, t}
 
-      %Provider.WSClosed{chain: c, provider_id: p, code: code, reason: r, ts: t} ->
+      %Provider.WSClosed{chain_id: c, provider_id: p, code: code, reason: r, ts: t} ->
         {c, p, :ws_closed, %{code: code, reason: r}, t}
 
-      %Provider.WSDisconnected{chain: c, provider_id: p, reason: r, ts: t} ->
+      %Provider.WSDisconnected{chain_id: c, provider_id: p, reason: r, ts: t} ->
         {c, p, :ws_disconnected, %{reason: r}, t}
     end
   end
@@ -114,22 +114,20 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
 
     events
     |> Enum.filter(fn e ->
-      # Include routing-decision style events with either atom or string keys.
-      # Be tolerant of chain field shapes to avoid dropping valid HTTP events.
       method = normalize_string(field(e, :method))
-      chain = normalize_string(field(e, :chain))
+      chain_id = extract_chain_id(e)
 
-      is_binary(method) and is_binary(chain) and
-        (MapSet.size(profile_chains_set) == 0 or MapSet.member?(profile_chains_set, chain))
+      is_binary(method) and is_integer(chain_id) and
+        (MapSet.size(profile_chains_set) == 0 or MapSet.member?(profile_chains_set, chain_id))
     end)
     |> Enum.map(fn e ->
-      chain = normalize_string(field(e, :chain))
+      chain_id = extract_chain_id(e)
       method = normalize_string(field(e, :method))
 
       %{
         ts: format_time(field(e, :ts)),
         ts_ms: normalize_timestamp(field(e, :ts)),
-        chain: chain,
+        chain_id: chain_id,
         method: method,
         strategy: field(e, :strategy),
         provider_id: field(e, :provider_id),
@@ -142,6 +140,13 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
     end)
   end
 
+  defp extract_chain_id(event) do
+    case field(event, :chain_id) do
+      id when is_integer(id) and id > 0 -> id
+      _ -> nil
+    end
+  end
+
   defp field(map, key) when is_map(map) do
     Map.get(map, key) || Map.get(map, Atom.to_string(key))
   end
@@ -151,15 +156,15 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
   defp normalize_string(_), do: nil
 
   def handle_subscription_event(evt, socket, buffer_event_fn) do
-    {chain, provider_id, event_kind, sub_type, details, ts} =
+    {chain_id, provider_id, event_kind, sub_type, details, ts} =
       extract_subscription_event_data(evt)
 
-    if chain in Map.get(socket.assigns, :profile_chains, []) do
+    if chain_id in Map.get(socket.assigns, :profile_chains, []) do
       entry = %{
         type: :ws_lifecycle,
         ts: format_time(ts),
         ts_ms: ts,
-        chain: chain,
+        chain_id: chain_id,
         provider_id: provider_id,
         event: event_kind,
         subscription_type: sub_type,
@@ -168,7 +173,7 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
 
       uev =
         Helpers.as_event(:subscription,
-          chain: chain,
+          chain_id: chain_id,
           provider_id: provider_id,
           severity: subscription_event_severity(event_kind),
           message: subscription_event_label(event_kind, sub_type),
@@ -184,21 +189,21 @@ defmodule LassoWeb.Dashboard.MessageHandlers do
   end
 
   defp extract_subscription_event_data(%Subscription.Established{} = evt) do
-    {evt.chain, evt.provider_id, :subscription_established, evt.subscription_type, %{}, evt.ts}
+    {evt.chain_id, evt.provider_id, :subscription_established, evt.subscription_type, %{}, evt.ts}
   end
 
   defp extract_subscription_event_data(%Subscription.Failed{} = evt) do
-    {evt.chain, evt.provider_id, :subscription_failed, evt.subscription_type,
+    {evt.chain_id, evt.provider_id, :subscription_failed, evt.subscription_type,
      %{reason: evt.reason}, evt.ts}
   end
 
   defp extract_subscription_event_data(%Subscription.Failover{} = evt) do
-    {evt.chain, evt.to_provider_id, :subscription_failover, evt.subscription_type,
+    {evt.chain_id, evt.to_provider_id, :subscription_failover, evt.subscription_type,
      %{from_provider_id: evt.from_provider_id, to_provider_id: evt.to_provider_id}, evt.ts}
   end
 
   defp extract_subscription_event_data(%Subscription.Stale{} = evt) do
-    {evt.chain, evt.provider_id, :subscription_stale, evt.subscription_type,
+    {evt.chain_id, evt.provider_id, :subscription_stale, evt.subscription_type,
      %{stale_duration_ms: evt.stale_duration_ms}, evt.ts}
   end
 

--- a/lib/lasso_web/dashboard/metrics_store.ex
+++ b/lib/lasso_web/dashboard/metrics_store.ex
@@ -53,7 +53,7 @@ defmodule LassoWeb.Dashboard.MetricsStore do
   Gets provider leaderboard aggregated across all cluster nodes.
   Returns cached data with coverage metadata. Reads ETS directly.
   """
-  @spec get_provider_leaderboard(String.t(), String.t()) :: cached_result(list())
+  @spec get_provider_leaderboard(String.t(), pos_integer()) :: cached_result(list())
   def get_provider_leaderboard(profile, chain) do
     key = {:provider_leaderboard, profile, chain}
     ets_read_or_refresh(key, [])
@@ -63,7 +63,7 @@ defmodule LassoWeb.Dashboard.MetricsStore do
   Gets realtime stats aggregated across all cluster nodes.
   Reads ETS directly.
   """
-  @spec get_realtime_stats(String.t(), String.t()) :: cached_result(map())
+  @spec get_realtime_stats(String.t(), pos_integer()) :: cached_result(map())
   def get_realtime_stats(profile, chain) do
     key = {:realtime_stats, profile, chain}
 
@@ -79,7 +79,7 @@ defmodule LassoWeb.Dashboard.MetricsStore do
   Gets RPC method performance with percentiles from all nodes.
   Reads ETS directly.
   """
-  @spec get_rpc_method_performance(String.t(), String.t(), String.t(), String.t()) ::
+  @spec get_rpc_method_performance(String.t(), pos_integer(), String.t(), String.t()) ::
           cached_result(map() | nil)
   def get_rpc_method_performance(profile, chain, provider_id, method) do
     key = {:method_perf, profile, chain, provider_id, method}
@@ -90,7 +90,7 @@ defmodule LassoWeb.Dashboard.MetricsStore do
   Gets all method performance data for a profile/chain in one bulk call.
   Reads ETS directly.
   """
-  @spec get_bulk_method_performance(String.t(), String.t()) :: cached_result(list())
+  @spec get_bulk_method_performance(String.t(), pos_integer()) :: cached_result(list())
   def get_bulk_method_performance(profile, chain) do
     key = {:bulk_method_perf, profile, chain}
     ets_read_or_refresh(key, [])

--- a/lib/lasso_web/dashboard/status_helpers.ex
+++ b/lib/lasso_web/dashboard/status_helpers.ex
@@ -124,13 +124,14 @@ defmodule LassoWeb.Dashboard.StatusHelpers do
   - :degraded_no_data - Block height polling is failing (distinct from startup transient)
   - :unavailable - No lag data available (fail-open for startup/transient)
   """
-  def check_block_lag(chain, provider_id) when is_binary(chain) and is_binary(provider_id) do
+  def check_block_lag(chain_id, provider_id)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) do
     threshold = lag_threshold_blocks()
 
     if threshold == 0 do
       :synced
     else
-      case calculate_optimistic_lag(chain, provider_id) do
+      case calculate_optimistic_lag(chain_id, provider_id) do
         {:ok, optimistic_lag} when optimistic_lag >= -threshold ->
           :synced
 
@@ -138,7 +139,7 @@ defmodule LassoWeb.Dashboard.StatusHelpers do
           :lagging
 
         {:error, _reason} ->
-          case check_block_height_source_status(chain, provider_id) do
+          case check_block_height_source_status(chain_id, provider_id) do
             :polling_failing -> :degraded_no_data
             _ -> :unavailable
           end
@@ -180,9 +181,9 @@ defmodule LassoWeb.Dashboard.StatusHelpers do
   - :ok - Block height tracking is working (has recent height data)
   - :polling_failing - No recent height data
   """
-  def check_block_height_source_status(chain, provider_id)
-      when is_binary(chain) and is_binary(provider_id) do
-    case BlockSyncRegistry.get_height(chain, provider_id) do
+  def check_block_height_source_status(chain_id, provider_id)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) do
+    case BlockSyncRegistry.get_height(chain_id, provider_id) do
       {:ok, {_height, timestamp, _source, _meta}} ->
         # Check if data is recent (within 60 seconds)
         age = System.system_time(:millisecond) - timestamp

--- a/lib/lasso_web/plugs/profile_resolver_plug.ex
+++ b/lib/lasso_web/plugs/profile_resolver_plug.ex
@@ -16,6 +16,7 @@ defmodule LassoWeb.Plugs.ProfileResolverPlug do
 
   ## Assigns
   - `:profile_slug` - The validated profile slug from the URL (e.g., "public", "testnet")
+  - `:profile_id` - The opaque runtime profile ID used by the pipeline
   - `:profile` - Full profile metadata from ConfigStore
 
   ## Default Profile Fallback
@@ -42,6 +43,7 @@ defmodule LassoWeb.Plugs.ProfileResolverPlug do
           {:ok, profile_meta} ->
             conn
             |> assign(:profile_slug, validated_slug)
+            |> assign(:profile_id, profile_meta.profile_id)
             |> assign(:profile, profile_meta)
 
           {:error, :not_found} ->

--- a/lib/lasso_web/rpc/helpers.ex
+++ b/lib/lasso_web/rpc/helpers.ex
@@ -29,7 +29,7 @@ defmodule LassoWeb.RPC.Helpers do
   Normalizes strategy tokens from params/routes into strategy atoms.
   """
   @spec normalize_strategy_token(String.t() | nil) ::
-          :load_balanced | :latency_weighted | :fastest | nil
+          :load_balanced | :latency_weighted | :fastest | :priority | nil
   def normalize_strategy_token("fastest"), do: :fastest
   def normalize_strategy_token("load-balanced"), do: :load_balanced
   def normalize_strategy_token("load_balanced"), do: :load_balanced
@@ -37,6 +37,7 @@ defmodule LassoWeb.RPC.Helpers do
   def normalize_strategy_token("round_robin"), do: :load_balanced
   def normalize_strategy_token("latency-weighted"), do: :latency_weighted
   def normalize_strategy_token("latency_weighted"), do: :latency_weighted
+  def normalize_strategy_token("priority"), do: :priority
   def normalize_strategy_token(_), do: nil
 
   @doc """
@@ -63,7 +64,8 @@ defmodule LassoWeb.RPC.Helpers do
       {:error, "Chain not configured: unknown"}
 
   """
-  @spec get_chain_id(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec get_chain_id(String.t(), pos_integer() | String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
   def get_chain_id(profile, chain_name) do
     case ConfigStore.get_chain(profile, chain_name) do
       {:ok, %{chain_id: chain_id}} when is_integer(chain_id) ->

--- a/lib/lasso_web/sockets/rpc_socket.ex
+++ b/lib/lasso_web/sockets/rpc_socket.ex
@@ -47,17 +47,28 @@ defmodule LassoWeb.RPCSocket do
     connection_id = :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
 
     params = transport_info[:params] || %{}
-    uri = transport_info[:connect_info][:uri]
-    chain = params["chain_id"] || "ethereum"
+    connect_info = transport_info[:connect_info] || %{}
+    uri = connect_info[:uri]
+    chain_identifier = params["chain_id"] || "ethereum"
 
     {strategy, provider_id} = extract_routing_params(uri, params)
 
-    with {:ok, profile} <- validate_profile(params["profile"], connection_id),
-         :ok <- validate_provider_override(profile, chain, provider_id, connection_id) do
+    with {:ok, profile_slug} <- validate_profile(params["profile"], connection_id),
+         {:ok, profile_meta} <- ConfigStore.get_profile(profile_slug),
+         {:ok, chain_id} <- resolve_chain_id(profile_meta.profile_id, chain_identifier),
+         :ok <-
+           validate_provider_override(
+             profile_meta.profile_id,
+             chain_id,
+             provider_id,
+             connection_id
+           ) do
       socket_state = %{
-        profile: profile,
-        chain: chain,
-        strategy: strategy,
+        profile: profile_meta.profile_id,
+        profile_slug: profile_slug,
+        chain_id: chain_id,
+        strategy: strategy || default_provider_strategy(),
+        requested_strategy: strategy || default_provider_strategy(),
         provider_id: provider_id,
         subscriptions: %{},
         client_pid: self(),
@@ -71,10 +82,18 @@ defmodule LassoWeb.RPCSocket do
       routing_info = build_routing_info(strategy, provider_id)
 
       Logger.info(
-        "JSON-RPC WebSocket client connected: #{profile}:#{chain}#{routing_info} (id: #{connection_id}, ip: #{client_ip})"
+        "JSON-RPC WebSocket client connected: #{profile_slug}:#{chain_id}#{routing_info} (id: #{connection_id}, ip: #{client_ip})"
       )
 
       {:ok, socket_state}
+    else
+      reason ->
+        Logger.warning("WebSocket connection rejected: #{inspect(reason)}",
+          connection_id: connection_id,
+          client_ip: client_ip
+        )
+
+        :error
     end
   end
 
@@ -96,15 +115,15 @@ defmodule LassoWeb.RPCSocket do
 
   defp validate_provider_override(_profile, _chain, nil, _connection_id), do: :ok
 
-  defp validate_provider_override(profile, chain, provider_id, connection_id) do
-    case ConfigStore.get_provider(profile, chain, provider_id) do
+  defp validate_provider_override(profile, chain_id, provider_id, connection_id) do
+    case ConfigStore.get_provider(profile, chain_id, provider_id) do
       {:ok, _provider} ->
         :ok
 
       {:error, _} ->
         Logger.warning("WebSocket connection rejected: provider not found",
           provided_provider: provider_id,
-          chain: chain,
+          chain_id: chain_id,
           profile: profile,
           connection_id: connection_id
         )
@@ -238,7 +257,7 @@ defmodule LassoWeb.RPCSocket do
 
     # Unsubscribe all active subscriptions
     Enum.each(state.subscriptions, fn {subscription_id, _type} ->
-      SubscriptionRouter.unsubscribe(state.profile, state.chain, subscription_id)
+      SubscriptionRouter.unsubscribe(state.profile, state.chain_id, subscription_id)
     end)
 
     :ok
@@ -255,9 +274,9 @@ defmodule LassoWeb.RPCSocket do
 
     # Create request context for observability
     ctx =
-      RequestContext.new(state.chain, method, params_list,
+      RequestContext.new(state.chain_id, method, params_list,
         transport: :ws,
-        strategy: default_provider_strategy()
+        strategy: state.strategy
       )
 
     case handle_rpc_method(method, params_list, state, ctx) do
@@ -327,7 +346,9 @@ defmodule LassoWeb.RPCSocket do
   defp handle_rpc_method("eth_subscribe", [subscription_type | rest], state, ctx) do
     case subscription_type do
       "newHeads" ->
-        case SubscriptionRouter.subscribe(state.profile, state.chain, {:newHeads}) do
+        case SubscriptionRouter.subscribe(state.profile, state.chain_id, {:newHeads},
+               provider_id: state.provider_id
+             ) do
           {:ok, subscription_id} ->
             new_state = update_subscriptions(state, subscription_id, "newHeads")
             updated_ctx = RequestContext.record_success(ctx, subscription_id)
@@ -342,7 +363,9 @@ defmodule LassoWeb.RPCSocket do
       "logs" ->
         filter = List.first(rest, %{})
 
-        case SubscriptionRouter.subscribe(state.profile, state.chain, {:logs, filter}) do
+        case SubscriptionRouter.subscribe(state.profile, state.chain_id, {:logs, filter},
+               provider_id: state.provider_id
+             ) do
           {:ok, subscription_id} ->
             new_state = update_subscriptions(state, subscription_id, {"logs", filter})
             updated_ctx = RequestContext.record_success(ctx, subscription_id)
@@ -368,7 +391,7 @@ defmodule LassoWeb.RPCSocket do
         {:ok, false, state, updated_ctx}
 
       {_subscription_type, updated_subscriptions} ->
-        SubscriptionRouter.unsubscribe(state.profile, state.chain, subscription_id)
+        SubscriptionRouter.unsubscribe(state.profile, state.chain_id, subscription_id)
         new_state = %{state | subscriptions: updated_subscriptions}
         updated_ctx = RequestContext.record_success(ctx, true)
         {:ok, true, new_state, updated_ctx}
@@ -378,7 +401,7 @@ defmodule LassoWeb.RPCSocket do
   defp handle_rpc_method("eth_chainId", [], state, ctx) do
     # Note: We don't have request_id here, so we can't build a Response.Success
     # This is fine - subscriptions and chainId return plain values, only pipeline results are Response.Success
-    case get_chain_id(state.profile, state.chain) do
+    case get_chain_id(state.profile, state.chain_id) do
       {:ok, chain_id} ->
         updated_ctx = RequestContext.record_success(ctx, chain_id)
         {:ok, chain_id, state, updated_ctx}
@@ -391,18 +414,19 @@ defmodule LassoWeb.RPCSocket do
 
   # Generic read-only method forwarding
   defp handle_rpc_method(method, params, state, ctx) do
-    strategy = state[:strategy] || default_provider_strategy()
+    strategy = state.strategy || default_provider_strategy()
 
     request_opts = %RequestOptions{
+      profile: state.profile,
       strategy: strategy,
       timeout_ms: 10_000,
       request_context: ctx,
-      provider_override: state[:provider_id]
+      provider_override: state.provider_id
     }
 
     # Pass context to RequestPipeline
     case RequestPipeline.execute_via_channels(
-           state.chain,
+           state.chain_id,
            method,
            params,
            request_opts
@@ -424,6 +448,13 @@ defmodule LassoWeb.RPCSocket do
 
   defp get_chain_id(profile, chain_name) do
     Helpers.get_chain_id(profile, chain_name)
+  end
+
+  defp resolve_chain_id(profile, identifier) when is_binary(identifier) do
+    case ConfigStore.lookup_chain_id_in_profile(profile, identifier) do
+      {:ok, chain_id} -> {:ok, chain_id}
+      :not_found -> {:error, "Unknown chain '#{identifier}'"}
+    end
   end
 
   defp default_provider_strategy do
@@ -466,8 +497,10 @@ defmodule LassoWeb.RPCSocket do
   # Map URL strategy strings to atoms (avoids String.to_atom)
   @strategy_map %{
     "fastest" => :fastest,
+    "load-balanced" => :load_balanced,
     "round-robin" => :load_balanced,
-    "latency-weighted" => :latency_weighted
+    "latency-weighted" => :latency_weighted,
+    "priority" => :priority
   }
 
   defp extract_routing_params(nil, _params), do: {nil, nil}
@@ -508,7 +541,13 @@ defmodule LassoWeb.RPCSocket do
   end
 
   defp extract_routing_params(%URI{} = uri, params) do
-    extract_routing_params(uri.path, params)
+    strategy = Helpers.normalize_strategy_token(params["strategy"])
+    provider_id = params["provider_id"]
+
+    case {strategy, provider_id} do
+      {nil, nil} -> extract_routing_params(uri.path, params)
+      routing -> routing
+    end
   end
 
   defp build_routing_info(nil, nil), do: ""
@@ -516,6 +555,10 @@ defmodule LassoWeb.RPCSocket do
 
   defp build_routing_info(nil, provider_id) when is_binary(provider_id),
     do: " [provider: #{provider_id}]"
+
+  defp build_routing_info(strategy, provider_id)
+       when is_atom(strategy) and is_binary(provider_id),
+       do: " [strategy: #{strategy}, provider: #{provider_id}]"
 
   ## Connection tracking helpers
 

--- a/test/integration/authenticated_probe_test.exs
+++ b/test/integration/authenticated_probe_test.exs
@@ -1,0 +1,75 @@
+defmodule Lasso.Providers.AuthenticatedProbeTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Config.ConfigStore
+  alias Lasso.Providers
+
+  @moduletag :integration
+
+  defmodule ProbeEndpoint do
+    import Plug.Conn
+
+    def init(opts), do: opts
+
+    def call(conn, opts) do
+      {:ok, body, conn} = read_body(conn)
+      request = Jason.decode!(body)
+      headers = Map.new(conn.req_headers)
+      send(opts[:test_pid], {:probe_request, request["method"], headers})
+
+      chain_hex = "0x" <> Integer.to_string(opts[:chain_id], 16)
+
+      response =
+        Jason.encode!(%{"jsonrpc" => "2.0", "id" => request["id"], "result" => chain_hex})
+
+      conn
+      |> put_resp_content_type("application/json")
+      |> send_resp(200, response)
+    end
+  end
+
+  test "health probes send the same provider authentication headers as routed requests" do
+    chain_id = 700_000_000 + rem(System.unique_integer([:positive]), 100_000_000)
+    provider_id = "authenticated-probe-#{chain_id}"
+    ref = {:probe_endpoint, chain_id}
+
+    {:ok, _pid} =
+      Plug.Cowboy.http(ProbeEndpoint, [test_pid: self(), chain_id: chain_id],
+        ref: ref,
+        port: 0
+      )
+
+    port = :ranch.get_port(ref)
+
+    on_exit(fn ->
+      Providers.remove_provider(chain_id, provider_id)
+      Lasso.ProfileChainSupervisor.stop_profile_chain("public", chain_id)
+      ConfigStore.unregister_chain_runtime("public", chain_id)
+      Plug.Cowboy.shutdown(ref)
+    end)
+
+    :ok =
+      ConfigStore.register_chain_runtime("public", chain_id, %{
+        display_name: "Authenticated Probe",
+        url_aliases: ["authenticated-probe-#{chain_id}"],
+        providers: []
+      })
+
+    assert {:ok, ^provider_id} =
+             Providers.add_provider(
+               chain_id,
+               %{
+                 id: provider_id,
+                 name: "Authenticated Probe Provider",
+                 url: "http://127.0.0.1:#{port}",
+                 api_key: "probe-secret",
+                 headers: %{"x-provider-network" => "local"}
+               },
+               validate: false
+             )
+
+    assert_receive {:probe_request, "eth_chainId", headers}, 3_000
+    assert headers["authorization"] == "Bearer probe-secret"
+    assert headers["x-provider-network"] == "local"
+  end
+end

--- a/test/integration/dynamic_providers_test.exs
+++ b/test/integration/dynamic_providers_test.exs
@@ -25,12 +25,43 @@ defmodule Lasso.Integration.DynamicProvidersTest do
     }
   ]
 
-  setup_all do
+  setup do
     :ok = ChainHelper.ensure_chain_exists(@test_chain)
     :ok
   end
 
   describe "Dynamic Provider Management" do
+    test "starts supervision for a runtime-registered chain" do
+      chain_id = 900_000_000 + :rand.uniform(99_999_999)
+      provider_id = "runtime-chain-provider-#{chain_id}"
+
+      :ok =
+        Lasso.Config.ConfigStore.register_chain_runtime("public", chain_id, %{
+          display_name: "Runtime Chain",
+          url_aliases: ["runtime-#{chain_id}"],
+          providers: []
+        })
+
+      on_exit(fn ->
+        Providers.remove_provider(chain_id, provider_id)
+        Lasso.Config.ConfigStore.unregister_chain_runtime("public", chain_id)
+      end)
+
+      assert {:ok, ^provider_id} =
+               Providers.add_provider(
+                 chain_id,
+                 %{
+                   id: provider_id,
+                   name: "Runtime Chain Provider",
+                   url: "http://127.0.0.1:1",
+                   priority: 1
+                 },
+                 validate: false
+               )
+
+      assert Lasso.ProfileChainSupervisor.running?("public", chain_id)
+    end
+
     setup do
       # Use unique provider ID per test to avoid conflicts
       test_id = "test_dynamic_#{:erlang.unique_integer([:positive])}"

--- a/test/integration/dynamic_providers_test.exs
+++ b/test/integration/dynamic_providers_test.exs
@@ -4,9 +4,9 @@ defmodule Lasso.Integration.DynamicProvidersTest do
   @moduletag :integration
 
   alias Lasso.Providers
-  alias Lasso.Testing.MockProvider
+  alias Lasso.Testing.{ChainHelper, MockProvider}
 
-  @test_chain "ethereum"
+  @test_chain 1
 
   # Use mock providers for deterministic testing
   @test_providers [
@@ -24,6 +24,11 @@ defmodule Lasso.Integration.DynamicProvidersTest do
       priority: 60
     }
   ]
+
+  setup_all do
+    :ok = ChainHelper.ensure_chain_exists(@test_chain)
+    :ok
+  end
 
   describe "Dynamic Provider Management" do
     setup do
@@ -64,18 +69,45 @@ defmodule Lasso.Integration.DynamicProvidersTest do
       assert dynamic_provider.has_ws == true
     end
 
-    test "can remove a provider dynamically", %{provider_config: config, test_id: test_id} do
-      # Add provider first
+    test "removal unregisters before rebuilding routing and reaps an unreferenced instance", %{
+      provider_config: config,
+      test_id: test_id
+    } do
+      alias Lasso.BlockSync.Worker
+      alias Lasso.Providers.{Catalog, InstanceSupervisor}
+
       assert {:ok, _id} = Providers.add_provider(@test_chain, config)
+      instance_id = Catalog.lookup_instance_id("public", @test_chain, test_id)
+      assert is_binary(instance_id)
 
-      # Verify it exists
-      assert {:ok, _provider} = Providers.get_provider(@test_chain, test_id)
+      assert %{provider_id: ^test_id} =
+               Enum.find(
+                 Catalog.get_profile_providers("public", @test_chain),
+                 &(&1.provider_id == test_id)
+               )
 
-      # Remove provider
+      assert eventually(fn ->
+               GenServer.whereis(InstanceSupervisor.via_name(instance_id)) != nil
+             end)
+
+      assert eventually(fn -> GenServer.whereis(Worker.via(@test_chain, instance_id)) != nil end)
+
       assert :ok = Providers.remove_provider(@test_chain, test_id)
 
-      # Verify it's gone
       assert {:error, :not_found} = Providers.get_provider(@test_chain, test_id)
+
+      refute Enum.any?(
+               Catalog.get_profile_providers("public", @test_chain),
+               &(&1.provider_id == test_id)
+             )
+
+      assert Catalog.get_instance_refs(instance_id) == []
+
+      assert eventually(fn ->
+               GenServer.whereis(InstanceSupervisor.via_name(instance_id)) == nil
+             end)
+
+      assert eventually(fn -> GenServer.whereis(Worker.via(@test_chain, instance_id)) == nil end)
     end
 
     test "prevents adding duplicate providers", %{provider_config: config, test_id: test_id} do
@@ -273,6 +305,18 @@ defmodule Lasso.Integration.DynamicProvidersTest do
       assert {:ok, block_number} = Lasso.RPC.Response.Success.decode_result(response)
       assert is_binary(block_number)
       assert String.starts_with?(block_number, "0x")
+    end
+  end
+
+  defp eventually(fun, attempts \\ 40)
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(25)
+      eventually(fun, attempts - 1)
     end
   end
 end

--- a/test/integration/dynamic_providers_test.exs
+++ b/test/integration/dynamic_providers_test.exs
@@ -60,6 +60,8 @@ defmodule Lasso.Integration.DynamicProvidersTest do
                )
 
       assert Lasso.ProfileChainSupervisor.running?("public", chain_id)
+
+      assert is_pid(GenServer.whereis(Lasso.Providers.ProbeCoordinator.via_name(chain_id)))
     end
 
     setup do
@@ -83,6 +85,60 @@ defmodule Lasso.Integration.DynamicProvidersTest do
       end)
 
       {:ok, provider_config: provider_config, test_id: test_id}
+    end
+
+    test "preserves runtime provider authentication and isolates physical instances" do
+      suffix = System.unique_integer([:positive])
+      first_id = "auth-first-#{suffix}"
+      second_id = "auth-second-#{suffix}"
+      url = "http://127.0.0.1:1"
+
+      on_exit(fn ->
+        Providers.remove_provider(@test_chain, first_id)
+        Providers.remove_provider(@test_chain, second_id)
+      end)
+
+      assert {:ok, ^first_id} =
+               Providers.add_provider(
+                 @test_chain,
+                 %{
+                   id: first_id,
+                   name: "First Auth Provider",
+                   url: url,
+                   api_key: "first-secret",
+                   headers: %{"x-network" => "first"}
+                 },
+                 validate: false
+               )
+
+      assert {:ok, ^second_id} =
+               Providers.add_provider(
+                 @test_chain,
+                 %{
+                   id: second_id,
+                   name: "Second Auth Provider",
+                   url: url,
+                   api_key: "second-secret",
+                   headers: %{"x-network" => "second"}
+                 },
+                 validate: false
+               )
+
+      assert {:ok, first} =
+               Lasso.Config.ConfigStore.get_provider("public", @test_chain, first_id)
+
+      assert first.api_key == "first-secret"
+      assert first.headers == %{"x-network" => "first"}
+
+      first_instance =
+        Lasso.Providers.Catalog.lookup_instance_id("public", @test_chain, first_id)
+
+      second_instance =
+        Lasso.Providers.Catalog.lookup_instance_id("public", @test_chain, second_id)
+
+      assert is_binary(first_instance)
+      assert is_binary(second_instance)
+      refute first_instance == second_instance
     end
 
     test "can add a provider dynamically", %{provider_config: config, test_id: test_id} do
@@ -148,6 +204,9 @@ defmodule Lasso.Integration.DynamicProvidersTest do
       # Try to add again
       assert {:error, {:already_exists, ^test_id}} =
                Providers.add_provider(@test_chain, config)
+
+      assert {:ok, existing} = Providers.get_provider(@test_chain, test_id)
+      assert existing.id == test_id
     end
 
     test "can list all providers with status", %{provider_config: config} do
@@ -239,8 +298,8 @@ defmodule Lasso.Integration.DynamicProvidersTest do
       assert {:ok, providers} = Providers.list_providers(@test_chain)
       dynamic = Enum.find(providers, fn p -> p.id == test_id end)
 
-      # Should be in connecting or healthy state
-      assert dynamic.status in [:connecting, :healthy]
+      assert dynamic.status in [:connecting, :healthy, :degraded, :unhealthy, :rate_limited]
+      assert dynamic.has_http
     end
 
     test "removed provider disappears from routing", %{provider_config: config, test_id: test_id} do

--- a/test/integration/mock_http_provider_lifecycle_test.exs
+++ b/test/integration/mock_http_provider_lifecycle_test.exs
@@ -1,0 +1,102 @@
+defmodule Lasso.Testing.MockHTTPProviderLifecycleTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Config.ConfigStore
+  alias Lasso.Providers.{Catalog, ProbeCoordinator}
+  alias Lasso.RPC.TransportRegistry
+  alias Lasso.Testing.MockHTTPProvider
+
+  @moduletag :integration
+
+  test "startup is ready synchronously and teardown removes every routing surface" do
+    chain_id = unique_chain_id()
+    provider_id = "lifecycle-provider"
+
+    assert {:ok, ^provider_id} = start_mock("public", chain_id, provider_id)
+    assert_provider_ready("public", chain_id, provider_id)
+
+    assert :ok = MockHTTPProvider.stop_mock("public", chain_id, provider_id)
+    refute_provider_present("public", chain_id, provider_id)
+
+    assert {:ok, ^provider_id} = start_mock("public", chain_id, provider_id)
+    assert_provider_ready("public", chain_id, provider_id)
+
+    assert :ok = MockHTTPProvider.stop_mock("public", chain_id, provider_id)
+    refute_provider_present("public", chain_id, provider_id)
+
+    stop_chain("public", chain_id)
+  end
+
+  test "teardown uses the profile that owns the provider" do
+    profile = "fixture-profile-#{System.unique_integer([:positive])}"
+    chain_id = unique_chain_id()
+    provider_id = "profile-provider"
+
+    assert {:ok, ^provider_id} = start_mock(profile, chain_id, provider_id)
+    assert_provider_ready(profile, chain_id, provider_id)
+
+    assert :ok = MockHTTPProvider.stop_mock(profile, chain_id, provider_id)
+    refute_provider_present(profile, chain_id, provider_id)
+
+    stop_chain(profile, chain_id)
+  end
+
+  test "probe coordinator does not probe behavior-backed mock endpoints" do
+    chain_id = unique_chain_id()
+    provider_id = "probe-isolated-provider"
+
+    assert {:ok, ^provider_id} = start_mock("public", chain_id, provider_id)
+    instance_id = Catalog.lookup_instance_id("public", chain_id, provider_id)
+
+    assert {:ok, %{mock?: true}} = Catalog.get_instance(instance_id)
+
+    probe_pid = start_supervised!({ProbeCoordinator, chain_id})
+    ProbeCoordinator.reload_instances(chain_id)
+    Process.sleep(25)
+    send(probe_pid, :tick)
+    Process.sleep(25)
+
+    state = :sys.get_state(ProbeCoordinator.via_name(chain_id))
+    assert state.instances[instance_id].last_probe_monotonic == nil
+
+    assert :ok = MockHTTPProvider.stop_mock("public", chain_id, provider_id)
+    stop_chain("public", chain_id)
+  end
+
+  defp start_mock(profile, chain_id, provider_id) do
+    MockHTTPProvider.start_mock(chain_id, %{
+      id: provider_id,
+      profile: profile,
+      behavior: :healthy,
+      priority: 1
+    })
+  end
+
+  defp assert_provider_ready(profile, chain_id, provider_id) do
+    assert {:ok, _provider} = ConfigStore.get_provider(profile, chain_id, provider_id)
+    assert is_binary(Catalog.lookup_instance_id(profile, chain_id, provider_id))
+    assert {:ok, _channel} = TransportRegistry.get_channel(profile, chain_id, provider_id, :http)
+    assert [{pid, _}] = Registry.lookup(Lasso.Registry, {:http_provider, provider_id})
+    assert Process.alive?(pid)
+  end
+
+  defp refute_provider_present(profile, chain_id, provider_id) do
+    assert {:error, :not_found} = ConfigStore.get_provider(profile, chain_id, provider_id)
+    assert Catalog.lookup_instance_id(profile, chain_id, provider_id) == nil
+
+    assert {:error, _reason} =
+             TransportRegistry.get_channel(profile, chain_id, provider_id, :http)
+
+    assert Registry.lookup(Lasso.Registry, {:http_provider, provider_id}) == []
+    assert GenServer.whereis(ProbeCoordinator.via_name(chain_id)) == nil
+  end
+
+  defp stop_chain(profile, chain_id) do
+    Lasso.ProfileChainSupervisor.stop_profile_chain(profile, chain_id)
+    ConfigStore.unregister_chain_runtime(profile, chain_id)
+  end
+
+  defp unique_chain_id do
+    800_000_000 + rem(System.unique_integer([:positive]), 100_000_000)
+  end
+end

--- a/test/integration/request_pipeline_integration_test.exs
+++ b/test/integration/request_pipeline_integration_test.exs
@@ -77,10 +77,8 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
       Process.sleep(500)
 
       # Verify circuit breaker is now open
-      CircuitBreakerHelper.assert_circuit_breaker_state(
-        {"#{chain}:failing_provider", :http},
-        :open
-      )
+      instance_id = Lasso.Providers.Catalog.lookup_instance_id(profile, chain, "failing_provider")
+      CircuitBreakerHelper.assert_circuit_breaker_state({instance_id, :http}, :open)
 
       # Next request should fail immediately with :circuit_open
       {:error, error, _ctx} =
@@ -119,7 +117,8 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
         Lasso.Testing.TelemetrySync.attach_collector([:lasso, :circuit_breaker, :open])
 
       # Force circuit breaker open
-      CircuitBreakerHelper.force_open({"#{chain}:flaky", :http})
+      instance_id = Lasso.Providers.Catalog.lookup_instance_id(profile, chain, "flaky")
+      CircuitBreakerHelper.force_open({instance_id, :http})
 
       # Wait for telemetry event
       {:ok, _measurements, _metadata} =
@@ -147,7 +146,7 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
       {:ok, close_collector} =
         Lasso.Testing.TelemetrySync.attach_collector([:lasso, :circuit_breaker, :close])
 
-      CircuitBreakerHelper.reset_to_closed({"#{chain}:flaky", :http})
+      CircuitBreakerHelper.reset_to_closed({instance_id, :http})
 
       # Wait for telemetry event
       {:ok, _measurements, _metadata} =
@@ -446,7 +445,7 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
       assert error.retriable? == false
       assert error.message =~ "ghost_provider"
       assert error.data.provider_id == "ghost_provider"
-      assert error.data.chain == chain
+      assert error.data.chain_id == chain
       assert ctx.executed_channel == nil
     end
   end
@@ -516,7 +515,7 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
           timeout: 1000
         )
 
-      assert metadata.chain == chain
+      assert metadata.chain_id == chain
       assert metadata.method == "eth_blockNumber"
 
       # Wait for stop event

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -208,8 +208,7 @@ defmodule Lasso.RPC.SelectionTest do
         %{id: "provider_2", priority: 20, behavior: :healthy, profile: profile, archival: false}
       ])
 
-      # Historical eth_getLogs request (block 12369621 is from 2021)
-      params = [%{"fromBlock" => "0xBCEE25", "toBlock" => "0xBCEE25"}]
+      params = [%{"fromBlock" => "earliest", "toBlock" => "earliest"}]
 
       # Should return empty list - no archival providers available
       channels = Selection.select_channels(profile, chain, "eth_getLogs", params: params)
@@ -226,8 +225,7 @@ defmodule Lasso.RPC.SelectionTest do
         %{id: "non_archival", priority: 20, behavior: :healthy, profile: profile, archival: false}
       ])
 
-      # Historical eth_getLogs request
-      params = [%{"fromBlock" => "0xBCEE25", "toBlock" => "0xBCEE25"}]
+      params = [%{"fromBlock" => "earliest", "toBlock" => "earliest"}]
 
       # Should return only the archival provider
       channels = Selection.select_channels(profile, chain, "eth_getLogs", params: params)

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -166,7 +166,7 @@ defmodule Lasso.RPC.SelectionTest do
       profile = "public"
       # Non-existent chain with no providers
       assert {:error, :no_providers_available} =
-               Selection.select_provider(profile, "nonexistent_chain", "eth_blockNumber")
+               Selection.select_provider(profile, 999_999_999, "eth_blockNumber")
     end
   end
 
@@ -182,7 +182,7 @@ defmodule Lasso.RPC.SelectionTest do
       {:ok, collector} =
         TelemetrySync.attach_collector(
           [:lasso, :selection, :success],
-          match: [chain: chain, method: "eth_blockNumber"]
+          match: [chain_id: chain, method: "eth_blockNumber"]
         )
 
       # Perform selection
@@ -192,7 +192,7 @@ defmodule Lasso.RPC.SelectionTest do
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1000)
 
       assert measurements.count == 1
-      assert metadata.chain == chain
+      assert metadata.chain_id == chain
       assert metadata.method == "eth_blockNumber"
       assert metadata.provider_id in ["provider_1"]
     end

--- a/test/integration/upstream_subscription_pool_integration_test.exs
+++ b/test/integration/upstream_subscription_pool_integration_test.exs
@@ -8,7 +8,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolIntegrationTest do
 
   setup do
     suffix = System.unique_integer([:positive])
-    test_chain = "test_ws_subs_#{suffix}"
+    test_chain = suffix
     test_provider = "mock_ws_provider_#{suffix}"
     test_profile = @default_profile
 

--- a/test/integration/upstream_subscription_pool_integration_test.exs
+++ b/test/integration/upstream_subscription_pool_integration_test.exs
@@ -19,7 +19,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolIntegrationTest do
         priority: 1
       })
 
-    Process.sleep(200)
+    assert wait_for_pool(test_profile, test_chain)
 
     on_exit(fn ->
       MockWSProvider.stop_mock(test_chain, test_provider)
@@ -172,5 +172,20 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolIntegrationTest do
 
   defp get_pool_state(profile \\ @default_profile, chain) do
     :sys.get_state(UpstreamSubscriptionPool.via(profile, chain))
+  end
+
+  defp wait_for_pool(profile, chain, attempts \\ 50)
+
+  defp wait_for_pool(_profile, _chain, 0), do: false
+
+  defp wait_for_pool(profile, chain, attempts) do
+    case GenServer.whereis(UpstreamSubscriptionPool.via(profile, chain)) do
+      pid when is_pid(pid) ->
+        true
+
+      nil ->
+        Process.sleep(20)
+        wait_for_pool(profile, chain, attempts - 1)
+    end
   end
 end

--- a/test/integration/websocket_edge_cases_test.exs
+++ b/test/integration/websocket_edge_cases_test.exs
@@ -39,8 +39,8 @@ defmodule Lasso.Integration.WebSocketEdgeCasesTest do
       id: "ws_#{chain}_#{id_suffix}",
       name: "Test WebSocket #{id_suffix}",
       ws_url: "ws://test.local/ws",
-      chain_name: chain,
-      chain_id: 1,
+      chain_name: Integer.to_string(chain),
+      chain_id: chain,
       reconnect_interval: Keyword.get(opts, :reconnect_interval, 100),
       max_reconnect_attempts: Keyword.get(opts, :max_reconnect_attempts, 3),
       heartbeat_interval: 10_000,
@@ -81,8 +81,8 @@ defmodule Lasso.Integration.WebSocketEdgeCasesTest do
   end
 
   defp resolve_instance_id(endpoint) do
-    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_name, endpoint.id) ||
-      "#{endpoint.chain_name}:#{endpoint.id}"
+    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_id, endpoint.id) ||
+      "#{endpoint.chain_id}:#{endpoint.id}"
   end
 
   describe "race conditions" do

--- a/test/integration/websocket_failure_scenarios_test.exs
+++ b/test/integration/websocket_failure_scenarios_test.exs
@@ -42,8 +42,8 @@ defmodule Lasso.Integration.WebSocketFailureScenarioTest do
       id: "ws_#{chain}_#{id_suffix}",
       name: "Test WebSocket #{id_suffix}",
       ws_url: "ws://test.local/ws",
-      chain_name: chain,
-      chain_id: 1,
+      chain_name: Integer.to_string(chain),
+      chain_id: chain,
       reconnect_interval: Keyword.get(opts, :reconnect_interval, 100),
       max_reconnect_attempts: Keyword.get(opts, :max_reconnect_attempts, 3),
       heartbeat_interval: 10_000,
@@ -84,8 +84,8 @@ defmodule Lasso.Integration.WebSocketFailureScenarioTest do
   end
 
   defp resolve_instance_id(endpoint) do
-    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_name, endpoint.id) ||
-      "#{endpoint.chain_name}:#{endpoint.id}"
+    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_id, endpoint.id) ||
+      "#{endpoint.chain_id}:#{endpoint.id}"
   end
 
   describe "connection timeouts" do

--- a/test/integration/websocket_message_handling_test.exs
+++ b/test/integration/websocket_message_handling_test.exs
@@ -40,8 +40,8 @@ defmodule Lasso.Integration.WebSocketMessageHandlingTest do
       id: "ws_#{chain}_#{id_suffix}",
       name: "Test WebSocket #{id_suffix}",
       ws_url: "ws://test.local/ws",
-      chain_name: chain,
-      chain_id: 1,
+      chain_name: Integer.to_string(chain),
+      chain_id: chain,
       reconnect_interval: Keyword.get(opts, :reconnect_interval, 100),
       max_reconnect_attempts: Keyword.get(opts, :max_reconnect_attempts, 3),
       heartbeat_interval: 10_000,
@@ -82,8 +82,8 @@ defmodule Lasso.Integration.WebSocketMessageHandlingTest do
   end
 
   defp resolve_instance_id(endpoint) do
-    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_name, endpoint.id) ||
-      "#{endpoint.chain_name}:#{endpoint.id}"
+    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_id, endpoint.id) ||
+      "#{endpoint.chain_id}:#{endpoint.id}"
   end
 
   describe "request correlation" do

--- a/test/integration/websocket_reconnection_test.exs
+++ b/test/integration/websocket_reconnection_test.exs
@@ -38,8 +38,8 @@ defmodule Lasso.Integration.WebSocketReconnectionTest do
       id: "ws_#{chain}_#{id_suffix}",
       name: "Test WebSocket #{id_suffix}",
       ws_url: "ws://test.local/ws",
-      chain_name: chain,
-      chain_id: 1,
+      chain_name: Integer.to_string(chain),
+      chain_id: chain,
       reconnect_interval: Keyword.get(opts, :reconnect_interval, 100),
       max_reconnect_attempts: Keyword.get(opts, :max_reconnect_attempts, 3),
       heartbeat_interval: 10_000,
@@ -80,8 +80,8 @@ defmodule Lasso.Integration.WebSocketReconnectionTest do
   end
 
   defp resolve_instance_id(endpoint) do
-    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_name, endpoint.id) ||
-      "#{endpoint.chain_name}:#{endpoint.id}"
+    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_id, endpoint.id) ||
+      "#{endpoint.chain_id}:#{endpoint.id}"
   end
 
   describe "basic reconnection" do

--- a/test/lasso/config/chain_alias_test.exs
+++ b/test/lasso/config/chain_alias_test.exs
@@ -1,0 +1,43 @@
+defmodule Lasso.Config.ChainAliasTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Config.ChainAlias
+
+  describe "canonical_slug/2" do
+    test "uses the first configured alias" do
+      assert ChainAlias.canonical_slug(1, ["mainnet", "ethereum"]) == "mainnet"
+    end
+
+    test "ignores invalid configured aliases" do
+      assert ChainAlias.canonical_slug(1, [nil, "", "ethereum"]) == "ethereum"
+    end
+
+    test "falls back to the decimal chain ID" do
+      assert ChainAlias.canonical_slug(1) == "1"
+      assert ChainAlias.canonical_slug(999_999, []) == "999999"
+    end
+  end
+
+  describe "aliases/1" do
+    test "returns only the universal decimal alias" do
+      assert ChainAlias.aliases(1) == ["1"]
+      assert ChainAlias.aliases(999_999) == ["999999"]
+    end
+  end
+
+  describe "display_name/2" do
+    test "uses and trims a configured label" do
+      assert ChainAlias.display_name(1, "  My Mainnet  ") == "My Mainnet"
+    end
+
+    test "missing or empty labels use a generic chain-ID fallback" do
+      assert ChainAlias.display_name(1, nil) == "Chain 1"
+      assert ChainAlias.display_name(1, "   ") == "Chain 1"
+      assert ChainAlias.display_name(999_999) == "Chain 999999"
+    end
+
+    test "invalid IDs render safely" do
+      assert ChainAlias.display_name(nil) == "Unknown chain"
+    end
+  end
+end

--- a/test/lasso/config/config_store_atomic_swap_test.exs
+++ b/test/lasso/config/config_store_atomic_swap_test.exs
@@ -13,6 +13,62 @@ defmodule Lasso.Config.ConfigStoreAtomicSwapTest do
 
   @reads 200
 
+  defmodule BlockingBackend do
+    def load_all({owner, specs}) do
+      send(owner, {:retry_load_started, self()})
+
+      receive do
+        :complete_retry_load -> {:ok, specs}
+      end
+    end
+  end
+
+  test "a degraded retry cannot overwrite runtime mutations made while it loads" do
+    alias Lasso.Config.Backend.File, as: FileBackend
+
+    {:ok, backend_state} =
+      FileBackend.init(
+        profiles_dir: "test/support/profiles",
+        legacy_config_path: "test/support/chains.yml"
+      )
+
+    {:ok, specs} = FileBackend.load_all(backend_state)
+    retry_specs = Enum.reject(specs, &(&1.profile_id == "public"))
+    original_state = :sys.get_state(ConfigStore)
+    owner = self()
+    chain_id = 876_543_210
+
+    on_exit(fn ->
+      ConfigStore.unregister_chain_runtime("public", chain_id)
+      :sys.replace_state(ConfigStore, fn _ -> original_state end)
+    end)
+
+    :sys.replace_state(ConfigStore, fn state ->
+      %{
+        state
+        | backend_module: BlockingBackend,
+          backend_state: {owner, retry_specs},
+          retry_timer: nil,
+          retry_task_ref: nil,
+          retry_task_snapshot: nil
+      }
+    end)
+
+    assert :ok =
+             ConfigStore.register_chain_runtime("public", chain_id, %{
+               display_name: "Retry-Safe Runtime Chain",
+               url_aliases: ["retry-safe-runtime"],
+               providers: []
+             })
+
+    send(ConfigStore, :retry_eager_load)
+    assert_receive {:retry_load_started, retry_task}, 1_000
+    send(retry_task, :complete_retry_load)
+
+    assert eventually(fn -> :sys.get_state(ConfigStore).retry_task_ref == nil end)
+    assert {:ok, _chain} = ConfigStore.get_chain("public", chain_id)
+  end
+
   test "concurrent readers never observe a missing system profile across reload" do
     # The file backend serves `public` and `testnet` from
     # `test/support/profiles/`. Both should be present in every

--- a/test/lasso/config/config_store_atomic_swap_test.exs
+++ b/test/lasso/config/config_store_atomic_swap_test.exs
@@ -1,0 +1,392 @@
+defmodule Lasso.Config.ConfigStoreAtomicSwapTest do
+  @moduledoc """
+  Concurrency guards for ConfigStore atomic reload and single-profile inject
+  semantics. Readers must observe either the old complete snapshot or the new
+  complete snapshot, never a partially populated ETS table.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Lasso.Config.{ConfigStore, ProfileId}
+  alias Lasso.Config.ChainConfig
+  alias Lasso.Config.ChainConfig.{Monitoring, Provider, Selection, Websocket, WebsocketFailover}
+
+  @reads 200
+
+  test "concurrent readers never observe a missing system profile across reload" do
+    # The file backend serves `public` and `testnet` from
+    # `test/support/profiles/`. Both should be present in every
+    # snapshot ConfigStore publishes.
+    expected = ["public", "testnet"]
+
+    parent = self()
+
+    reader =
+      Task.async(fn ->
+        observed =
+          Enum.map(1..@reads, fn _ ->
+            for slug <- expected do
+              case ConfigStore.resolve(:system, slug) do
+                {:ok, profile_id} -> {slug, ConfigStore.get_profile(profile_id)}
+                {:error, _} = err -> {slug, err}
+              end
+            end
+          end)
+
+        send(parent, {:done, observed})
+      end)
+
+    # Hammer reload while the reader runs.
+    Enum.each(1..10, fn _ -> :ok = ConfigStore.reload() end)
+
+    Task.await(reader, 5_000)
+    receive do: ({:done, observed} -> assert_no_partial_snapshot(observed))
+  end
+
+  defp assert_no_partial_snapshot(observed) do
+    for round <- observed, {slug, get_result} <- round do
+      assert {:ok, %{slug: ^slug}} = get_result,
+             "resolve+get_profile returned #{inspect(get_result)} for #{slug} mid-reload"
+    end
+  end
+
+  @tag timeout: 10_000
+  test "single-profile inject publishes meta + chains + resolve atomically" do
+    # The bug class this defends against: `store_profile/2` writing the
+    # three rows as separate `:ets.insert/2` calls. A reader between
+    # them could observe meta+chains without the resolve entry, or
+    # resolve+meta without chains. Batched into a single `:ets.insert(t,
+    # [tup1, tup2, tup3])` it cannot.
+    slug = "inject_atomic_#{:rand.uniform(999_999_999)}"
+    chain = "test_chain_inject_atomic"
+    chain_id = 987_654
+
+    spec = %{
+      scope: :system,
+      profile_id: ProfileId.for_system(slug),
+      slug: slug,
+      name: "atomic-inject-#{slug}",
+      rps_limit: 100,
+      burst_limit: 200,
+      unlisted: true,
+      chains: %{chain => build_chain(slug, chain, chain_id: chain_id)}
+    }
+
+    on_exit(fn -> ConfigStore.remove_profile(spec.profile_id) end)
+
+    parent = self()
+
+    reader =
+      Task.async(fn ->
+        observed =
+          for _ <- 1..@reads do
+            case ConfigStore.resolve(:system, slug) do
+              {:ok, profile_id} ->
+                {ConfigStore.get_profile(profile_id), ConfigStore.get_chain(profile_id, chain)}
+
+              {:error, :not_found} ->
+                :pre_publish
+            end
+          end
+
+        send(parent, {:done, observed})
+      end)
+
+    # Hammer inject_profile + remove_profile to maximize the chance of a
+    # reader landing inside the write window. Each cycle exercises a
+    # full rebuild_shared_infrastructure, so we keep the count modest;
+    # the reader runs many more iterations against this writer.
+    Enum.each(1..10, fn _ ->
+      :ok = ConfigStore.inject_profile(spec)
+      :ok = ConfigStore.remove_profile(spec.profile_id)
+    end)
+
+    Task.await(reader, 5_000)
+
+    receive do
+      {:done, observed} ->
+        for result <- observed do
+          case result do
+            :pre_publish ->
+              :ok
+
+            {{:ok, %{slug: ^slug}}, {:ok, %ChainConfig{display_name: ^chain}}} ->
+              :ok
+
+            other ->
+              flunk(
+                "Partial snapshot during inject: #{inspect(other)} — expected either :pre_publish " <>
+                  "(resolve = :not_found) or both meta + chain present together"
+              )
+          end
+        end
+    end
+  end
+
+  test "lookup_chain_id_in_profile honors stored URL aliases" do
+    slug = "alias_profile_#{:rand.uniform(999_999_999)}"
+    profile_id = ProfileId.for_system(slug)
+    chain_slug = "my-stable-chain-slug"
+    chain_id = 424_242
+
+    spec = %{
+      scope: :system,
+      profile_id: profile_id,
+      slug: slug,
+      name: "alias-profile",
+      rps_limit: 100,
+      burst_limit: 200,
+      unlisted: true,
+      chains: %{chain_slug => build_chain(slug, chain_slug, chain_id: chain_id)}
+    }
+
+    on_exit(fn -> ConfigStore.remove_profile(profile_id) end)
+
+    assert :ok = ConfigStore.inject_profile(spec)
+    assert {:ok, ^chain_id} = ConfigStore.lookup_chain_id_in_profile(profile_id, chain_slug)
+
+    assert {:ok, %ChainConfig{chain_id: ^chain_id}} =
+             ConfigStore.get_chain(profile_id, chain_slug)
+  end
+
+  test "ConfigStore and Owner restarts republish a readable last-good snapshot" do
+    slug = "owner-restart-#{:rand.uniform(999_999_999)}"
+    chain_id = 799_999
+    spec = alias_spec(slug, chain_id, "owner-restart-chain")
+
+    on_exit(fn -> ConfigStore.remove_profile(spec.profile_id) end)
+
+    assert :ok = ConfigStore.inject_profile(spec)
+    assert {:ok, profile_id} = ConfigStore.resolve(:system, slug)
+    assert {:ok, profile} = ConfigStore.get_profile(profile_id)
+    assert {:ok, %ChainConfig{}} = ConfigStore.get_chain(profile_id, chain_id)
+
+    config_store = Process.whereis(ConfigStore)
+    config_monitor = Process.monitor(config_store)
+    Process.exit(config_store, :kill)
+    assert_receive {:DOWN, ^config_monitor, :process, ^config_store, :killed}, 1_000
+
+    assert eventually(fn -> Process.whereis(ConfigStore) not in [nil, config_store] end)
+    assert {:ok, ^profile} = ConfigStore.get_profile(profile_id)
+
+    assert :ok =
+             ConfigStore.register_provider_runtime(profile_id, chain_id, %{
+               id: "runtime-provider",
+               name: "Runtime Provider",
+               url: "https://runtime.example",
+               priority: 10
+             })
+
+    assert {:ok, chain_with_runtime_provider} = ConfigStore.get_chain(profile_id, chain_id)
+    assert Enum.any?(chain_with_runtime_provider.providers, &(&1.id == "runtime-provider"))
+
+    owner = Process.whereis(Lasso.Config.ConfigStore.Owner)
+    owner_monitor = Process.monitor(owner)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_monitor, :process, ^owner, :killed}, 1_000
+
+    assert eventually(fn ->
+             Process.whereis(Lasso.Config.ConfigStore.Owner) not in [nil, owner]
+           end)
+
+    assert eventually(fn -> ConfigStore.get_profile(profile_id) == {:ok, profile} end)
+    assert {:ok, ^profile_id} = ConfigStore.resolve(:system, slug)
+
+    assert eventually(fn ->
+             ConfigStore.get_chain(profile_id, chain_id) == {:ok, chain_with_runtime_provider}
+           end)
+
+    assert :ok = ConfigStore.reload()
+  end
+
+  test "configured aliases are profile-local and decimal collisions retain the last-good snapshot" do
+    first = alias_spec("alias-a", 700_001, "shared-alias")
+    second = alias_spec("alias-b", 700_002, "shared-alias")
+
+    on_exit(fn ->
+      ConfigStore.remove_profile(first.profile_id)
+      ConfigStore.remove_profile(second.profile_id)
+    end)
+
+    assert :ok = ConfigStore.inject_profile(first)
+    assert :ok = ConfigStore.inject_profile(second)
+
+    assert {:ok, 700_001} =
+             ConfigStore.lookup_chain_id_in_profile(first.profile_id, "shared-alias")
+
+    assert {:ok, 700_002} =
+             ConfigStore.lookup_chain_id_in_profile(second.profile_id, "shared-alias")
+
+    original_state = :sys.get_state(ConfigStore)
+    original_specs = Application.get_env(:lasso, :config_store_invalid_chain_specs)
+
+    on_exit(fn ->
+      :sys.replace_state(ConfigStore, fn _ -> original_state end)
+      Application.put_env(:lasso, :config_store_invalid_chain_specs, original_specs)
+    end)
+
+    invalid = %{
+      first
+      | profile_id: "collision",
+        slug: "collision",
+        chains: %{
+          "one" => build_chain("collision", "one", chain_id: 1),
+          "other" => %{build_chain("collision", "other", chain_id: 2) | url_aliases: ["1"]}
+        }
+    }
+
+    assert {:error, {:chain_alias_collides_with_chain_id, 2, "1"}} =
+             ConfigStore.inject_profile(invalid)
+
+    assert {:ok, 700_001} =
+             ConfigStore.lookup_chain_id_in_profile(first.profile_id, "shared-alias")
+
+    Application.put_env(:lasso, :config_store_invalid_chain_specs, [invalid])
+
+    :sys.replace_state(ConfigStore, fn state ->
+      %{
+        state
+        | backend_module: Lasso.Config.ConfigStoreAtomicSwapTest.InvalidChainBackend,
+          backend_state: nil
+      }
+    end)
+
+    assert {:error, {:chain_alias_collides_with_chain_id, 2, "1"}} = ConfigStore.reload()
+
+    assert {:ok, 700_001} =
+             ConfigStore.lookup_chain_id_in_profile(first.profile_id, "shared-alias")
+  end
+
+  test "invalid chain IDs leave the last good snapshot active" do
+    original_state = :sys.get_state(ConfigStore)
+    original_specs = Application.get_env(:lasso, :config_store_invalid_chain_specs)
+
+    on_exit(fn ->
+      :sys.replace_state(ConfigStore, fn _ -> original_state end)
+      Application.put_env(:lasso, :config_store_invalid_chain_specs, original_specs)
+    end)
+
+    assert {:ok, profile_id} = ConfigStore.resolve(:system, "public")
+
+    for {chain_id, expected_error} <- [
+          {nil, :invalid_chain_id},
+          {0, :invalid_chain_id},
+          {"1", :invalid_chain_id}
+        ] do
+      Application.put_env(:lasso, :config_store_invalid_chain_specs, [invalid_spec(chain_id)])
+
+      :sys.replace_state(ConfigStore, fn state ->
+        %{
+          state
+          | backend_module: Lasso.Config.ConfigStoreAtomicSwapTest.InvalidChainBackend,
+            backend_state: nil
+        }
+      end)
+
+      assert {:error, ^expected_error} = ConfigStore.reload()
+      assert {:ok, ^profile_id} = ConfigStore.resolve(:system, "public")
+    end
+
+    duplicate = %{
+      invalid_spec(1)
+      | chains: %{
+          "one" => build_chain("invalid", "one", chain_id: 1),
+          "two" => build_chain("invalid", "two", chain_id: 1)
+        }
+    }
+
+    Application.put_env(:lasso, :config_store_invalid_chain_specs, [duplicate])
+
+    :sys.replace_state(ConfigStore, fn state ->
+      %{
+        state
+        | backend_module: Lasso.Config.ConfigStoreAtomicSwapTest.InvalidChainBackend,
+          backend_state: nil
+      }
+    end)
+
+    assert {:error, :duplicate_chain_id} = ConfigStore.reload()
+    assert {:ok, ^profile_id} = ConfigStore.resolve(:system, "public")
+  end
+
+  defp alias_spec(slug, chain_id, alias_name) do
+    %{
+      scope: :system,
+      profile_id: slug,
+      slug: slug,
+      name: slug,
+      rps_limit: 100,
+      burst_limit: 200,
+      unlisted: true,
+      chains: %{alias_name => build_chain(slug, alias_name, chain_id: chain_id)}
+    }
+  end
+
+  defp invalid_spec(chain_id) do
+    %{
+      scope: :system,
+      profile_id: "invalid",
+      slug: "invalid",
+      name: "Invalid",
+      rps_limit: 1,
+      burst_limit: 1,
+      chains: %{"invalid" => build_chain("invalid", "invalid", chain_id: chain_id)}
+    }
+  end
+
+  defp eventually(fun, attempts \\ 20)
+  defp eventually(fun, 0), do: fun.()
+
+  defp eventually(fun, attempts) do
+    if fun.() do
+      true
+    else
+      Process.sleep(25)
+      eventually(fun, attempts - 1)
+    end
+  end
+
+  defp build_chain(slug, name, opts) do
+    chain_id = Keyword.get(opts, :chain_id)
+
+    %ChainConfig{
+      display_name: name,
+      chain_id: chain_id,
+      url_aliases: [name],
+      block_time_ms: 12_000,
+      providers: [
+        %Provider{
+          id: "p1",
+          name: "p1",
+          priority: 100,
+          url: "https://example.invalid/#{slug}/#{name}/p1",
+          ws_url: nil,
+          capabilities: nil,
+          subscribe_new_heads: false,
+          archival: false
+        }
+      ],
+      monitoring: %Monitoring{probe_interval_ms: 60_000, lag_alert_threshold_blocks: 5},
+      selection: %Selection{max_lag_blocks: 5},
+      websocket: %Websocket{
+        subscribe_new_heads: false,
+        new_heads_timeout_ms: 30_000,
+        failover: %WebsocketFailover{}
+      }
+    }
+  end
+
+  defmodule InvalidChainBackend do
+    @behaviour Lasso.Config.Backend
+
+    @impl true
+    def init(_config), do: {:ok, :invalid_chain_test}
+
+    @impl true
+    def load_all(:invalid_chain_test),
+      do: {:ok, Application.fetch_env!(:lasso, :config_store_invalid_chain_specs)}
+
+    @impl true
+    def load(_state, _slug), do: {:error, :not_found}
+  end
+end

--- a/test/lasso/config/file_backend_compatibility_test.exs
+++ b/test/lasso/config/file_backend_compatibility_test.exs
@@ -1,0 +1,127 @@
+defmodule Lasso.Config.FileBackendCompatibilityTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Config.Backend.File, as: FileBackend
+
+  setup do
+    root = Path.join(System.tmp_dir!(), "lasso-file-compat-#{System.unique_integer([:positive])}")
+    profiles_dir = Path.join(root, "profiles")
+    legacy_path = Path.join(root, "chains.yml")
+    File.mkdir_p!(root)
+    on_exit(fn -> File.rm_rf!(root) end)
+
+    {:ok, root: root, profiles_dir: profiles_dir, legacy_path: legacy_path}
+  end
+
+  test "legacy chains.yml auto-migrates without losing routing fields", context do
+    File.write!(context.legacy_path, """
+    chains:
+      ethereum:
+        chain_id: 1
+        name: Ethereum Mainnet
+        block_time_ms: 12000
+        selection:
+          max_lag_blocks: 2
+          archival_threshold: 256
+        monitoring:
+          probe_interval_ms: 15000
+          lag_alert_threshold_blocks: 4
+        websocket:
+          subscribe_new_heads: false
+          new_heads_timeout_ms: 45000
+          failover:
+            max_backfill_blocks: 55
+            backfill_timeout_ms: 9000
+        providers:
+          - id: primary
+            name: Primary
+            url: https://rpc.example.com
+            ws_url: wss://rpc.example.com/ws
+            priority: 7
+            archival: false
+            sharing_mode: isolated
+            capabilities:
+              methods: [eth_blockNumber, eth_chainId]
+    """)
+
+    assert {:ok, state} =
+             FileBackend.init(
+               profiles_dir: context.profiles_dir,
+               legacy_config_path: context.legacy_path
+             )
+
+    assert File.exists?(Path.join(context.profiles_dir, "public.yml"))
+    assert {:ok, [profile]} = FileBackend.load_all(state)
+    assert profile.profile_id == "public"
+    assert profile.slug == "public"
+
+    assert %{"ethereum" => chain} = profile.chains
+    assert chain.chain_id == 1
+    assert chain.name == "Ethereum Mainnet"
+    assert chain.display_name == "Ethereum Mainnet"
+    assert chain.url_aliases == ["ethereum"]
+    assert chain.block_time_ms == 12_000
+    assert chain.selection.max_lag_blocks == 2
+    assert chain.selection.archival_threshold == 256
+    assert chain.monitoring.probe_interval_ms == 15_000
+    assert chain.websocket.subscribe_new_heads == false
+    assert chain.websocket.failover.max_backfill_blocks == 55
+
+    assert [provider] = chain.providers
+    assert provider.id == "primary"
+    assert provider.priority == 7
+    assert provider.archival == false
+    assert provider.sharing_mode == :isolated
+    assert provider.capabilities.methods == ["eth_blockNumber", "eth_chainId"]
+  end
+
+  test "frontmatter profile retains legacy aliases and provider authentication", context do
+    File.mkdir_p!(context.profiles_dir)
+
+    File.write!(Path.join(context.profiles_dir, "custom.yml"), """
+    ---
+    name: Custom
+    slug: custom
+    rps_limit: 25
+    burst_limit: 50
+    ---
+    chains:
+      custom-chain:
+        chain_id: 31337
+        name: Custom Chain
+        url_aliases: [custom-chain, local]
+        providers:
+          - id: authenticated
+            name: Authenticated
+            url: https://rpc.example.com
+            api_key: secret-token
+            headers:
+              x-network: local
+            auth_headers:
+              authorization: Basic explicit
+      unnamed:
+        chain_id: 31338
+        providers: []
+    """)
+
+    assert {:ok, state} =
+             FileBackend.init(
+               profiles_dir: context.profiles_dir,
+               legacy_config_path: context.legacy_path
+             )
+
+    assert {:ok, profile} = FileBackend.load(state, "custom")
+    assert profile.profile_id == "custom"
+    assert profile.rps_limit == 25
+    assert profile.burst_limit == 50
+
+    chain = profile.chains["custom-chain"]
+    assert chain.url_aliases == ["custom-chain", "local"]
+    assert [provider] = chain.providers
+    assert provider.api_key == "secret-token"
+    assert provider.headers == %{"x-network" => "local"}
+    assert provider.auth_headers == %{"authorization" => "Basic explicit"}
+    assert profile.chains["unnamed"].name == "unnamed"
+    assert profile.chains["unnamed"].display_name == "unnamed"
+  end
+end

--- a/test/lasso/config/profile_id_test.exs
+++ b/test/lasso/config/profile_id_test.exs
@@ -1,0 +1,10 @@
+defmodule Lasso.Config.ProfileIdTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Config.ProfileId
+
+  test "system profile identity is its YAML slug" do
+    assert ProfileId.for_system("public") == "public"
+    assert ProfileId.for_system("testnet") == "testnet"
+  end
+end

--- a/test/lasso/config/profile_isolation_test.exs
+++ b/test/lasso/config/profile_isolation_test.exs
@@ -89,11 +89,11 @@ defmodule Lasso.Config.ProfileIsolationTest do
       chains_b = ConfigStore.list_chains_for_profile(@profile_b)
 
       # Verify each profile only sees its own chain
-      assert Enum.any?(chains_a, &(&1 == @test_chain <> "_a"))
-      refute Enum.any?(chains_a, &(&1 == @test_chain <> "_b"))
+      assert 1 in chains_a
+      refute 2 in chains_a
 
-      assert Enum.any?(chains_b, &(&1 == @test_chain <> "_b"))
-      refute Enum.any?(chains_b, &(&1 == @test_chain <> "_a"))
+      assert 2 in chains_b
+      refute 1 in chains_b
 
       # Cleanup
       ConfigStore.unregister_chain_runtime(@profile_a, @test_chain <> "_a")
@@ -143,7 +143,7 @@ defmodule Lasso.Config.ProfileIsolationTest do
           "eth_blockNumber"
         )
 
-      # Profile B hasn't recorded any data, so should have zero calls
+      # Profile B has not recorded any data.
       assert metrics_b.total_calls == 0
     end
 

--- a/test/lasso/config/profile_validator_test.exs
+++ b/test/lasso/config/profile_validator_test.exs
@@ -204,9 +204,9 @@ defmodule Lasso.Config.ProfileValidatorTest do
   end
 
   describe "resolve_alias/1" do
-    test "maps old slugs to canonical names" do
+    test "maps only the retained default alias" do
       assert "public" = ProfileValidator.resolve_alias("default")
-      assert "managed" = ProfileValidator.resolve_alias("premium")
+      assert "premium" = ProfileValidator.resolve_alias("premium")
     end
 
     test "passes through canonical and unknown slugs unchanged" do

--- a/test/lasso/config/profile_validator_test.exs
+++ b/test/lasso/config/profile_validator_test.exs
@@ -206,12 +206,11 @@ defmodule Lasso.Config.ProfileValidatorTest do
   describe "resolve_alias/1" do
     test "maps only the retained default alias" do
       assert "public" = ProfileValidator.resolve_alias("default")
-      assert "premium" = ProfileValidator.resolve_alias("premium")
+      assert "legacy-tier" = ProfileValidator.resolve_alias("legacy-tier")
     end
 
     test "passes through canonical and unknown slugs unchanged" do
       assert "public" = ProfileValidator.resolve_alias("public")
-      assert "managed" = ProfileValidator.resolve_alias("managed")
       assert "testnet" = ProfileValidator.resolve_alias("testnet")
       assert "custom" = ProfileValidator.resolve_alias("custom")
     end

--- a/test/lasso/core/block_sync/consensus_p75_test.exs
+++ b/test/lasso/core/block_sync/consensus_p75_test.exs
@@ -4,7 +4,7 @@ defmodule Lasso.BlockSync.ConsensusP75Test do
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
 
   setup do
-    chain = "test_p75_#{System.unique_integer([:positive])}"
+    chain = System.unique_integer([:positive])
     BlockSyncRegistry.clear_chain(chain)
     on_exit(fn -> BlockSyncRegistry.clear_chain(chain) end)
     {:ok, chain: chain}

--- a/test/lasso/core/chain_state_test.exs
+++ b/test/lasso/core/chain_state_test.exs
@@ -5,8 +5,8 @@ defmodule Lasso.RPC.ChainStateTest do
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
 
   setup do
-    # Generate unique chain name for each test to avoid conflicts
-    chain = "test_chain_#{System.unique_integer([:positive])}"
+    # Generate a unique chain ID for each test to avoid conflicts
+    chain = System.unique_integer([:positive])
 
     # Clear any existing data for this chain
     BlockSyncRegistry.clear_chain(chain)

--- a/test/lasso/core/request/request_pipeline/failover_strategy_test.exs
+++ b/test/lasso/core/request/request_pipeline/failover_strategy_test.exs
@@ -8,7 +8,7 @@ defmodule Lasso.RPC.RequestPipeline.FailoverStrategyTest do
   defp make_channel(provider_id \\ "test-provider") do
     %Channel{
       profile: "public",
-      chain: "ethereum",
+      chain_id: 1,
       provider_id: provider_id,
       transport: :http,
       raw_channel: nil,
@@ -18,7 +18,7 @@ defmodule Lasso.RPC.RequestPipeline.FailoverStrategyTest do
   end
 
   defp make_ctx(opts \\ []) do
-    ctx = RequestContext.new("ethereum", "eth_call", [])
+    ctx = RequestContext.new(1, "eth_call", [])
     error_categories = Keyword.get(opts, :error_categories, %{})
     %{ctx | repeated_error_categories: error_categories}
   end

--- a/test/lasso/core/request/request_pipeline_test.exs
+++ b/test/lasso/core/request/request_pipeline_test.exs
@@ -35,7 +35,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "execute_via_channels/4 - parameter validation" do
     test "creates RequestContext when not provided" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -43,15 +43,15 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
       ctx = extract_context(result)
       assert %RequestContext{} = ctx
-      assert ctx.chain == "ethereum"
+      assert ctx.chain_id == 1
       assert ctx.method == "eth_blockNumber"
     end
 
     test "uses provided RequestContext" do
-      custom_ctx = RequestContext.new("ethereum", "eth_call", [], strategy: :fastest)
+      custom_ctx = RequestContext.new(1, "eth_call", [], strategy: :fastest)
 
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_call", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_call", [], %RequestOptions{
           profile: "public",
           strategy: :fastest,
           timeout_ms: 30_000,
@@ -65,7 +65,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "handles empty params" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -82,7 +82,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
         transport: :http
       }
 
-      result = RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], opts)
+      result = RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], opts)
       assert_result_valid(result)
     end
   end
@@ -90,7 +90,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "execute_via_channels/4 - observability" do
     test "marks selection start" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -102,7 +102,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "tracks retry count" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -116,14 +116,14 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "stores request metadata in context" do
       result =
         RequestPipeline.execute_via_channels(
-          "ethereum",
+          1,
           "eth_getBalance",
           ["0x123", "latest"],
           %RequestOptions{profile: "public", strategy: :load_balanced, timeout_ms: 30_000}
         )
 
       ctx = extract_context(result)
-      assert ctx.chain == "ethereum"
+      assert ctx.chain_id == 1
       assert ctx.method == "eth_getBalance"
       assert ctx.params == ["0x123", "latest"]
     end
@@ -132,7 +132,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "execute_via_channels/4 - strategy support" do
     test "accepts :fastest strategy" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :fastest,
           timeout_ms: 30_000
@@ -143,7 +143,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "accepts :priority strategy" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :priority,
           timeout_ms: 30_000
@@ -154,7 +154,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test ":load_balanced strategy" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -165,7 +165,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "stores strategy in context" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_call", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_call", [], %RequestOptions{
           profile: "public",
           strategy: :fastest,
           timeout_ms: 30_000
@@ -179,7 +179,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "execute_via_channels/4 - transport preferences" do
     test "accepts :http transport override" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           transport: :http,
           timeout_ms: 30_000,
@@ -191,7 +191,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "accepts :ws transport override" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           transport: :ws,
           timeout_ms: 30_000,
@@ -203,7 +203,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "defaults to :http when no transport specified" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -217,7 +217,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "execute_via_channels/4 - timeout handling" do
     test "accepts custom timeout" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           timeout_ms: 5000,
           strategy: :load_balanced
@@ -228,7 +228,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "uses default timeout when not specified" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -244,7 +244,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
       result =
         RequestPipeline.execute_via_channels(
-          "ethereum",
+          1,
           "eth_getBalance",
           params,
           %RequestOptions{profile: "public", strategy: :load_balanced, timeout_ms: 30_000}
@@ -256,7 +256,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "handles nil params" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", nil, %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", nil, %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -270,7 +270,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "RequestContext lifecycle" do
     test "context is always returned in result tuple" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_test", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_test", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -282,7 +282,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "context tracks timing information" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -295,7 +295,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "context includes unique request ID" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_test", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_test", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -310,7 +310,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
   describe "Fast-fail failover logic" do
     test "FailoverStrategy returns terminal when no channels remaining" do
       error = JError.new(-32_005, "Rate limit", category: :rate_limit, retriable?: true)
-      ctx = RequestContext.new("ethereum", "eth_blockNumber", [])
+      ctx = RequestContext.new(1, "eth_blockNumber", [])
 
       assert {:terminal_error, :no_channels_remaining} =
                FailoverStrategy.decide(error, [], ctx)
@@ -372,7 +372,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
     end
 
     test "circuit_open errors trigger failover when channels remain" do
-      ctx = RequestContext.new("ethereum", "eth_blockNumber", [])
+      ctx = RequestContext.new(1, "eth_blockNumber", [])
       dummy_channel = %Lasso.RPC.Channel{provider_id: "test", transport: :http}
 
       assert {:failover, :circuit_open} =
@@ -381,7 +381,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "execute_via_channels increments retry count on failover" do
       result =
-        RequestPipeline.execute_via_channels("ethereum", "eth_blockNumber", [], %RequestOptions{
+        RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
           timeout_ms: 30_000
@@ -399,7 +399,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
         TelemetrySync.start_collector([:lasso, :failover, :fast_fail])
 
       ctx =
-        RequestContext.new("ethereum", "eth_blockNumber", [])
+        RequestContext.new(1, "eth_blockNumber", [])
         |> Map.put(:opts, %RequestOptions{
           profile: "public",
           strategy: :load_balanced,
@@ -415,7 +415,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
       assert measurements.count == 1
       assert measurements.duration == 5
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.method == "eth_blockNumber"
       assert metadata.provider_id == "test_provider"
       assert metadata.transport == :http
@@ -452,7 +452,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
       # We test via execute_via_channels on a chain with no providers configured.
       result =
         RequestPipeline.execute_via_channels(
-          "nonexistent_chain",
+          9_999_999,
           "eth_blockNumber",
           [],
           %RequestOptions{profile: "public", strategy: :load_balanced, timeout_ms: 5_000}
@@ -469,7 +469,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
       _result =
         RequestPipeline.execute_via_channels(
-          "nonexistent_chain",
+          9_999_999,
           "eth_blockNumber",
           [],
           %RequestOptions{profile: "public", strategy: :load_balanced, timeout_ms: 5_000}
@@ -478,7 +478,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 2_000)
 
       assert measurements.count == 1
-      assert metadata.chain == "nonexistent_chain"
+      assert metadata.chain_id == 9_999_999
       assert metadata.method == "eth_blockNumber"
       assert is_integer(metadata.retry_after_ms)
     end
@@ -486,11 +486,11 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "Observability.record_degraded_mode emits [:lasso, :failover, :degraded_mode]" do
       collector = TelemetrySync.start_collector([:lasso, :failover, :degraded_mode])
 
-      Observability.record_degraded_mode("ethereum", "eth_blockNumber")
+      Observability.record_degraded_mode(1, "eth_blockNumber")
 
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert measurements.count == 1
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.method == "eth_blockNumber"
     end
 
@@ -498,11 +498,11 @@ defmodule Lasso.RPC.RequestPipelineTest do
       collector = TelemetrySync.start_collector([:lasso, :failover, :degraded_success])
 
       channel = %Lasso.RPC.Channel{provider_id: "test_provider", transport: :http}
-      Observability.record_degraded_success("ethereum", "eth_blockNumber", channel)
+      Observability.record_degraded_success(1, "eth_blockNumber", channel)
 
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert measurements.count == 1
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.method == "eth_blockNumber"
       assert metadata.provider_id == "test_provider"
       assert metadata.transport == :http
@@ -511,11 +511,11 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "Observability.record_exhaustion emits [:lasso, :failover, :exhaustion]" do
       collector = TelemetrySync.start_collector([:lasso, :failover, :exhaustion])
 
-      Observability.record_exhaustion("ethereum", "eth_blockNumber", :http, 5000)
+      Observability.record_exhaustion(1, "eth_blockNumber", :http, 5000)
 
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert measurements.count == 1
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.method == "eth_blockNumber"
       assert metadata.retry_after_ms == 5000
       assert metadata.transport == :http
@@ -524,7 +524,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "exhaustion error includes retry_after_ms when circuits have recovery times" do
       collector = TelemetrySync.start_collector([:lasso, :failover, :exhaustion])
 
-      Observability.record_exhaustion("ethereum", "eth_blockNumber", :http, 3000)
+      Observability.record_exhaustion(1, "eth_blockNumber", :http, 3000)
 
       {:ok, _measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert metadata.retry_after_ms == 3000
@@ -533,7 +533,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "exhaustion defaults retry_after_ms to 0 when nil" do
       collector = TelemetrySync.start_collector([:lasso, :failover, :exhaustion])
 
-      Observability.record_exhaustion("ethereum", "eth_blockNumber", :http, nil)
+      Observability.record_exhaustion(1, "eth_blockNumber", :http, nil)
 
       {:ok, _measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert metadata.retry_after_ms == 0
@@ -542,7 +542,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "exhaustion defaults transport to :both when nil" do
       collector = TelemetrySync.start_collector([:lasso, :failover, :exhaustion])
 
-      Observability.record_exhaustion("ethereum", "eth_blockNumber", nil, 1000)
+      Observability.record_exhaustion(1, "eth_blockNumber", nil, 1000)
 
       {:ok, _measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert metadata.transport == :both
@@ -565,12 +565,12 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "Selection.select_channels accepts include_half_open option" do
       # include_half_open defaults to true in Selection.select_channels
       channels_with =
-        Lasso.RPC.Selection.select_channels("public", "ethereum", "eth_blockNumber",
+        Lasso.RPC.Selection.select_channels("public", 1, "eth_blockNumber",
           include_half_open: true
         )
 
       channels_without =
-        Lasso.RPC.Selection.select_channels("public", "ethereum", "eth_blockNumber",
+        Lasso.RPC.Selection.select_channels("public", 1, "eth_blockNumber",
           include_half_open: false
         )
 
@@ -633,7 +633,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
     test "CandidateListing.get_min_recovery_time returns {:ok, nil} when no circuits open" do
       {:ok, result} =
-        Lasso.Providers.CandidateListing.get_min_recovery_time("public", "ethereum")
+        Lasso.Providers.CandidateListing.get_min_recovery_time("public", 1)
 
       # Either nil (no open circuits) or a positive integer
       assert result == nil or (is_integer(result) and result > 0)
@@ -643,7 +643,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
       # Verify the message format when retry_after_ms is present
       result =
         RequestPipeline.execute_via_channels(
-          "nonexistent_chain",
+          9_999_999,
           "eth_blockNumber",
           [],
           %RequestOptions{profile: "public", strategy: :load_balanced, timeout_ms: 5_000}
@@ -659,7 +659,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
       collector = TelemetrySync.start_collector([:lasso, :failover, :circuit_open])
 
       ctx =
-        RequestContext.new("ethereum", "eth_blockNumber", [])
+        RequestContext.new(1, "eth_blockNumber", [])
 
       channel = %Lasso.RPC.Channel{provider_id: "test_provider", transport: :http}
 
@@ -667,7 +667,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert measurements.count == 1
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.provider_id == "test_provider"
       assert metadata.transport == :http
     end
@@ -675,11 +675,11 @@ defmodule Lasso.RPC.RequestPipelineTest do
     test "Observability.record_request_start emits [:lasso, :rpc, :request, :start]" do
       collector = TelemetrySync.start_collector([:lasso, :rpc, :request, :start])
 
-      Observability.record_request_start("ethereum", "eth_blockNumber", :load_balanced)
+      Observability.record_request_start(1, "eth_blockNumber", :load_balanced)
 
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert measurements.count == 1
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.method == "eth_blockNumber"
       assert metadata.strategy == :load_balanced
     end
@@ -688,7 +688,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
       collector = TelemetrySync.start_collector([:lasso, :request, :slow])
 
       Observability.record_slow_request(
-        "ethereum",
+        1,
         "eth_blockNumber",
         "provider_1",
         :http,
@@ -697,7 +697,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
 
       {:ok, measurements, metadata} = TelemetrySync.await_event(collector, timeout: 1_000)
       assert measurements.latency_ms == 2500.0
-      assert metadata.chain == "ethereum"
+      assert metadata.chain_id == 1
       assert metadata.method == "eth_blockNumber"
       assert metadata.provider == "provider_1"
       assert metadata.transport == :http

--- a/test/lasso/core/streaming/instance_subscription_manager_test.exs
+++ b/test/lasso/core/streaming/instance_subscription_manager_test.exs
@@ -22,7 +22,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManagerTest do
 
   setup do
     suffix = System.unique_integer([:positive])
-    test_chain = "test_manager_#{suffix}"
+    test_chain = suffix
     test_provider = "mock_manager_provider_#{suffix}"
 
     {:ok, ^test_provider} =
@@ -371,7 +371,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManagerTest do
 
     test "returns error when connection state is unknown" do
       fake_instance_id = "unknown_instance_#{System.unique_integer([:positive])}"
-      {:ok, pid} = InstanceSubscriptionManager.start_link({"fake_chain", fake_instance_id})
+      {:ok, pid} = InstanceSubscriptionManager.start_link({1, fake_instance_id})
 
       result = InstanceSubscriptionManager.ensure_subscription(fake_instance_id, {:newHeads})
       assert result == {:error, :connection_unknown}

--- a/test/lasso/core/streaming/stream_coordinator_test.exs
+++ b/test/lasso/core/streaming/stream_coordinator_test.exs
@@ -55,7 +55,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "initialization" do
     test "initializes with correct default state" do
-      chain = "test_chain"
+      chain = 1
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1"]
 
@@ -63,7 +63,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
       state = get_coordinator_state(pid)
 
-      assert state.chain == chain
+      assert state.chain_id == chain
       assert state.key == key
       assert state.primary_provider_id == "provider_1"
       assert state.failover_status == :active
@@ -78,7 +78,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "event handling - status routing" do
     setup do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1", max_event_buffer: 10]
 
@@ -188,7 +188,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "provider_unhealthy signal" do
     setup do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1"]
 
@@ -283,7 +283,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "circuit breaker" do
     setup do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
 
       opts = [
@@ -394,7 +394,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "dynamic failover budget" do
     test "uses default budget when ws provider count is zero" do
-      chain = "test_chain_no_ws_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1", failover_cooldown_ms: 1_000]
 
@@ -432,7 +432,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "state management" do
     test "tracks failover history correctly" do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1"]
 
@@ -457,7 +457,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "event buffer" do
     setup do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1", max_event_buffer: 3]
 
@@ -526,14 +526,11 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
         end)
 
       assert log =~ "Event buffer full"
-      assert log =~ "dropping oldest event"
+      assert log =~ "entering degraded mode"
 
-      # Buffer should still be size 3, with event1 dropped
       state = get_coordinator_state(pid)
-      assert length(state.failover_context.event_buffer) == 3
-      # event1 dropped, buffer now has [event2, event3, event4]
-      refute event1 in state.failover_context.event_buffer
-      assert event4 in state.failover_context.event_buffer
+      assert state.failover_status == :degraded
+      assert state.failover_context == nil
     end
 
     test "buffer preserves event ordering during drain", %{coordinator: pid} do
@@ -572,7 +569,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "stale backfill handling" do
     setup do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1"]
 
@@ -635,7 +632,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
   describe "backfill task crash handling" do
     setup do
-      chain = "test_chain_#{:rand.uniform(999_999)}"
+      chain = System.unique_integer([:positive])
       key = {:newHeads}
       opts = [primary_provider_id: "provider_1", max_failover_attempts: 2]
 

--- a/test/lasso/core/transport/websocket/connection_telemetry_test.exs
+++ b/test/lasso/core/transport/websocket/connection_telemetry_test.exs
@@ -30,7 +30,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
 
     # Start circuit breaker for the endpoint (keyed by instance_id)
     circuit_breaker_config = %{failure_threshold: 3, recovery_timeout: 200, success_threshold: 1}
-    instance_id = "#{endpoint.chain_name}:#{endpoint.id}"
+    instance_id = "#{endpoint.chain_id}:#{endpoint.id}"
 
     {:ok, _} =
       CircuitBreaker.start_link({{instance_id, :ws}, circuit_breaker_config})
@@ -39,7 +39,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
       # Clean up WebSocket connection
       cleanup_ws_connection(endpoint)
       # Clean up circuit breaker
-      cleanup_circuit_breaker(endpoint.chain_name, endpoint.id)
+      cleanup_circuit_breaker(endpoint.chain_id, endpoint.id)
       # Clean up application config
       Application.delete_env(:lasso, :ws_client_module)
       Application.delete_env(:lasso, :ws_client_opts)
@@ -57,8 +57,8 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
     end
   end
 
-  defp cleanup_circuit_breaker(chain_name, provider_id) do
-    instance_id = "#{chain_name}:#{provider_id}"
+  defp cleanup_circuit_breaker(chain_id, provider_id) do
+    instance_id = "#{chain_id}:#{provider_id}"
     key = "#{instance_id}:ws"
 
     case GenServer.whereis({:via, Registry, {Lasso.Registry, {:circuit_breaker, key}}}) do
@@ -68,8 +68,8 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
   end
 
   defp resolve_instance_id(endpoint) do
-    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_name, endpoint.id) ||
-      "#{endpoint.chain_name}:#{endpoint.id}"
+    Lasso.Providers.Catalog.lookup_instance_id(endpoint.profile, endpoint.chain_id, endpoint.id) ||
+      "#{endpoint.chain_id}:#{endpoint.id}"
   end
 
   describe "connection lifecycle telemetry" do
@@ -82,7 +82,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
 
       assert Registry.lookup(
                Lasso.Registry,
-               {:ws_conn, endpoint.profile, endpoint.chain_name, endpoint.id}
+               {:ws_conn, endpoint.profile, endpoint.chain_id, endpoint.id}
              ) == []
 
       GenServer.stop(pid)
@@ -104,7 +104,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
       # Verify telemetry data
       assert measurements == %{}
       assert metadata.provider_id == endpoint.id
-      assert metadata.chain == endpoint.chain_name
+      assert metadata.chain_id == endpoint.chain_id
       assert metadata.reconnect_attempt == 0
 
       GenServer.stop(pid)
@@ -156,7 +156,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
             TelemetrySync.await_event(failed_collector, timeout: 3_000)
 
           assert metadata.provider_id == endpoint.id
-          assert metadata.chain == endpoint.chain_name
+          assert metadata.chain_id == endpoint.chain_id
           assert is_binary(metadata.error_message) or is_atom(metadata.error_message)
           assert is_boolean(metadata.will_reconnect)
 

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -5,13 +5,10 @@ defmodule Lasso.Providers.CandidateListingTest do
   alias Lasso.Providers.{Catalog, CandidateListing}
 
   @profile "cl_test"
-  @chain "cl_test_chain"
-  @config_table :lasso_config_store
+  @chain 99
   @instance_table :lasso_instance_state
 
   setup do
-    original_profiles = ConfigStore.list_profiles()
-
     register_chain(@profile, @chain, [
       %{id: "p1", name: "P1", url: "https://cl-test-1.example.com", priority: 1},
       %{
@@ -32,7 +29,6 @@ defmodule Lasso.Providers.CandidateListingTest do
     on_exit(fn ->
       clean_instance_state()
       ConfigStore.unregister_chain_runtime(@profile, @chain)
-      :ets.insert(@config_table, {{:profile_list}, original_profiles})
       Catalog.build_from_config()
     end)
 
@@ -70,7 +66,7 @@ defmodule Lasso.Providers.CandidateListingTest do
     end
 
     test "returns empty list for unknown chain" do
-      assert CandidateListing.list_candidates(@profile, "nonexistent", %{}) == []
+      assert CandidateListing.list_candidates(@profile, 98, %{}) == []
     end
   end
 
@@ -288,15 +284,9 @@ defmodule Lasso.Providers.CandidateListingTest do
   # Helpers
 
   defp register_chain(profile, chain, providers) do
-    current = ConfigStore.list_profiles()
-
-    unless profile in current do
-      :ets.insert(@config_table, {{:profile_list}, [profile | current]})
-    end
-
     ConfigStore.register_chain_runtime(profile, chain, %{
-      chain_id: 99,
-      name: chain,
+      chain_id: chain,
+      name: "cl_test_chain",
       providers: providers
     })
   end

--- a/test/lasso/providers/catalog_test.exs
+++ b/test/lasso/providers/catalog_test.exs
@@ -6,43 +6,29 @@ defmodule Lasso.Providers.CatalogTest do
 
   @profile_a "catalog_test_a"
   @profile_b "catalog_test_b"
-  @chain "catalog_test_chain"
-  @config_table :lasso_config_store
+  @chain_id 99
 
   setup do
-    # Ensure test profiles appear in the profile list so Catalog.build_from_config finds them
-    original_profiles = ConfigStore.list_profiles()
-
     on_exit(fn ->
-      ConfigStore.unregister_chain_runtime(@profile_a, @chain)
-      ConfigStore.unregister_chain_runtime(@profile_b, @chain)
-      # Restore original profile list
-      :ets.insert(@config_table, {{:profile_list}, original_profiles})
-      # Rebuild catalog to remove test data
+      ConfigStore.unregister_chain_runtime(@profile_a, @chain_id)
+      ConfigStore.unregister_chain_runtime(@profile_b, @chain_id)
       Catalog.build_from_config()
     end)
 
     :ok
   end
 
-  defp register_chain(profile, chain, providers) do
-    # Add profile to profile list if not present
-    current = ConfigStore.list_profiles()
-
-    unless profile in current do
-      :ets.insert(@config_table, {{:profile_list}, [profile | current]})
-    end
-
-    ConfigStore.register_chain_runtime(profile, chain, %{
-      chain_id: 99,
-      name: chain,
+  defp register_chain(profile, chain_id, providers) do
+    ConfigStore.register_chain_runtime(profile, chain_id, %{
+      chain_id: chain_id,
+      display_name: "Test Chain #{chain_id}",
       providers: providers
     })
   end
 
   describe "build_from_config/0" do
     test "is idempotent" do
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "eth_drpc", name: "dRPC", url: "https://eth.drpc.org", priority: 1}
       ])
 
@@ -61,37 +47,139 @@ defmodule Lasso.Providers.CatalogTest do
     test "same URL providers across profiles share instance_id" do
       url = "https://catalog-test-shared.example.com"
 
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "shared_p", name: "Shared", url: url, priority: 1}
       ])
 
-      register_chain(@profile_b, @chain, [
+      register_chain(@profile_b, @chain_id, [
         %{id: "shared_p", name: "Shared", url: url, priority: 2}
       ])
 
       Catalog.build_from_config()
 
-      id_a = Catalog.lookup_instance_id(@profile_a, @chain, "shared_p")
-      id_b = Catalog.lookup_instance_id(@profile_b, @chain, "shared_p")
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "shared_p")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "shared_p")
 
       assert id_a != nil
       assert id_a == id_b
     end
 
     test "different URL providers get different instance_ids" do
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "provider_1", name: "P1", url: "https://catalog-test-1.example.com", priority: 1},
         %{id: "provider_2", name: "P2", url: "https://catalog-test-2.example.com", priority: 2}
       ])
 
       Catalog.build_from_config()
 
-      id_1 = Catalog.lookup_instance_id(@profile_a, @chain, "provider_1")
-      id_2 = Catalog.lookup_instance_id(@profile_a, @chain, "provider_2")
+      id_1 = Catalog.lookup_instance_id(@profile_a, @chain_id, "provider_1")
+      id_2 = Catalog.lookup_instance_id(@profile_a, @chain_id, "provider_2")
 
       assert id_1 != nil
       assert id_2 != nil
       assert id_1 != id_2
+    end
+
+    test "same HTTP URL with same WS URL shares instance_id" do
+      url = "https://catalog-test-ws-same.example.com"
+      ws_url = "wss://catalog-test-ws-same.example.com"
+
+      register_chain(@profile_a, @chain_id, [
+        %{id: "shared_ws", name: "Shared WS", url: url, ws_url: ws_url, priority: 1}
+      ])
+
+      register_chain(@profile_b, @chain_id, [
+        %{id: "shared_ws", name: "Shared WS", url: url <> "/", ws_url: ws_url <> "/", priority: 2}
+      ])
+
+      Catalog.build_from_config()
+
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "shared_ws")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "shared_ws")
+
+      assert id_a != nil
+      assert id_a == id_b
+    end
+
+    test "same HTTP URL with different WS URLs does not share instance_id" do
+      url = "https://catalog-test-ws-different.example.com"
+
+      register_chain(@profile_a, @chain_id, [
+        %{
+          id: "split_ws",
+          name: "Split WS A",
+          url: url,
+          ws_url: "wss://catalog-test-ws-a.example.com",
+          priority: 1
+        }
+      ])
+
+      register_chain(@profile_b, @chain_id, [
+        %{
+          id: "split_ws",
+          name: "Split WS B",
+          url: url,
+          ws_url: "wss://catalog-test-ws-b.example.com",
+          priority: 2
+        }
+      ])
+
+      Catalog.build_from_config()
+
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "split_ws")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "split_ws")
+
+      assert id_a != nil
+      assert id_b != nil
+      assert id_a != id_b
+    end
+
+    test "same HTTP URL with and without WS URL does not share instance_id" do
+      url = "https://catalog-test-ws-presence.example.com"
+
+      register_chain(@profile_a, @chain_id, [
+        %{id: "ws_presence", name: "HTTP Only", url: url, priority: 1}
+      ])
+
+      register_chain(@profile_b, @chain_id, [
+        %{
+          id: "ws_presence",
+          name: "HTTP+WS",
+          url: url,
+          ws_url: "wss://catalog-test-ws-presence.example.com",
+          priority: 2
+        }
+      ])
+
+      Catalog.build_from_config()
+
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "ws_presence")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "ws_presence")
+
+      assert id_a != nil
+      assert id_b != nil
+      assert id_a != id_b
+    end
+
+    test "isolated sharing mode prevents sharing across profiles" do
+      url = "https://catalog-test-isolated.example.com"
+
+      register_chain(@profile_a, @chain_id, [
+        %{id: "isolated", name: "Isolated A", url: url, priority: 1, sharing_mode: :isolated}
+      ])
+
+      register_chain(@profile_b, @chain_id, [
+        %{id: "isolated", name: "Isolated B", url: url, priority: 2, sharing_mode: :isolated}
+      ])
+
+      Catalog.build_from_config()
+
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "isolated")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "isolated")
+
+      assert id_a != nil
+      assert id_b != nil
+      assert id_a != id_b
     end
   end
 
@@ -99,17 +187,17 @@ defmodule Lasso.Providers.CatalogTest do
     test "returns all profiles referencing an instance" do
       url = "https://catalog-test-refs.example.com"
 
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "refs_p", name: "Refs", url: url, priority: 1}
       ])
 
-      register_chain(@profile_b, @chain, [
+      register_chain(@profile_b, @chain_id, [
         %{id: "refs_p", name: "Refs", url: url, priority: 2}
       ])
 
       Catalog.build_from_config()
 
-      instance_id = Catalog.lookup_instance_id(@profile_a, @chain, "refs_p")
+      instance_id = Catalog.lookup_instance_id(@profile_a, @chain_id, "refs_p")
       refs = Catalog.get_instance_refs(instance_id)
 
       assert @profile_a in refs
@@ -119,14 +207,14 @@ defmodule Lasso.Providers.CatalogTest do
 
   describe "get_profile_providers/2" do
     test "returns provider list with instance_id cross-references" do
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "p1", name: "P1", url: "https://catalog-test-pp-1.example.com", priority: 1},
         %{id: "p2", name: "P2", url: "https://catalog-test-pp-2.example.com", priority: 2}
       ])
 
       Catalog.build_from_config()
 
-      providers = Catalog.get_profile_providers(@profile_a, @chain)
+      providers = Catalog.get_profile_providers(@profile_a, @chain_id)
       assert length(providers) == 2
 
       p1 = Enum.find(providers, &(&1.provider_id == "p1"))
@@ -138,23 +226,23 @@ defmodule Lasso.Providers.CatalogTest do
   describe "lookup_instance_id/3" do
     test "returns nil for non-existent provider" do
       Catalog.build_from_config()
-      assert Catalog.lookup_instance_id("nonexistent", @chain, "nope") == nil
+      assert Catalog.lookup_instance_id("nonexistent", @chain_id, "nope") == nil
     end
   end
 
   describe "get_instance/1" do
     test "returns instance config" do
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "inst_p", name: "InstP", url: "https://catalog-test-inst.example.com", priority: 1}
       ])
 
       Catalog.build_from_config()
 
-      instance_id = Catalog.lookup_instance_id(@profile_a, @chain, "inst_p")
+      instance_id = Catalog.lookup_instance_id(@profile_a, @chain_id, "inst_p")
       assert instance_id != nil
 
       {:ok, instance} = Catalog.get_instance(instance_id)
-      assert instance.chain == @chain
+      assert instance.chain_id == @chain_id
       assert instance.url == "https://catalog-test-inst.example.com"
     end
 
@@ -163,22 +251,33 @@ defmodule Lasso.Providers.CatalogTest do
     end
   end
 
-  describe "sharing_mode: :isolated" do
-    test "same URL with sharing_mode: :isolated produces different instance_ids per profile" do
-      url = "https://catalog-test-isolated.example.com"
-
-      register_chain(@profile_a, @chain, [
-        %{id: "iso_p", name: "Iso", url: url, priority: 1, sharing_mode: :isolated}
+  describe "account-based isolation" do
+    test "providers with different key-in-path URLs produce different instance_ids" do
+      # Key-in-path URLs (e.g. Alchemy, Infura) naturally isolate per account
+      # because the URL itself encodes the credential. This is the primary
+      # BYOK isolation mechanism at the Catalog level.
+      register_chain(@profile_a, @chain_id, [
+        %{
+          id: "iso_p",
+          name: "Iso",
+          url: "https://eth-mainnet.g.alchemy.com/v2/key_aaa",
+          priority: 1
+        }
       ])
 
-      register_chain(@profile_b, @chain, [
-        %{id: "iso_p", name: "Iso", url: url, priority: 1, sharing_mode: :isolated}
+      register_chain(@profile_b, @chain_id, [
+        %{
+          id: "iso_p",
+          name: "Iso",
+          url: "https://eth-mainnet.g.alchemy.com/v2/key_bbb",
+          priority: 1
+        }
       ])
 
       Catalog.build_from_config()
 
-      id_a = Catalog.lookup_instance_id(@profile_a, @chain, "iso_p")
-      id_b = Catalog.lookup_instance_id(@profile_b, @chain, "iso_p")
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "iso_p")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "iso_p")
 
       assert id_a != nil
       assert id_b != nil
@@ -188,7 +287,7 @@ defmodule Lasso.Providers.CatalogTest do
 
   describe "BYOK isolation" do
     test "same provider_id with different URLs produces different instance_ids" do
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{
           id: "alchemy",
           name: "Alchemy",
@@ -197,7 +296,7 @@ defmodule Lasso.Providers.CatalogTest do
         }
       ])
 
-      register_chain(@profile_b, @chain, [
+      register_chain(@profile_b, @chain_id, [
         %{
           id: "alchemy",
           name: "Alchemy",
@@ -208,8 +307,8 @@ defmodule Lasso.Providers.CatalogTest do
 
       Catalog.build_from_config()
 
-      id_a = Catalog.lookup_instance_id(@profile_a, @chain, "alchemy")
-      id_b = Catalog.lookup_instance_id(@profile_b, @chain, "alchemy")
+      id_a = Catalog.lookup_instance_id(@profile_a, @chain_id, "alchemy")
+      id_b = Catalog.lookup_instance_id(@profile_b, @chain_id, "alchemy")
 
       assert id_a != nil
       assert id_b != nil
@@ -219,7 +318,7 @@ defmodule Lasso.Providers.CatalogTest do
 
   describe "list_all_instance_ids/0" do
     test "returns all unique instance_ids" do
-      register_chain(@profile_a, @chain, [
+      register_chain(@profile_a, @chain_id, [
         %{id: "list_p1", name: "P1", url: "https://catalog-test-list-1.example.com", priority: 1},
         %{id: "list_p2", name: "P2", url: "https://catalog-test-list-2.example.com", priority: 2}
       ])

--- a/test/lasso/providers/instance_id_test.exs
+++ b/test/lasso/providers/instance_id_test.exs
@@ -3,199 +3,53 @@ defmodule Lasso.Providers.InstanceIdTest do
 
   alias Lasso.Providers.InstanceId
 
-  describe "derive/3" do
-    test "same URL and chain produce the same instance_id" do
-      config = %{url: "https://eth.drpc.org", archival: true}
-      id1 = InstanceId.derive("ethereum", config)
-      id2 = InstanceId.derive("ethereum", config)
-      assert id1 == id2
-    end
+  test "shares matching HTTP and WebSocket endpoints" do
+    config = %{url: "https://rpc.example.com", ws_url: "wss://rpc.example.com"}
+    assert InstanceId.derive(1, config) == InstanceId.derive(1, config)
+  end
 
-    test "different chains produce different instance_ids" do
-      config = %{url: "https://rpc.example.com"}
-      id_eth = InstanceId.derive("ethereum", config)
-      id_arb = InstanceId.derive("arbitrum", config)
-      assert id_eth != id_arb
-    end
+  test "distinguishes chains and endpoint URLs" do
+    config = %{url: "https://rpc.example.com"}
+    assert InstanceId.derive(1, config) != InstanceId.derive(10, config)
 
-    test "different URLs produce different instance_ids" do
-      config_a = %{url: "https://eth.drpc.org"}
-      config_b = %{url: "https://rpc.ankr.com/eth"}
-      id_a = InstanceId.derive("ethereum", config_a)
-      id_b = InstanceId.derive("ethereum", config_b)
-      assert id_a != id_b
-    end
+    assert InstanceId.derive(1, config) !=
+             InstanceId.derive(1, %{url: "https://other.example.com"})
+  end
 
-    test "different API keys produce different instance_ids" do
-      config_a = %{url: "https://eth.drpc.org", api_key: "key_aaa"}
-      config_b = %{url: "https://eth.drpc.org", api_key: "key_bbb"}
-      id_a = InstanceId.derive("ethereum", config_a)
-      id_b = InstanceId.derive("ethereum", config_b)
-      assert id_a != id_b
-    end
+  test "different credentials produce different instance identities" do
+    first = %{url: "https://rpc.example.com", api_key: "first-key"}
+    second = %{url: "https://rpc.example.com", api_key: "second-key"}
 
-    test "same URL across profiles produces the same instance_id (sharing_mode: :auto)" do
-      config = %{url: "https://eth.drpc.org"}
-      id_default = InstanceId.derive("ethereum", config, profile: "public")
-      id_premium = InstanceId.derive("ethereum", config, profile: "managed")
-      assert id_default == id_premium
-    end
+    refute InstanceId.auth_fingerprint(first) == InstanceId.auth_fingerprint(second)
+    refute InstanceId.derive(1, first) == InstanceId.derive(1, second)
+  end
 
-    test "sharing_mode: :isolated forces unique ids per profile" do
-      config = %{url: "https://eth.drpc.org"}
+  test "authentication headers are canonicalized before fingerprinting" do
+    first = %{url: "https://rpc.example.com", headers: [{"x-api-key", "secret"}, {"x-id", "1"}]}
+    second = %{url: "https://rpc.example.com", headers: [{"x-id", "1"}, {"x-api-key", "secret"}]}
 
-      id_default =
-        InstanceId.derive("ethereum", config, profile: "public", sharing_mode: :isolated)
+    assert InstanceId.auth_fingerprint(first) == InstanceId.auth_fingerprint(second)
+    assert InstanceId.derive(1, first) == InstanceId.derive(1, second)
+  end
 
-      id_premium =
-        InstanceId.derive("ethereum", config, profile: "managed", sharing_mode: :isolated)
+  test "isolated sharing mode salts by profile ID" do
+    config = %{url: "https://rpc.example.com"}
 
-      assert id_default != id_premium
-    end
+    assert InstanceId.derive(1, config, sharing_mode: :isolated, profile_id: "a") !=
+             InstanceId.derive(1, config, sharing_mode: :isolated, profile_id: "b")
+  end
 
-    test "format is chain:host_hint:hash_12" do
-      config = %{url: "https://eth.drpc.org/path"}
-      id = InstanceId.derive("ethereum", config)
-      assert id =~ ~r/^ethereum:drpc:[a-f0-9]{12}$/
-    end
-
-    test "host_hint extracts penultimate domain part" do
-      config = %{url: "https://eth-mainnet.g.alchemy.com/v2/key123"}
-      id = InstanceId.derive("ethereum", config)
-      assert id =~ ~r/^ethereum:alchemy:/
-    end
-
-    test "host_hint for simple two-part domain" do
-      config = %{url: "https://rpc.example.com"}
-      id = InstanceId.derive("ethereum", config)
-      assert id =~ ~r/^ethereum:example:/
-    end
-
-    test "sharing_mode: :isolated without profile raises ArgumentError" do
-      config = %{url: "https://eth.drpc.org"}
-
-      assert_raise ArgumentError, ~r/profile is required/, fn ->
-        InstanceId.derive("ethereum", config, sharing_mode: :isolated)
-      end
+  test "isolated sharing mode requires a profile ID" do
+    assert_raise ArgumentError, fn ->
+      InstanceId.derive(1, %{url: "https://rpc.example.com"}, sharing_mode: :isolated)
     end
   end
 
-  describe "normalize_url/1" do
-    test "lowercases scheme and host" do
-      assert InstanceId.normalize_url("HTTPS://ETH.DRPC.ORG") ==
-               InstanceId.normalize_url("https://eth.drpc.org")
-    end
+  test "normalizes equivalent endpoint URLs" do
+    assert InstanceId.normalize_url("HTTPS://RPC.EXAMPLE.COM:443/") ==
+             InstanceId.normalize_url("https://rpc.example.com")
 
-    test "strips default HTTPS port 443" do
-      assert InstanceId.normalize_url("https://eth.drpc.org:443") ==
-               InstanceId.normalize_url("https://eth.drpc.org")
-    end
-
-    test "strips default HTTP port 80" do
-      assert InstanceId.normalize_url("http://eth.drpc.org:80") ==
-               InstanceId.normalize_url("http://eth.drpc.org")
-    end
-
-    test "preserves non-default ports" do
-      normalized = InstanceId.normalize_url("https://eth.drpc.org:8545")
-      assert normalized =~ ":8545"
-    end
-
-    test "strips trailing slash" do
-      assert InstanceId.normalize_url("https://eth.drpc.org/") ==
-               InstanceId.normalize_url("https://eth.drpc.org")
-    end
-
-    test "preserves path without trailing slash" do
-      normalized = InstanceId.normalize_url("https://eth.drpc.org/v2/key123")
-      assert normalized =~ "/v2/key123"
-      refute String.ends_with?(normalized, "/v2/key123/")
-    end
-
-    test "sorts query parameters" do
-      assert InstanceId.normalize_url("https://rpc.example.com?z=1&a=2") ==
-               InstanceId.normalize_url("https://rpc.example.com?a=2&z=1")
-    end
-
-    test "no query preserves nil query" do
-      normalized = InstanceId.normalize_url("https://eth.drpc.org")
-      refute normalized =~ "?"
-    end
-
-    test "normalizes URL with both path and query" do
-      url_a = "https://rpc.example.com/v2/key123?z=1&a=2"
-      url_b = "https://rpc.example.com/v2/key123?a=2&z=1"
-      assert InstanceId.normalize_url(url_a) == InstanceId.normalize_url(url_b)
-      normalized = InstanceId.normalize_url(url_a)
-      assert normalized =~ "/v2/key123"
-      assert normalized =~ "a=2"
-    end
-
-    test "strips default WSS port 443" do
-      assert InstanceId.normalize_url("wss://eth.drpc.org:443") ==
-               InstanceId.normalize_url("wss://eth.drpc.org")
-    end
-
-    test "strips default WS port 80" do
-      assert InstanceId.normalize_url("ws://eth.drpc.org:80") ==
-               InstanceId.normalize_url("ws://eth.drpc.org")
-    end
-  end
-
-  describe "auth_fingerprint/1" do
-    test "returns nil when no auth configured" do
-      assert InstanceId.auth_fingerprint(%{url: "https://example.com"}) == nil
-    end
-
-    test "returns nil for empty api_key" do
-      assert InstanceId.auth_fingerprint(%{api_key: ""}) == nil
-    end
-
-    test "same api_key produces same fingerprint" do
-      fp1 = InstanceId.auth_fingerprint(%{api_key: "my-secret-key"})
-      fp2 = InstanceId.auth_fingerprint(%{api_key: "my-secret-key"})
-      assert fp1 == fp2
-      assert is_binary(fp1)
-      assert byte_size(fp1) == 12
-    end
-
-    test "different api_keys produce different fingerprints" do
-      fp1 = InstanceId.auth_fingerprint(%{api_key: "key_aaa"})
-      fp2 = InstanceId.auth_fingerprint(%{api_key: "key_bbb"})
-      assert fp1 != fp2
-    end
-
-    test "auth_headers produce a fingerprint" do
-      fp = InstanceId.auth_fingerprint(%{auth_headers: %{"Authorization" => "Bearer token"}})
-      assert is_binary(fp)
-      assert byte_size(fp) == 12
-    end
-
-    test "different auth_headers produce different fingerprints" do
-      fp1 = InstanceId.auth_fingerprint(%{auth_headers: %{"Authorization" => "Bearer a"}})
-      fp2 = InstanceId.auth_fingerprint(%{auth_headers: %{"Authorization" => "Bearer b"}})
-      assert fp1 != fp2
-    end
-
-    test "empty auth_headers returns nil" do
-      assert InstanceId.auth_fingerprint(%{auth_headers: %{}}) == nil
-    end
-
-    test "api_key takes precedence over auth_headers when both present" do
-      fp = InstanceId.auth_fingerprint(%{api_key: "my-key", auth_headers: %{"X-Auth" => "val"}})
-      fp_key_only = InstanceId.auth_fingerprint(%{api_key: "my-key"})
-      assert fp == fp_key_only
-    end
-
-    test "returns nil for Provider struct (no api_key/auth_headers fields)" do
-      provider = %Lasso.Config.ChainConfig.Provider{
-        id: "test",
-        name: "Test",
-        url: "https://example.com",
-        priority: 1
-      }
-
-      assert InstanceId.auth_fingerprint(provider) == nil
-    end
+    assert InstanceId.normalize_url("wss://rpc.example.com:443/") ==
+             InstanceId.normalize_url("wss://rpc.example.com")
   end
 end

--- a/test/lasso/providers/instance_supervisor_test.exs
+++ b/test/lasso/providers/instance_supervisor_test.exs
@@ -5,15 +5,11 @@ defmodule Lasso.Providers.InstanceSupervisorTest do
   alias Lasso.Providers.{Catalog, InstanceSupervisor}
 
   @profile "is_test"
-  @chain "is_test_chain"
-  @config_table :lasso_config_store
+  @chain 99
 
   setup do
-    original_profiles = ConfigStore.list_profiles()
-
     on_exit(fn ->
       ConfigStore.unregister_chain_runtime(@profile, @chain)
-      :ets.insert(@config_table, {{:profile_list}, original_profiles})
       Catalog.build_from_config()
     end)
 
@@ -130,15 +126,9 @@ defmodule Lasso.Providers.InstanceSupervisorTest do
   # Helpers
 
   defp register_chain(profile, chain, providers) do
-    current = ConfigStore.list_profiles()
-
-    unless profile in current do
-      :ets.insert(@config_table, {{:profile_list}, [profile | current]})
-    end
-
     ConfigStore.register_chain_runtime(profile, chain, %{
-      chain_id: 99,
-      name: chain,
+      chain_id: chain,
+      name: "is_test_chain",
       providers: providers
     })
   end

--- a/test/lasso/providers/probe_coordinator_test.exs
+++ b/test/lasso/providers/probe_coordinator_test.exs
@@ -5,13 +5,10 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
   alias Lasso.Providers.{Catalog, ProbeCoordinator}
 
   @profile "pc_test"
-  @chain "pc_test_chain"
-  @config_table :lasso_config_store
+  @chain 98
   @instance_table :lasso_instance_state
 
   setup do
-    original_profiles = ConfigStore.list_profiles()
-
     register_chain(@profile, @chain, [
       %{id: "pc_p1", name: "P1", url: "https://pc-test-1.example.com", priority: 1},
       %{id: "pc_p2", name: "P2", url: "https://pc-test-2.example.com", priority: 2}
@@ -32,7 +29,6 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
       ConfigStore.unregister_chain_runtime(@profile, @chain)
       ConfigStore.unregister_chain_runtime("pc_test_b", @chain)
-      :ets.insert(@config_table, {{:profile_list}, original_profiles})
       clean_instance_state()
       Catalog.build_from_config()
     end)
@@ -42,24 +38,24 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "start_link/1" do
     test "starts and registers via Registry" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       assert Process.alive?(pid)
       assert GenServer.whereis(ProbeCoordinator.via_name(@chain)) == pid
     end
 
     test "loads instances from catalog on init" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       state = :sys.get_state(pid)
 
       instance_ids = Catalog.list_instances_for_chain(@chain)
       assert map_size(state.instances) == length(instance_ids)
-      assert state.chain == @chain
+      assert state.chain_id == @chain
     end
   end
 
   describe "tick cycle and probing" do
     test "writes health state to ETS after probe" do
-      {:ok, _pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, _pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
 
       # Wait for at least one tick cycle to fire probes
@@ -78,7 +74,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
 
     test "real probe task updates coordinator backoff state" do
-      chain = "pc_async_path_chain"
+      chain = 97
       profile = "pc_async_path"
 
       register_chain(profile, chain, [
@@ -86,7 +82,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
       ])
 
       Catalog.build_from_config()
-      {:ok, pid} = ProbeCoordinator.start_link(chain)
+      {:ok, pid} = start_coordinator(chain)
 
       on_exit(fn ->
         try do
@@ -118,7 +114,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "reload_instances/1" do
     test "picks up new instances after catalog rebuild" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       state_before = :sys.get_state(pid)
       count_before = map_size(state_before.instances)
       assert count_before == 2
@@ -142,7 +138,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
 
     test "preserves backoff state for existing instances on reload" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
       [first_id | _] = instance_ids
 
@@ -166,7 +162,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "backoff behavior" do
     test "successful probe resets failure count" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
       [first_id | _] = instance_ids
 
@@ -182,7 +178,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
 
     test "failure increments failure count and sets backoff" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
       [first_id | _] = instance_ids
 
@@ -198,7 +194,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
 
     test "multiple failures increase backoff exponentially" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
       [first_id | _] = instance_ids
 
@@ -219,7 +215,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "minimum probe interval" do
     test "enforces 10s floor between probes regardless of backoff" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
       [first_id | _] = instance_ids
 
@@ -248,7 +244,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
 
     test "allows probing after minimum interval has elapsed" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       instance_ids = Catalog.list_instances_for_chain(@chain)
       [first_id | _] = instance_ids
 
@@ -266,27 +262,31 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
       new_state = %{state | instances: Map.put(state.instances, first_id, modified)}
       :sys.replace_state(pid, fn _ -> new_state end)
+      send(pid, :tick)
 
-      # Wait for a tick cycle
+      # Wait for the explicit tick to dispatch a probe.
       Process.sleep(300)
 
-      # The instance should have been probed (11s > 10s minimum)
+      # At least one eligible instance should have been probed (11s > 10s minimum).
       after_state = :sys.get_state(pid)
-      after_inst = Map.get(after_state.instances, first_id)
-      assert after_inst.last_probe_monotonic > now - 11_000
+
+      assert Enum.any?(after_state.instances, fn {_id, instance} ->
+               is_integer(instance.last_probe_monotonic) and
+                 instance.last_probe_monotonic > now - 11_000
+             end)
     end
   end
 
   describe "via_name/1" do
     test "returns a Registry via tuple" do
-      {:via, Registry, {Lasso.Registry, key}} = ProbeCoordinator.via_name("ethereum")
-      assert key == {:probe_coordinator, "ethereum"}
+      {:via, Registry, {Lasso.Registry, key}} = ProbeCoordinator.via_name(1)
+      assert key == {:probe_coordinator, 1}
     end
   end
 
   describe "probe result for unknown instance" do
     test "ignores results for instance_ids not in state" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
 
       ref = make_ref()
       send(pid, {ref, {"unknown:fake:000000000000", :success}})
@@ -299,7 +299,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "DOWN message handling" do
     test "handles DOWN messages without crashing" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
 
       send(pid, {:DOWN, make_ref(), :process, self(), :normal})
       Process.sleep(50)
@@ -310,7 +310,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "rate_limited result sets backoff floor" do
     test "rate_limited sets backoff to at least 30s" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       [first_id | _] = Catalog.list_instances_for_chain(@chain)
 
       ref = make_ref()
@@ -323,7 +323,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
 
     test "rate_limited does not lower an existing higher backoff" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       [first_id | _] = Catalog.list_instances_for_chain(@chain)
 
       # Simulate high backoff from prior failures
@@ -347,7 +347,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "auth_failed result sets 120s backoff" do
     test "auth_failed sets fixed 120s backoff" do
-      {:ok, pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, pid} = start_coordinator(@chain)
       [first_id | _] = Catalog.list_instances_for_chain(@chain)
 
       ref = make_ref()
@@ -362,7 +362,7 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   describe "ETS probe writes after tick cycle" do
     test "failed probes write degraded/unhealthy to health_probe ETS" do
-      {:ok, _pid} = ProbeCoordinator.start_link(@chain)
+      {:ok, _pid} = start_coordinator(@chain)
       [first_id | _] = Catalog.list_instances_for_chain(@chain)
 
       # Wait for probes to fire against unreachable URLs
@@ -381,16 +381,17 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
 
   # Helpers
 
+  defp start_coordinator(chain_id) do
+    {:ok, pid} = ProbeCoordinator.start_link(chain_id)
+    send(pid, :load_instances)
+    assert_wait_until(fn -> map_size(:sys.get_state(pid).instances) > 0 end)
+    {:ok, pid}
+  end
+
   defp register_chain(profile, chain, providers) do
-    current = ConfigStore.list_profiles()
-
-    unless profile in current do
-      :ets.insert(@config_table, {{:profile_list}, [profile | current]})
-    end
-
     ConfigStore.register_chain_runtime(profile, chain, %{
-      chain_id: 99,
-      name: chain,
+      chain_id: chain,
+      name: "pc_test_chain",
       providers: providers
     })
   end

--- a/test/lasso/providers/provider_headers_test.exs
+++ b/test/lasso/providers/provider_headers_test.exs
@@ -1,0 +1,28 @@
+defmodule Lasso.Providers.ProviderHeadersTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Providers.ProviderHeaders
+
+  test "builds bearer and configured transport headers with explicit auth precedence" do
+    headers =
+      ProviderHeaders.build(%{
+        api_key: "fallback-token",
+        headers: %{"x-provider" => "provider-value"},
+        auth_headers: [{"Authorization", "Basic explicit"}]
+      })
+      |> Map.new()
+
+    assert headers["content-type"] == "application/json"
+    assert headers["accept"] == "application/json"
+    assert headers["x-provider"] == "provider-value"
+    assert headers["authorization"] == "Basic explicit"
+  end
+
+  test "ignores malformed headers" do
+    headers =
+      ProviderHeaders.build(%{headers: [{:invalid, nil}, {:valid, "value"}, :invalid]})
+
+    assert {"valid", "value"} in headers
+    refute Enum.any?(headers, fn {key, _value} -> key == "invalid" end)
+  end
+end

--- a/test/lasso/providers/shared_ws_runtime_test.exs
+++ b/test/lasso/providers/shared_ws_runtime_test.exs
@@ -6,9 +6,9 @@ defmodule Lasso.Providers.SharedWSRuntimeTest do
   alias Lasso.Providers.InstanceSupervisor
 
   setup do
-    chain = "shared_ws_#{System.unique_integer([:positive])}"
+    chain = System.unique_integer([:positive])
     default_provider_id = "default_ws_#{System.unique_integer([:positive])}"
-    premium_provider_id = "premium_ws_#{System.unique_integer([:positive])}"
+    secondary_provider_id = "secondary_ws_#{System.unique_integer([:positive])}"
 
     default_profile = "public"
 
@@ -26,8 +26,8 @@ defmodule Lasso.Providers.SharedWSRuntimeTest do
       end
 
     chain_config = %{
-      chain_id: 0,
-      name: chain,
+      chain_id: chain,
+      name: "Shared WS Test Chain",
       providers: [],
       websocket: %{
         subscribe_new_heads: true,
@@ -80,14 +80,14 @@ defmodule Lasso.Providers.SharedWSRuntimeTest do
       ConfigStore.register_provider_runtime(
         secondary_profile,
         chain,
-        Map.put(provider_common, :id, premium_provider_id)
+        Map.put(provider_common, :id, secondary_provider_id)
       )
 
     Catalog.build_from_config()
 
     on_exit(fn ->
       _ = ConfigStore.unregister_provider_runtime(default_profile, chain, default_provider_id)
-      _ = ConfigStore.unregister_provider_runtime(secondary_profile, chain, premium_provider_id)
+      _ = ConfigStore.unregister_provider_runtime(secondary_profile, chain, secondary_provider_id)
       _ = ConfigStore.unregister_chain_runtime(default_profile, chain)
       _ = ConfigStore.unregister_chain_runtime(secondary_profile, chain)
 
@@ -111,27 +111,27 @@ defmodule Lasso.Providers.SharedWSRuntimeTest do
     %{
       chain: chain,
       default_profile: default_profile,
-      premium_profile: secondary_profile,
+      secondary_profile: secondary_profile,
       default_provider_id: default_provider_id,
-      premium_provider_id: premium_provider_id
+      secondary_provider_id: secondary_provider_id
     }
   end
 
   test "starts one shared WS connection and fans out profile-local events", ctx do
     default_provider_id = ctx.default_provider_id
-    premium_provider_id = ctx.premium_provider_id
+    secondary_provider_id = ctx.secondary_provider_id
 
     default_instance_id =
       Catalog.lookup_instance_id(ctx.default_profile, ctx.chain, ctx.default_provider_id)
 
-    premium_instance_id =
-      Catalog.lookup_instance_id(ctx.premium_profile, ctx.chain, ctx.premium_provider_id)
+    secondary_instance_id =
+      Catalog.lookup_instance_id(ctx.secondary_profile, ctx.chain, ctx.secondary_provider_id)
 
     assert is_binary(default_instance_id)
-    assert default_instance_id == premium_instance_id
+    assert default_instance_id == secondary_instance_id
 
     Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:conn:#{ctx.default_profile}:#{ctx.chain}")
-    Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:conn:#{ctx.premium_profile}:#{ctx.chain}")
+    Phoenix.PubSub.subscribe(Lasso.PubSub, "ws:conn:#{ctx.secondary_profile}:#{ctx.chain}")
 
     {:ok, supervisor_pid} =
       DynamicSupervisor.start_child(
@@ -140,7 +140,7 @@ defmodule Lasso.Providers.SharedWSRuntimeTest do
       )
 
     assert_receive {:ws_connected, ^default_provider_id, _connection_id}, 2_000
-    assert_receive {:ws_connected, ^premium_provider_id, _connection_id}, 2_000
+    assert_receive {:ws_connected, ^secondary_provider_id, _connection_id}, 2_000
 
     assert [{shared_ws_pid, _}] =
              Registry.lookup(Lasso.Registry, {:ws_conn_instance, default_instance_id})
@@ -157,9 +157,9 @@ defmodule Lasso.Providers.SharedWSRuntimeTest do
 
     assert Registry.lookup(Lasso.Registry, {
              :ws_conn,
-             ctx.premium_profile,
+             ctx.secondary_profile,
              ctx.chain,
-             ctx.premium_provider_id
+             ctx.secondary_provider_id
            }) == []
   end
 end

--- a/test/lasso/public_api_compatibility_test.exs
+++ b/test/lasso/public_api_compatibility_test.exs
@@ -1,0 +1,145 @@
+defmodule Lasso.PublicAPICompatibilityTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Config.{Backend.File, ChainConfig, ConfigStore}
+  alias Lasso.RPC.TransportRegistry
+
+  @legacy_exports %{
+    ConfigStore => [
+      find_chain_name_by_id: 1,
+      get_all_chains: 0,
+      get_chain: 2,
+      get_profile: 1,
+      get_profile_chains: 1,
+      get_provider: 3,
+      get_provider_ids: 2,
+      get_providers: 2,
+      list_chains: 0,
+      list_chains_for_profile: 1,
+      list_profiles: 0,
+      list_profiles_for_chain: 1,
+      load_all_profiles: 0,
+      register_chain_runtime: 3,
+      register_provider_runtime: 3,
+      reload: 0,
+      status: 0,
+      unregister_chain_runtime: 2,
+      unregister_provider_runtime: 3
+    ],
+    Lasso.Providers => [
+      add_provider: 2,
+      add_provider: 3,
+      add_provider: 4,
+      get_provider: 2,
+      get_provider: 3,
+      list_providers: 1,
+      list_providers: 2,
+      remove_provider: 2,
+      remove_provider: 3,
+      remove_provider: 4,
+      update_provider: 3,
+      update_provider: 4,
+      update_provider: 5
+    ],
+    TransportRegistry => [
+      close_channel: 3,
+      close_channel: 4,
+      get_candidate_channels: 1,
+      get_candidate_channels: 2,
+      get_candidate_channels: 3,
+      get_channel: 4,
+      get_channel: 5,
+      initialize_provider_channels: 3,
+      initialize_provider_channels: 4,
+      list_provider_channels: 2,
+      list_provider_channels: 3,
+      refresh_capabilities: 3,
+      refresh_capabilities: 4,
+      start_link: 1,
+      via_name: 1,
+      via_name: 2
+    ]
+  }
+
+  setup do
+    chain_id = 991_337
+
+    :ok =
+      ConfigStore.register_chain_runtime("public", chain_id, %{
+        name: "Compatibility Chain",
+        url_aliases: ["compatibility-chain"],
+        providers: []
+      })
+
+    on_exit(fn -> ConfigStore.unregister_chain_runtime("public", chain_id) end)
+    {:ok, chain_id: chain_id}
+  end
+
+  test "legacy callable exports remain available" do
+    for {module, exports} <- @legacy_exports,
+        {:module, ^module} = Code.ensure_loaded(module),
+        {function, arity} <- exports do
+      assert function_exported?(module, function, arity),
+             "expected #{inspect(module)}.#{function}/#{arity} to remain exported"
+    end
+
+    assert {:module, File} = Code.ensure_loaded(File)
+    assert function_exported?(File, :load, 2)
+  end
+
+  test "legacy ConfigStore path startup remains accepted" do
+    assert {:ok, state} = ConfigStore.init("config/chains.yml")
+    assert state.backend_module == File
+    assert state.backend_config[:legacy_config_path] == "config/chains.yml"
+  end
+
+  test "legacy chain names remain available on ChainConfig", %{chain_id: chain_id} do
+    config = %ChainConfig{name: "Legacy Name", display_name: "Legacy Name"}
+    assert config.name == config.display_name
+
+    assert {:ok, loaded} = ConfigStore.get_chain("public", chain_id)
+    assert loaded.name == loaded.display_name
+  end
+
+  test "legacy runtime chain registration retains its chain alias" do
+    chain_id = 991_339
+
+    assert :ok =
+             ConfigStore.register_chain_runtime("public", "legacy-runtime", %{
+               chain_id: chain_id,
+               name: "Legacy Runtime Display",
+               providers: []
+             })
+
+    on_exit(fn -> ConfigStore.unregister_chain_runtime("public", chain_id) end)
+
+    assert {:ok, ^chain_id} =
+             ConfigStore.lookup_chain_id_in_profile("public", "legacy-runtime")
+
+    assert {:ok, "legacy-runtime"} = ConfigStore.find_chain_name_by_id(chain_id)
+  end
+
+  test "standalone legacy TransportRegistry startup remains reachable by chain name" do
+    chain_id = 991_338
+    chain_name = "standalone-legacy-chain"
+
+    assert {:ok, pid} = TransportRegistry.start_link({chain_name, %{chain_id: chain_id}})
+    assert GenServer.whereis(TransportRegistry.via_name(chain_name)) == pid
+    GenServer.stop(pid)
+  end
+
+  test "legacy chain lookup and transport registry names resolve through loaded aliases", %{
+    chain_id: chain_id
+  } do
+    assert {:ok, ^chain_id} =
+             ConfigStore.lookup_chain_id_in_profile("public", "compatibility-chain")
+
+    assert {:ok, "compatibility-chain"} = ConfigStore.find_chain_name_by_id(chain_id)
+
+    assert TransportRegistry.via_name("compatibility-chain") ==
+             TransportRegistry.via_name("public", chain_id)
+
+    assert TransportRegistry.via_name("default", "compatibility-chain") ==
+             TransportRegistry.via_name("public", chain_id)
+  end
+end

--- a/test/lasso/rpc/optimistic_lag_test.exs
+++ b/test/lasso/rpc/optimistic_lag_test.exs
@@ -18,7 +18,7 @@ defmodule Lasso.RPC.OptimisticLagTest do
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
   alias Lasso.RPC.ChainState
 
-  @chain "optimistic_lag_test_chain"
+  @chain 9_999_001
 
   setup do
     BlockSyncRegistry.clear_chain(@chain)

--- a/test/lasso/rpc/upstream_subscription_pool_test.exs
+++ b/test/lasso/rpc/upstream_subscription_pool_test.exs
@@ -26,7 +26,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
   setup do
     suffix = System.unique_integer([:positive])
-    test_chain = "test_pool_unit_#{suffix}"
+    test_chain = suffix
     test_provider = "mock_provider_#{suffix}"
     test_profile = @default_profile
 

--- a/test/lasso_web/dashboard/event_stream_test.exs
+++ b/test/lasso_web/dashboard/event_stream_test.exs
@@ -82,7 +82,7 @@ defmodule LassoWeb.Dashboard.EventStreamTest do
           event = %RoutingDecision{
             request_id: "req-#{i}",
             provider_id: "provider-1",
-            chain: "ethereum",
+            chain_id: 1,
             method: "eth_blockNumber",
             result: :success,
             duration_ms: 100,

--- a/test/lasso_web/sockets/rpc_socket_test.exs
+++ b/test/lasso_web/sockets/rpc_socket_test.exs
@@ -3,6 +3,8 @@ defmodule LassoWeb.RPCSocketTest do
 
   alias LassoWeb.RPCSocket
 
+  @chain_id 99_999_991
+
   defp transport_info(path, params) do
     %{
       params: params,
@@ -13,32 +15,64 @@ defmodule LassoWeb.RPCSocketTest do
     }
   end
 
+  setup do
+    :ok =
+      Lasso.Config.ConfigStore.register_chain_runtime("public", @chain_id, %{
+        display_name: "Test Chain",
+        url_aliases: ["test-chain"],
+        providers: []
+      })
+
+    on_exit(fn ->
+      Lasso.Config.ConfigStore.unregister_chain_runtime("public", @chain_id)
+    end)
+
+    :ok
+  end
+
   describe "connect/1 - profile validation" do
     test "accepts when no profile is specified (defaults to public)" do
       assert {:ok, state} =
-               RPCSocket.connect(transport_info("/ws/rpc/ethereum", %{"chain_id" => "ethereum"}))
+               RPCSocket.connect(
+                 transport_info("/ws/rpc/test-chain", %{"chain_id" => "test-chain"})
+               )
 
       assert state.profile == "public"
-      assert state.chain == "ethereum"
+      assert state.chain_id == @chain_id
     end
 
     test "accepts an existing profile" do
       assert {:ok, state} =
                RPCSocket.connect(
-                 transport_info("/ws/rpc/profile/public/ethereum", %{
-                   "chain_id" => "ethereum",
+                 transport_info("/ws/rpc/profile/public/test-chain", %{
+                   "chain_id" => "test-chain",
                    "profile" => "public"
                  })
                )
 
       assert state.profile == "public"
+      assert state.chain_id == @chain_id
+    end
+
+    test "accepts a numeric chain ID" do
+      assert {:ok, state} =
+               RPCSocket.connect(
+                 transport_info("/ws/rpc/#{@chain_id}", %{"chain_id" => to_string(@chain_id)})
+               )
+
+      assert state.chain_id == @chain_id
+    end
+
+    test "rejects an unknown or nonpositive chain ID" do
+      assert :error = RPCSocket.connect(transport_info("/ws/rpc/0", %{"chain_id" => "0"}))
+      assert :error = RPCSocket.connect(transport_info("/ws/rpc/nope", %{"chain_id" => "nope"}))
     end
 
     test "rejects when profile is explicitly invalid" do
       assert :error =
                RPCSocket.connect(
-                 transport_info("/ws/rpc/profile/zzz/ethereum", %{
-                   "chain_id" => "ethereum",
+                 transport_info("/ws/rpc/profile/zzz/test-chain", %{
+                   "chain_id" => "test-chain",
                    "profile" => "zzz"
                  })
                )
@@ -49,8 +83,8 @@ defmodule LassoWeb.RPCSocketTest do
     test "rejects when provider override does not exist" do
       assert :error =
                RPCSocket.connect(
-                 transport_info("/ws/rpc/provider/ghost/ethereum", %{
-                   "chain_id" => "ethereum",
+                 transport_info("/ws/rpc/provider/ghost/test-chain", %{
+                   "chain_id" => "test-chain",
                    "profile" => "public"
                  })
                )
@@ -59,8 +93,8 @@ defmodule LassoWeb.RPCSocketTest do
     test "accepts when no provider override is specified" do
       assert {:ok, state} =
                RPCSocket.connect(
-                 transport_info("/ws/rpc/ethereum", %{
-                   "chain_id" => "ethereum",
+                 transport_info("/ws/rpc/test-chain", %{
+                   "chain_id" => "test-chain",
                    "profile" => "public"
                  })
                )

--- a/test/support/lasso/testing/chain_helper.ex
+++ b/test/support/lasso/testing/chain_helper.ex
@@ -11,36 +11,33 @@ defmodule Lasso.Testing.ChainHelper do
   @test_profile "public"
 
   @doc """
-  Ensures a chain exists and its supervisors are running.
+  Ensures a chain exists for the given profile and its supervisors are running.
 
   If the chain doesn't exist, creates it with default test configuration.
   If the chain exists but supervisors aren't running, starts them.
 
   ## Options
   - `:profile` - Profile to use (default: "public")
-
-  ## Returns
-  - `:ok` on success
-  - `{:error, reason}` on failure
   """
-  def ensure_chain_exists(chain_name, opts \\ []) do
+  @spec ensure_chain_exists(pos_integer(), keyword()) :: :ok | {:error, term()}
+  def ensure_chain_exists(chain_id, opts \\ []) when is_integer(chain_id) and chain_id > 0 do
     profile = Keyword.get(opts, :profile, @test_profile)
 
-    case Lasso.Config.ConfigStore.get_chain(profile, chain_name) do
+    case Lasso.Config.ConfigStore.get_chain(profile, chain_id) do
       {:ok, _chain_config} ->
-        ensure_chain_supervisors_running(profile, chain_name)
+        ensure_chain_supervisors_running(profile, chain_id)
 
       {:error, :not_found} ->
-        Logger.info("Chain '#{chain_name}' not found, creating for mock provider")
+        Logger.info("Chain #{chain_id} not found, creating for mock provider")
 
-        with :ok <- create_chain(profile, chain_name),
-             {:ok, chain_config} <- Lasso.Config.ConfigStore.get_chain(profile, chain_name),
-             :ok <- start_chain_supervisors(profile, chain_name, chain_config) do
-          Logger.info("Successfully started chain supervisor for '#{chain_name}'")
+        with :ok <- create_chain(profile, chain_id),
+             {:ok, chain_config} <- Lasso.Config.ConfigStore.get_chain(profile, chain_id),
+             :ok <- start_chain_supervisors(profile, chain_id, chain_config) do
+          Logger.info("Successfully started chain supervisor for #{chain_id}")
           :ok
         else
           {:error, reason} = error ->
-            Logger.error("Failed to start chain '#{chain_name}': #{inspect(reason)}")
+            Logger.error("Failed to start chain #{chain_id}: #{inspect(reason)}")
             error
         end
     end
@@ -48,14 +45,12 @@ defmodule Lasso.Testing.ChainHelper do
 
   @doc """
   Returns default chain configuration for test chains.
-
-  ## Example
-      config = default_chain_config("test_chain")
   """
-  def default_chain_config(chain_name) do
+  @spec default_chain_config(pos_integer()) :: map()
+  def default_chain_config(chain_id) when is_integer(chain_id) and chain_id > 0 do
     %{
-      chain_id: nil,
-      name: chain_name,
+      chain_id: chain_id,
+      display_name: "Chain #{chain_id}",
       providers: [],
       connection: %{
         heartbeat_interval: 30_000,
@@ -72,31 +67,28 @@ defmodule Lasso.Testing.ChainHelper do
 
   @doc """
   Checks if the chain supervisor is running for a given profile and chain.
-
-  ## Example
-      ChainHelper.chain_supervisor_running?("public", "ethereum")
-      # => true
   """
-  def chain_supervisor_running?(profile, chain_name) do
-    Lasso.ProfileChainSupervisor.running?(profile, chain_name)
+  @spec chain_supervisor_running?(String.t(), pos_integer()) :: boolean()
+  def chain_supervisor_running?(profile, chain_id) when is_integer(chain_id) do
+    Lasso.ProfileChainSupervisor.running?(profile, chain_id)
   end
 
   # Private helpers
 
-  defp create_chain(profile, chain_name) do
-    config = default_chain_config(chain_name)
-    Lasso.Config.ConfigStore.register_chain_runtime(profile, chain_name, config)
+  defp create_chain(profile, chain_id) do
+    config = default_chain_config(chain_id)
+    Lasso.Config.ConfigStore.register_chain_runtime(profile, chain_id, config)
   end
 
-  defp ensure_chain_supervisors_running(profile, chain_name) do
-    case Lasso.ProfileChainSupervisor.running?(profile, chain_name) do
+  defp ensure_chain_supervisors_running(profile, chain_id) do
+    case Lasso.ProfileChainSupervisor.running?(profile, chain_id) do
       true ->
         :ok
 
       false ->
-        case Lasso.Config.ConfigStore.get_chain(profile, chain_name) do
+        case Lasso.Config.ConfigStore.get_chain(profile, chain_id) do
           {:ok, chain_config} ->
-            start_chain_supervisors(profile, chain_name, chain_config)
+            start_chain_supervisors(profile, chain_id, chain_config)
 
           {:error, _} = error ->
             error
@@ -104,8 +96,8 @@ defmodule Lasso.Testing.ChainHelper do
     end
   end
 
-  defp start_chain_supervisors(profile, chain_name, chain_config) do
-    case Lasso.ProfileChainSupervisor.start_profile_chain(profile, chain_name, chain_config) do
+  defp start_chain_supervisors(profile, chain_id, chain_config) do
+    case Lasso.ProfileChainSupervisor.start_profile_chain(profile, chain_id, chain_config) do
       {:ok, _pid} -> :ok
       {:error, {:already_started, _pid}} -> :ok
       {:error, reason} -> {:error, reason}

--- a/test/support/lasso/testing/integration_helper.ex
+++ b/test/support/lasso/testing/integration_helper.ex
@@ -70,6 +70,9 @@ defmodule Lasso.Testing.IntegrationHelper do
         end
       end)
 
+    # Publish one final catalog snapshot after the complete fixture has been registered.
+    Lasso.Providers.Catalog.build_from_config()
+
     # Wait for all providers to be fully registered
     Enum.each(provider_ids, fn provider_id ->
       wait_for_provider_ready(chain, provider_id,
@@ -295,7 +298,20 @@ defmodule Lasso.Testing.IntegrationHelper do
         :ok
 
       {:error, :timeout} ->
-        raise "Provider #{provider_id} not registered within timeout"
+        config_provider =
+          Lasso.Config.ConfigStore.get_provider(profile, chain, provider_id)
+
+        config_provider_ids =
+          Lasso.Config.ConfigStore.get_provider_ids(profile, chain)
+
+        catalog_provider_ids =
+          Lasso.Providers.Catalog.get_profile_providers(profile, chain)
+          |> Enum.map(& &1.provider_id)
+
+        raise "Provider #{provider_id} not registered within timeout; " <>
+                "config_provider=#{inspect(config_provider)} " <>
+                "config_provider_ids=#{inspect(config_provider_ids)} " <>
+                "catalog_provider_ids=#{inspect(catalog_provider_ids)}"
     end
   end
 

--- a/test/support/lasso/testing/integration_helper.ex
+++ b/test/support/lasso/testing/integration_helper.ex
@@ -159,11 +159,12 @@ defmodule Lasso.Testing.IntegrationHelper do
 
   Broadcasts a provider unhealthy event that will trigger the failover flow.
   """
-  def trigger_provider_failover(chain, failed_provider_id, reason \\ :simulated_failure) do
+  def trigger_provider_failover(chain_id, failed_provider_id, reason \\ :simulated_failure)
+      when is_integer(chain_id) and chain_id > 0 do
     profile = "public"
 
     event = %Lasso.Events.Provider.Unhealthy{
-      chain: chain,
+      chain_id: chain_id,
       provider_id: failed_provider_id,
       reason: reason,
       ts: System.monotonic_time(:millisecond)
@@ -171,7 +172,7 @@ defmodule Lasso.Testing.IntegrationHelper do
 
     Phoenix.PubSub.broadcast(
       Lasso.PubSub,
-      Lasso.Events.Provider.topic(profile, chain),
+      Lasso.Topics.provider_event(profile, chain_id),
       event
     )
 

--- a/test/support/lasso/testing/mock_http_provider.ex
+++ b/test/support/lasso/testing/mock_http_provider.ex
@@ -65,62 +65,35 @@ defmodule Lasso.Testing.MockHTTPProvider do
       __mock__: true
     }
 
-    # Ensure chain exists and register provider
     with :ok <- ChainHelper.ensure_chain_exists(chain, profile: profile),
          :ok <-
-           Lasso.Config.ConfigStore.register_provider_runtime(profile, chain, provider_config) do
-      # Rebuild catalog so the new provider is visible
-      Lasso.Providers.Catalog.build_from_config()
+           Lasso.Config.ConfigStore.register_provider_runtime(profile, chain, provider_config),
+         :ok <- Lasso.RPC.ChainSupervisor.ensure_provider(profile, chain, provider_config),
+         instance_id when is_binary(instance_id) <-
+           Lasso.Providers.Catalog.lookup_instance_id(profile, chain, provider_id),
+         {:ok, _channel} <-
+           Lasso.RPC.TransportRegistry.get_channel(profile, chain, provider_id, :http) do
+      ensure_circuit_breaker(instance_id, :http)
 
-      Logger.info("MockHTTPProvider: registered #{provider_id}, initializing channels...")
+      :ets.insert(:lasso_instance_state, {
+        {:health_probe, instance_id},
+        %{
+          status: :healthy,
+          http_status: :healthy,
+          consecutive_failures: 0,
+          last_error: nil,
+          last_health_check: System.system_time(:millisecond)
+        }
+      })
 
-      result =
-        Lasso.RPC.TransportRegistry.initialize_provider_channels(
-          profile,
-          chain,
-          provider_id,
-          provider_config
-        )
+      setup_cleanup(profile, chain, provider_id, instance_id)
 
-      Logger.info("MockHTTPProvider: initialize_provider_channels returned: #{inspect(result)}")
-
-      case result do
-        :ok ->
-          instance_id = Lasso.Providers.Catalog.lookup_instance_id(profile, chain, provider_id)
-
-          # Ensure circuit breaker exists for HTTP transport
-          if instance_id do
-            ensure_circuit_breaker(instance_id, :http)
-          end
-
-          # Mark as healthy in ETS
-          if instance_id do
-            :ets.insert(:lasso_instance_state, {
-              {:health_probe, instance_id},
-              %{
-                status: :healthy,
-                http_status: :healthy,
-                consecutive_failures: 0,
-                last_error: nil,
-                last_health_check: System.system_time(:millisecond)
-              }
-            })
-          end
-
-          # Set up cleanup callback
-          setup_cleanup(profile, chain, provider_id, instance_id)
-
-          Logger.debug("Started mock HTTP provider #{provider_id} for #{chain}")
-          {:ok, provider_id}
-
-        error ->
-          GenServer.stop(pid)
-          {:error, {:channel_initialization_failed, error}}
-      end
+      Logger.debug("Started mock HTTP provider #{provider_id} for #{chain}")
+      {:ok, provider_id}
     else
-      {:error, reason} ->
-        GenServer.stop(pid)
-        {:error, {:registration_failed, reason}}
+      error ->
+        rollback_start(profile, chain, provider_id, pid)
+        {:error, {:registration_failed, error}}
     end
   end
 
@@ -142,11 +115,11 @@ defmodule Lasso.Testing.MockHTTPProvider do
   @doc """
   Stops a mock HTTP provider.
   """
-  def stop_mock(chain, provider_id) do
-    # Remove from ConfigStore
-    Lasso.Config.ConfigStore.unregister_provider_runtime("public", chain, provider_id)
+  def stop_mock(chain, provider_id), do: stop_mock("public", chain, provider_id)
 
-    # Stop the GenServer
+  def stop_mock(profile, chain, provider_id) do
+    removal_result = Lasso.Providers.remove_provider(profile, chain, provider_id)
+
     case Registry.lookup(Lasso.Registry, {:http_provider, provider_id}) do
       [{pid, _}] ->
         if Process.alive?(pid) do
@@ -163,7 +136,7 @@ defmodule Lasso.Testing.MockHTTPProvider do
         :ok
     end
 
-    :ok
+    removal_result
   end
 
   defp ensure_circuit_breaker(instance_id, transport) do
@@ -255,10 +228,17 @@ defmodule Lasso.Testing.MockHTTPProvider do
     {:reply, response, state}
   end
 
-  defp setup_cleanup(_profile, chain, provider_id, instance_id) do
+  defp rollback_start(profile, chain, provider_id, pid) do
+    Lasso.Providers.remove_provider(profile, chain, provider_id)
+    if Process.alive?(pid), do: GenServer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+
+  defp setup_cleanup(profile, chain, provider_id, instance_id) do
     ExUnit.Callbacks.on_exit({:cleanup_mock_http, provider_id}, fn ->
       Logger.debug("Test cleanup: stopping mock HTTP provider #{provider_id}")
-      stop_mock(chain, provider_id)
+      stop_mock(profile, chain, provider_id)
 
       if instance_id do
         for transport <- [:http, :ws] do

--- a/test/support/lasso/testing/mock_ws_provider.ex
+++ b/test/support/lasso/testing/mock_ws_provider.ex
@@ -56,38 +56,32 @@ defmodule Lasso.Testing.MockWSProvider do
   - `:confirm_delay` - Delay before confirming subscriptions in ms (default: 0)
   - `:priority` - Provider priority (default: 100)
   """
-  def start_mock(chain, spec) when is_map(spec) do
+  def start_mock(chain_id, spec) when is_integer(chain_id) and chain_id > 0 and is_map(spec) do
     provider_id = Map.get(spec, :id) || raise "Mock WS provider requires :id field"
     profile = Map.get(spec, :profile, @test_profile)
 
-    # Create provider config
     provider_config = %{
       id: provider_id,
       name: "Mock WS Provider #{provider_id}",
       url: "http://mock-#{provider_id}.test",
-      # Mock HTTP endpoint
       ws_url: "ws://mock-#{provider_id}.test",
       type: "test",
       priority: Map.get(spec, :priority, 100)
     }
 
-    # Ensure chain exists (auto-create if needed) and register provider
-    with :ok <- ChainHelper.ensure_chain_exists(chain, profile: profile),
+    with :ok <- ChainHelper.ensure_chain_exists(chain_id, profile: profile),
          :ok <-
-           Lasso.Config.ConfigStore.register_provider_runtime(profile, chain, provider_config) do
-      # Rebuild catalog so the new provider is visible
+           Lasso.Config.ConfigStore.register_provider_runtime(profile, chain_id, provider_config) do
       Lasso.Providers.Catalog.build_from_config()
-      instance_id = instance_id_for(profile, chain, provider_id)
+      instance_id = instance_id_for(profile, chain_id, provider_id)
 
-      # Start the mock WS connection GenServer with the shared WSConnection registry key
       {:ok, _pid} =
         GenServer.start_link(
           __MODULE__,
-          {chain, spec},
+          {chain_id, spec},
           name: {:via, Registry, {Lasso.Registry, ws_instance_key(instance_id)}}
         )
 
-      # Mark as healthy in ETS
       :ets.insert(:lasso_instance_state, {
         {:health_probe, instance_id},
         %{
@@ -99,30 +93,26 @@ defmodule Lasso.Testing.MockWSProvider do
         }
       })
 
-      # Start InstanceSubscriptionManager for this instance (if not already running).
-      # Must happen BEFORE ws_connected broadcast so the manager receives it.
-      start_instance_subscription_manager(chain, instance_id)
+      start_instance_subscription_manager(chain_id, instance_id)
 
-      # Generate connection_id and broadcast ws_connected event
       connection_id =
         "conn_mock_" <> (:crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower))
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
-        "ws:conn:#{profile}:#{chain}",
+        Lasso.Topics.ws_connection(profile, chain_id),
         {:ws_connected, provider_id, connection_id}
       )
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
-        "ws:conn:instance:#{instance_id}",
+        Lasso.Topics.ws_conn_instance(instance_id),
         {:ws_connected, instance_id, connection_id}
       )
 
-      # Set up cleanup callback
-      setup_cleanup(profile, chain, provider_id)
+      setup_cleanup(profile, chain_id, provider_id)
 
-      Logger.debug("Started mock WS provider #{provider_id} for #{chain}")
+      Logger.debug("Started mock WS provider #{provider_id} for chain_id #{chain_id}")
       {:ok, provider_id}
     else
       {:error, reason} ->
@@ -134,10 +124,10 @@ defmodule Lasso.Testing.MockWSProvider do
   Sends a subscription request to the mock provider.
   Used internally by WSConnection.
   """
-  def send_message(profile \\ @test_profile, chain, provider_id, message) do
+  def send_message(profile \\ @test_profile, chain_id, provider_id, message) do
     case Registry.lookup(
            Lasso.Registry,
-           ws_instance_key(instance_id_for(profile, chain, provider_id))
+           ws_instance_key(instance_id_for(profile, chain_id, provider_id))
          ) do
       [{pid, _}] -> GenServer.cast(pid, {:send_message, message})
       [] -> {:error, :not_found}
@@ -147,14 +137,14 @@ defmodule Lasso.Testing.MockWSProvider do
   @doc """
   Sends a mock newHeads block to all subscribers.
   """
-  def send_block(chain, provider_id, block_header, opts \\ []) when is_map(block_header) do
+  def send_block(chain_id, provider_id, block_header, opts \\ []) when is_map(block_header) do
     profile = Keyword.get(opts, :profile, @test_profile)
 
     case Registry.lookup(
            Lasso.Registry,
-           ws_instance_key(instance_id_for(profile, chain, provider_id))
+           ws_instance_key(instance_id_for(profile, chain_id, provider_id))
          ) do
-      [{pid, _}] -> GenServer.cast(pid, {:broadcast_block, chain, block_header})
+      [{pid, _}] -> GenServer.cast(pid, {:broadcast_block, chain_id, block_header})
       [] -> {:error, :not_found}
     end
   end
@@ -164,13 +154,13 @@ defmodule Lasso.Testing.MockWSProvider do
 
   Useful for testing ordered delivery and backfill scenarios.
   """
-  def send_block_sequence(chain, provider_id, start_block, count, opts \\ []) do
+  def send_block_sequence(chain_id, provider_id, start_block, count, opts \\ []) do
     delay_ms = Keyword.get(opts, :delay_ms, 10)
     profile = Keyword.get(opts, :profile, @test_profile)
 
     Enum.each(start_block..(start_block + count - 1), fn block_num ->
       send_block(
-        chain,
+        chain_id,
         provider_id,
         %{
           "number" => "0x" <> String.downcase(Integer.to_string(block_num, 16)),
@@ -191,8 +181,8 @@ defmodule Lasso.Testing.MockWSProvider do
   @doc """
   Simulates a disconnect by stopping the mock provider.
   """
-  def simulate_disconnect(chain, provider_id, opts \\ []) do
-    stop_mock(chain, provider_id, opts)
+  def simulate_disconnect(chain_id, provider_id, opts \\ []) do
+    stop_mock(chain_id, provider_id, opts)
   end
 
   @doc """
@@ -219,23 +209,28 @@ defmodule Lasso.Testing.MockWSProvider do
       # Send blocks from backup
       MockWSProvider.send_block_sequence(chain, "backup", 1005, 5)
   """
-  def simulate_provider_failure(chain, provider_id, reason \\ :test_failure, profile \\ "public") do
-    # Emit the same WSDisconnected event that real WS connections emit
+  def simulate_provider_failure(
+        chain_id,
+        provider_id,
+        reason \\ :test_failure,
+        profile \\ "public"
+      )
+      when is_integer(chain_id) and chain_id > 0 do
     event = %Lasso.Events.Provider.WSDisconnected{
       ts: System.system_time(:millisecond),
-      chain: chain,
+      chain_id: chain_id,
       provider_id: provider_id,
       reason: reason
     }
 
     Phoenix.PubSub.broadcast(
       Lasso.PubSub,
-      Lasso.Events.Provider.topic(profile, chain),
+      Lasso.Topics.provider_event(profile, chain_id),
       event
     )
 
     Logger.debug(
-      "Simulated provider failure: #{provider_id} on #{chain} (reason: #{inspect(reason)})"
+      "Simulated provider failure: #{provider_id} on chain_id #{chain_id} (reason: #{inspect(reason)})"
     )
 
     :ok
@@ -244,14 +239,14 @@ defmodule Lasso.Testing.MockWSProvider do
   @doc """
   Sends a mock log event to all log subscribers.
   """
-  def send_log(chain, provider_id, log, opts \\ []) when is_map(log) do
+  def send_log(chain_id, provider_id, log, opts \\ []) when is_map(log) do
     profile = Keyword.get(opts, :profile, @test_profile)
 
     case Registry.lookup(
            Lasso.Registry,
-           ws_instance_key(instance_id_for(profile, chain, provider_id))
+           ws_instance_key(instance_id_for(profile, chain_id, provider_id))
          ) do
-      [{pid, _}] -> GenServer.cast(pid, {:broadcast_log, chain, log})
+      [{pid, _}] -> GenServer.cast(pid, {:broadcast_log, chain_id, log})
       [] -> {:error, :not_found}
     end
   end
@@ -259,12 +254,11 @@ defmodule Lasso.Testing.MockWSProvider do
   @doc """
   Stops a mock WebSocket provider.
   """
-  def stop_mock(chain, provider_id, opts \\ []) do
+  def stop_mock(chain_id, provider_id, opts \\ []) do
     profile = Keyword.get(opts, :profile, @test_profile)
-    instance_id = instance_id_for(profile, chain, provider_id)
+    instance_id = instance_id_for(profile, chain_id, provider_id)
 
-    # Remove from ConfigStore
-    Lasso.Config.ConfigStore.unregister_provider_runtime(profile, chain, provider_id)
+    Lasso.Config.ConfigStore.unregister_provider_runtime(profile, chain_id, provider_id)
 
     # Stop the InstanceSubscriptionManager if running
     case Registry.lookup(Lasso.Registry, {:instance_sub_manager, instance_id}) do
@@ -579,12 +573,12 @@ defmodule Lasso.Testing.MockWSProvider do
     "0x" <> Integer.to_string(state.next_sub_id, 16)
   end
 
-  defp setup_cleanup(profile, chain, provider_id) do
-    instance_id = instance_id_for(profile, chain, provider_id)
+  defp setup_cleanup(profile, chain_id, provider_id) do
+    instance_id = instance_id_for(profile, chain_id, provider_id)
 
     ExUnit.Callbacks.on_exit({:cleanup_mock_ws, provider_id}, fn ->
       Logger.debug("Test cleanup: stopping mock WS provider #{provider_id}")
-      stop_mock(chain, provider_id, profile: profile)
+      stop_mock(chain_id, provider_id, profile: profile)
 
       if instance_id do
         for transport <- [:http, :ws] do
@@ -602,13 +596,13 @@ defmodule Lasso.Testing.MockWSProvider do
     end)
   end
 
-  defp start_instance_subscription_manager(chain, instance_id) do
+  defp start_instance_subscription_manager(chain_id, instance_id) do
     case Registry.lookup(Lasso.Registry, {:instance_sub_manager, instance_id}) do
       [{_pid, _}] ->
         :ok
 
       [] ->
-        case Lasso.Core.Streaming.InstanceSubscriptionManager.start_link({chain, instance_id}) do
+        case Lasso.Core.Streaming.InstanceSubscriptionManager.start_link({chain_id, instance_id}) do
           {:ok, _pid} ->
             :ok
 
@@ -627,8 +621,8 @@ defmodule Lasso.Testing.MockWSProvider do
 
   defp ws_instance_key(instance_id), do: {:ws_conn_instance, instance_id}
 
-  defp instance_id_for(profile, chain, provider_id) do
-    Lasso.Providers.Catalog.lookup_instance_id(profile, chain, provider_id) ||
-      "#{chain}:#{provider_id}"
+  defp instance_id_for(profile, chain_id, provider_id) do
+    Lasso.Providers.Catalog.lookup_instance_id(profile, chain_id, provider_id) ||
+      "#{chain_id}:#{provider_id}"
   end
 end

--- a/test/support/lasso/testing/probe_mocks.ex
+++ b/test/support/lasso/testing/probe_mocks.ex
@@ -1,0 +1,194 @@
+defmodule Lasso.Testing.ProbeMocks do
+  @moduledoc """
+  Test seams for `Lasso.Discovery.ProbeSession`.
+
+  Each submodule has the same surface as the real probe module it stands in
+  for. By default it delegates to the real implementation. Per-test, the
+  caller stashes a behavior override in a shared ETS table; lookups walk
+  the calling process's `$ancestors` chain so overrides propagate through
+  Tasks spawned by the per-session supervisor.
+
+  Override values:
+
+    * `{:raise, reason}` — raise `RuntimeError.exception(reason)` on call.
+    * `{:throw, term}` — `throw/1` the term.
+    * `{:exit, term}` — `exit/1` the term.
+    * `{:return, value}` — return `value` directly without calling the real module.
+    * `{:block}` — block forever (deterministic hang; drives budget/kill tests).
+    * `{:rate_limited, n}` — return an HTTP-429-like result for the first `n` calls
+      to the probe, then delegate to the real module. Drives slow-mode tests.
+    * `nil` (or unset) — delegate to the real module.
+
+  Usage:
+
+      setup do
+        Lasso.Testing.ProbeMocks.setup()
+        on_exit(fn -> Lasso.Testing.ProbeMocks.clear_all() end)
+        :ok
+      end
+
+      test "..." do
+        Lasso.Testing.ProbeMocks.set(:method_support, {:raise, "boom"})
+        ...
+      end
+  """
+
+  @table __MODULE__.Table
+  @keys [:identify, :method_support, :limits, :websocket]
+
+  @spec setup() :: :ok
+  def setup do
+    if :ets.whereis(@table) == :undefined do
+      :ets.new(@table, [:named_table, :public, :set, write_concurrency: true])
+    end
+
+    :ok
+  end
+
+  @spec set(atom(), term()) :: :ok
+  def set(key, override) when key in @keys do
+    setup()
+    :ets.insert(@table, {{self(), key}, override})
+    :ok
+  end
+
+  @spec clear(atom()) :: :ok
+  def clear(key) when key in @keys do
+    if :ets.whereis(@table) != :undefined do
+      :ets.delete(@table, {self(), key})
+    end
+
+    :ok
+  end
+
+  @spec clear_all() :: :ok
+  def clear_all do
+    if :ets.whereis(@table) != :undefined do
+      Enum.each(@keys, fn key -> :ets.delete(@table, {self(), key}) end)
+    end
+
+    :ok
+  end
+
+  @doc false
+  def dispatch(key, real_mod, real_fun, args) do
+    case lookup_override(key) do
+      nil ->
+        apply(real_mod, real_fun, args)
+
+      {:return, value} ->
+        value
+
+      {:raise, reason} ->
+        raise RuntimeError, reason
+
+      {:throw, term} ->
+        throw(term)
+
+      {:exit, term} ->
+        exit(term)
+
+      {:block} ->
+        Process.sleep(:infinity)
+
+      {:rate_limited, n} when is_integer(n) and n > 0 ->
+        table = @table
+        call_key = {self(), key, :call_count}
+
+        count =
+          case :ets.lookup(table, call_key) do
+            [{_, c}] -> c
+            [] -> 0
+          end
+
+        :ets.insert(table, {call_key, count + 1})
+
+        if count < n do
+          opts = if is_list(List.last(args)), do: List.last(args), else: []
+
+          if on_throttle = Keyword.get(opts, :on_throttle) do
+            on_throttle.(%{retry_after_ms: nil, phase: :methods})
+          end
+
+          [
+            %{
+              method: "eth_blockNumber",
+              status: :unknown,
+              error: "429 Too Many Requests",
+              error_code: 429,
+              duration_ms: 0,
+              category: :core
+            }
+          ]
+        else
+          apply(real_mod, real_fun, args)
+        end
+    end
+  end
+
+  defp lookup_override(key) do
+    if :ets.whereis(@table) != :undefined do
+      callers = Process.get(:"$callers", [])
+      ancestors = Process.get(:"$ancestors", [])
+      chain = [self() | callers ++ ancestors]
+
+      Enum.find_value(chain, fn
+        pid when is_pid(pid) ->
+          case :ets.lookup(@table, {pid, key}) do
+            [{_, override}] -> override
+            [] -> nil
+          end
+
+        _ ->
+          nil
+      end)
+    end
+  end
+
+  defmodule Discovery do
+    @moduledoc false
+    def identify(url, opts) do
+      Lasso.Testing.ProbeMocks.dispatch(:identify, Lasso.Discovery, :identify, [url, opts])
+    end
+  end
+
+  defmodule MethodSupport do
+    @moduledoc false
+    def probe(url, opts) do
+      Lasso.Testing.ProbeMocks.dispatch(
+        :method_support,
+        Lasso.Discovery.Probes.MethodSupport,
+        :probe,
+        [url, opts]
+      )
+    end
+  end
+
+  defmodule Limits do
+    @moduledoc false
+    def probe(url, opts) do
+      Lasso.Testing.ProbeMocks.dispatch(
+        :limits,
+        Lasso.Discovery.Probes.Limits,
+        :probe,
+        [url, opts]
+      )
+    end
+
+    def available_tests do
+      Lasso.Discovery.Probes.Limits.available_tests()
+    end
+  end
+
+  defmodule WebSocket do
+    @moduledoc false
+    def probe(url, opts) do
+      Lasso.Testing.ProbeMocks.dispatch(
+        :websocket,
+        Lasso.Discovery.Probes.WebSocket,
+        :probe,
+        [url, opts]
+      )
+    end
+  end
+end

--- a/test/support/lasso_integration_case.ex
+++ b/test/support/lasso_integration_case.ex
@@ -64,8 +64,8 @@ defmodule Lasso.Test.LassoIntegrationCase do
       @moduletag :integration
 
       setup do
-        # Generate unique chain ID for this test
-        chain = "test_#{:rand.uniform(999_999_999)}"
+        # Generate a unique positive EVM chain ID for this test.
+        chain = :rand.uniform(999_999_999)
 
         # Store chain in process dictionary for helper access
         # This avoids var! hygiene issues while maintaining convenience

--- a/test/support/lasso_integration_case.ex
+++ b/test/support/lasso_integration_case.ex
@@ -65,7 +65,7 @@ defmodule Lasso.Test.LassoIntegrationCase do
 
       setup do
         # Generate a unique positive EVM chain ID for this test.
-        chain = :rand.uniform(999_999_999)
+        chain = 1_000_000_000 + System.unique_integer([:positive, :monotonic])
 
         # Store chain in process dictionary for helper access
         # This avoids var! hygiene issues while maintaining convenience
@@ -108,12 +108,14 @@ defmodule Lasso.Test.LassoIntegrationCase do
       end
 
       defp cleanup_test_resources(chain) do
-        # Clean up chain-specific resources
-        # This includes stopping any supervisors, cleaning registries, etc.
+        profiles = Lasso.Config.ConfigStore.list_profiles_for_chain(chain)
 
-        # Give async cleanup a moment to complete
-        Process.sleep(50)
+        Enum.each(profiles, fn profile ->
+          Lasso.ProfileChainSupervisor.stop_profile_chain(profile, chain)
+          Lasso.Config.ConfigStore.unregister_chain_runtime(profile, chain)
+        end)
 
+        Lasso.Providers.Catalog.build_from_config()
         :ok
       end
 

--- a/test/unit/strategies/staleness_test.exs
+++ b/test/unit/strategies/staleness_test.exs
@@ -29,19 +29,19 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
     setup do
       # Test parameters
       profile = "test"
-      chain = "ethereum"
+      chain_id = 1
       method = "eth_blockNumber"
       timeout = 5000
 
-      ctx = Fastest.prepare_context(profile, chain, method, timeout)
+      ctx = Fastest.prepare_context(profile, chain_id, method, timeout)
 
-      {:ok, ctx: ctx, profile: profile, chain: chain, method: method}
+      {:ok, ctx: ctx, profile: profile, chain_id: chain_id, method: method}
     end
 
     test "provider with fresh metrics (< 10min) gets normal latency score", %{
       ctx: ctx,
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       method: method
     } do
       current_time = System.system_time(:millisecond)
@@ -65,7 +65,7 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
         }
       end)
 
-      ranked = Fastest.rank_channels(channels, method, ctx, profile, chain)
+      ranked = Fastest.rank_channels(channels, method, ctx, profile, chain_id)
 
       # Should use actual latency (implicitly tested by ranking)
       assert length(ranked) == 1
@@ -75,7 +75,7 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
     test "provider with stale metrics (> 10min) gets cold start penalty", %{
       ctx: ctx,
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       method: method
     } do
       current_time = System.system_time(:millisecond)
@@ -107,7 +107,7 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
         }
       end)
 
-      ranked = Fastest.rank_channels(channels, method, ctx, profile, chain)
+      ranked = Fastest.rank_channels(channels, method, ctx, profile, chain_id)
 
       # Slow fresh provider should be ranked higher than fast stale provider
       # (200ms fresh < 500ms stale penalty)
@@ -118,7 +118,7 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
     test "missing last_updated_ms treated as cold start", %{
       ctx: ctx,
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       method: method
     } do
       channels = [
@@ -141,7 +141,7 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
         }
       end)
 
-      ranked = Fastest.rank_channels(channels, method, ctx, profile, chain)
+      ranked = Fastest.rank_channels(channels, method, ctx, profile, chain_id)
 
       # Provider with timestamp should be ranked first (200ms < 500ms penalty)
       assert length(ranked) == 2
@@ -153,19 +153,19 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
     setup do
       # Test parameters
       profile = "test"
-      chain = "ethereum"
+      chain_id = 1
       method = "eth_blockNumber"
       timeout = 5000
 
-      ctx = LatencyWeighted.prepare_context(profile, chain, method, timeout)
+      ctx = LatencyWeighted.prepare_context(profile, chain_id, method, timeout)
 
-      {:ok, ctx: ctx, profile: profile, chain: chain, method: method}
+      {:ok, ctx: ctx, profile: profile, chain_id: chain_id, method: method}
     end
 
     test "fresh metrics get normal weight calculation", %{
       ctx: ctx,
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       method: method
     } do
       current_time = System.system_time(:millisecond)
@@ -188,14 +188,14 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
       end)
 
       # Just verify it doesn't crash and returns the channel
-      ranked = LatencyWeighted.rank_channels(channels, method, ctx, profile, chain)
+      ranked = LatencyWeighted.rank_channels(channels, method, ctx, profile, chain_id)
       assert length(ranked) == 1
     end
 
     test "stale metrics get explore_floor weight", %{
       ctx: ctx,
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       method: method
     } do
       current_time = System.system_time(:millisecond)
@@ -217,14 +217,14 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
         }
       end)
 
-      ranked = LatencyWeighted.rank_channels(channels, method, ctx, profile, chain)
+      ranked = LatencyWeighted.rank_channels(channels, method, ctx, profile, chain_id)
       assert length(ranked) == 1
     end
 
     test "multiple providers with mixed freshness sort correctly", %{
       ctx: ctx,
       profile: profile,
-      chain: chain,
+      chain_id: chain_id,
       method: method
     } do
       current_time = System.system_time(:millisecond)
@@ -264,7 +264,7 @@ defmodule Lasso.RPC.Strategies.StalenessTest do
         }
       end)
 
-      ranked = LatencyWeighted.rank_channels(channels, method, ctx, profile, chain)
+      ranked = LatencyWeighted.rank_channels(channels, method, ctx, profile, chain_id)
 
       # Should return all 3 channels, stale one should have lower effective weight
       assert length(ranked) == 3


### PR DESCRIPTION
## OSS Sync from lasso-cloud

Selective sync from cloud commits `4eca7de44f4f34e53a809d99ebf7265c8a90212c..fc6aebc3a243b4e9bb27e68881c7365273d34aef`.

This ports the routing-runtime portion of the custom-profiles work without importing the Cloud account, billing, entitlement, or profile-builder product.

### Changes

- Use opaque profile IDs and positive integer chain IDs throughout the routing hot path.
- Keep file-backed YAML profiles authoritative for profile identity, URL aliases, and display names.
- Preserve existing named HTTP/WS routes and add decimal chain-ID routing.
- Publish ConfigStore updates atomically with restart-safe ETS ownership and last-known-good recovery.
- Reject missing, invalid, duplicate, or alias-colliding chain IDs before publication.
- Scope logical routing, metrics, transport, circuit, and subscription state by profile while sharing physical provider instances only when endpoint and credential identity match.
- Reconcile runtime provider add/remove operations, including supervisor startup and last-reference cleanup.
- Port request/error normalization, strategy metadata, and WebSocket readiness/runtime updates.
- Adapt the authless OSS controllers, socket, metrics, and read-only dashboard.
- Remove the stale `premium -> managed` alias; retain `default -> public`.

### Preserved OSS behavior

- Existing YAML/frontmatter and legacy `chains.yml` compatibility.
- `Backend.load/2` compatibility and runtime provider management APIs.
- Invalid HTTP provider overrides return structured invalid-parameter errors.
- Invalid WebSocket profiles/providers reject the handshake.
- Dashboard `default` alias resolution, standalone health topology, and WebSocket startup jitter.
- Existing `config/profiles/public.yml` and `testnet.yml` are unchanged.

### Skipped / deferred

- `lib/lasso_cloud/**`, database migrations, auth, API keys, billing, Stripe, entitlements, metering, and memberships.
- Cloud dashboard profile builder and activation/edit lifecycle.
- Headless discovery/ProbeSession/SSRF/config generation; planned as a separately reviewed follow-up.
- Cloud Sentry/runtime dependencies and proprietary profile configuration.

### Cloud follow-ups found during review

- jaxernst/lasso-cloud#298
- jaxernst/lasso-cloud#299
- jaxernst/lasso-cloud#301
- jaxernst/lasso-cloud#304
- jaxernst/lasso-cloud#306
- jaxernst/lasso-cloud#311
- jaxernst/lasso-cloud#312

### Verification

- [x] `mix format --check-formatted`
- [x] `mix compile --warnings-as-errors`
- [x] `mix test --include integration --timeout 30000` — 989 tests, 0 failures across repeated full-suite seeds
- [x] `mix credo --strict`
- [x] `mix dialyzer` — passed with the repository's 28 existing ignored warnings
- [x] `git diff --check`
- [x] Proprietary marker scan across every changed file
- [x] No changes to `mix.exs`, `mix.lock`, or committed profile YAML
- [x] Local Anvil HTTP routing smoke (`eth_blockNumber` returned `0x0`)
- [x] Production release build and `/api/health` boot smoke
- [x] Cold rollback smoke: base release booted successfully after the PR release
- [x] Clean Docker image build and `/api/health` boot smoke after #42 refreshed and pinned the base images

### Release note

Use a cold restart for this internal runtime-key migration. Existing profile and chain URL forms remain compatible.

