### PR TITLE
Restore clean Docker builds and document public routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           otp-version: ${{ matrix.otp }}
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-deps-
 
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-test-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
@@ -67,7 +67,7 @@ jobs:
           otp-version: "28.0"
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-deps-
 
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-dev-28.0-1.18.4-${{ hashFiles('**/mix.lock') }}
@@ -105,7 +105,7 @@ jobs:
           otp-version: "28.0"
 
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-deps-${{ hashFiles('**/mix.lock') }}
@@ -113,7 +113,7 @@ jobs:
             ${{ runner.os }}-deps-
 
       - name: Cache build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _build
           key: ${{ runner.os }}-build-dev-28.0-1.18.4-${{ hashFiles('**/mix.lock') }}
@@ -121,7 +121,7 @@ jobs:
             ${{ runner.os }}-build-dev-28.0-1.18.4-
 
       - name: Cache PLT
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: priv/plts
           key: ${{ runner.os }}-plt-28.0-1.18.4-${{ hashFiles('**/mix.lock') }}
@@ -139,3 +139,38 @@ jobs:
 
       - name: Run Dialyzer
         run: mix dialyzer --format github
+
+  docker:
+    name: Docker build and boot
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image from clean context
+        run: docker build --pull --no-cache --tag lasso-rpc:ci .
+
+      - name: Boot image and verify health
+        shell: bash
+        run: |
+          set -euo pipefail
+          secret_key_base="$(openssl rand -hex 64)"
+          docker run --detach --name lasso-rpc-ci --publish 4000:4000 \
+            --env LASSO_NODE_ID=ci \
+            --env PHX_HOST=localhost \
+            --env PHX_SCHEME=http \
+            --env SECRET_KEY_BASE="$secret_key_base" \
+            lasso-rpc:ci
+
+          trap 'docker logs lasso-rpc-ci || true; docker rm --force lasso-rpc-ci >/dev/null 2>&1 || true' EXIT
+
+          for _ in $(seq 1 60); do
+            if curl --fail --silent --show-error http://127.0.0.1:4000/api/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "Container did not become healthy within 60 seconds" >&2
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM hexpm/elixir:1.17.3-erlang-27.2-debian-bullseye-20241202 AS builder
+FROM hexpm/elixir:1.17.3-erlang-27.3.4.14-debian-bullseye-20260713@sha256:163ac81d99259269e3465859f24e016897a7817e78992b565548104e26cba6c9 AS builder
 
 # Install build dependencies
 RUN apt-get update && \
@@ -48,7 +48,7 @@ RUN mix tailwind.install && \
 RUN mix release
 
 # Runtime stage
-FROM hexpm/elixir:1.17.3-erlang-27.2-debian-bullseye-20241202-slim
+FROM hexpm/elixir:1.17.3-erlang-27.3.4.14-debian-bullseye-20260713-slim@sha256:0d1d03b4106fa4fca80d1889911069d595db1e32bbe75a7898cd072d59495e3b
 
 # Install runtime dependencies
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Profiles (namespaced routing configs):
 - HTTP: `/rpc/profile/:profile/...`
 - WS: `/ws/rpc/profile/:profile/...`
 
+Routes without `/profile/:profile` use the included `public` profile. Use a namespaced route to select any other profile. The legacy `default` profile name remains an alias for `public`.
+
 ---
 
 ## Quick Start
@@ -186,11 +188,11 @@ curl -sS -X POST 'http://localhost:4000/rpc/ethereum?include_meta=headers' \
 
 Profiles live in `config/profiles/*.yml`. Each profile defines chains, providers, routing policy, and limits. `${ENV_VAR}` substitution is supported (and unresolved placeholders will fail startup).
 
-For the **full configuration reference (all supported options + tuning notes)**, see `config/profiles/default.yml`.
+For the **full configuration reference (all supported options + tuning notes)**, see [`config/profiles/public.yml`](config/profiles/public.yml).
 
-### Ready to Use: Default Profile
+### Ready to Use: Public Profile
 
-The included `default.yml` profile is configured with free public providers (no API keys required). Start `mix phx.server` and you have a working multi-provider RPC proxy.
+The included `public.yml` profile is configured with free public providers (no API keys required). Start `mix phx.server` and you have a working multi-provider RPC proxy.
 
 Good for:
 
@@ -202,10 +204,10 @@ Good for:
 Minimal example:
 
 ```yaml
-# config/profiles/default.yml
+# config/profiles/public.yml
 ---
-name: "Default"
-slug: "default"
+name: "Public RPC"
+slug: "public"
 type: "standard"
 default_rps_limit: 100
 default_burst_limit: 500


### PR DESCRIPTION
## Summary

- refresh the pinned Elixir 1.17.3 / OTP 27 images from OTP 27.2 to 27.3.4.14 and pin the multi-platform image digests
- add a clean, uncached Docker build plus `/api/health` boot smoke to CI
- update `actions/cache` from v3 to v4 so the workflow remains supported
- document that bare RPC routes select `public`, and correct stale `default.yml` references

## Why

A clean clone could no longer build the dated 2024 Docker images after upstream certificate and package metadata rotation. That also prevented validating release images for the larger runtime sync in #41.

The bare-route fallback was implemented but not stated explicitly in user-facing documentation.

## Validation

- `docker build --pull --no-cache --tag lasso-rpc:docker-refresh .`
- booted the resulting image with production runtime environment
- `GET /api/health` returned `status: healthy`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

This PR intentionally contains no application runtime changes.
