### PR TITLE
Sync routing resilience and relicense under Apache-2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Lasso RPC is now licensed under Apache-2.0 to support broader self-hosting, distribution, and commercial embedding
 - Profiles are now loaded exclusively from YAML files in `config/profiles/`; profile slugs are opaque routing IDs, chain aliases resolve to positive integer EIP-155 IDs internally, and `default` remains an alias for `public`
 - Configuration reloads publish a complete new snapshot only after validation; malformed YAML or invalid chain IDs leave the last known-good snapshot active. A cold restart loads profiles from disk before routing begins
 - Dashboard and RPC routes accept both configured chain aliases and decimal chain IDs, while WebSocket startup attempts are jittered to avoid synchronized upstream handshakes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,4 +206,4 @@ Key directories:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the same AGPL-3.0 license that covers this project.
+Unless you explicitly state otherwise, contributions you intentionally submit to this project are licensed under Apache-2.0 on the same terms as the project, consistent with Section 5 of the Apache License 2.0.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,661 +1,202 @@
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
-
-Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
-
-                            Preamble
-
-The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
-
-The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works. By contrast,
-our General Public Licenses are intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.
-
-When we speak of free software, we are referring to freedom, not
-price. Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
-
-A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate. Many developers of free software are heartened and
-encouraged by the resulting cooperation. However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
-
-The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community. It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server. Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
-
-An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals. This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
-
-The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-0. Definitions.
-
-"This License" refers to version 3 of the GNU Affero General Public License.
-
-"Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-"The Program" refers to any copyrightable work licensed under this
-License. Each licensee is addressed as "you". "Licensees" and
-"recipients" may be individuals or organizations.
-
-To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy. The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy. Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies. Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License. If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-1. Source Code.
-
-The "source code" for a work means the preferred form of the work
-for making modifications to it. "Object code" means any non-source
-form of a work.
-
-A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form. A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities. However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work. For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-The Corresponding Source for a work in source code form is that
-same work.
-
-2. Basic Permissions.
-
-All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met. This License explicitly affirms your unlimited
-permission to run the unmodified Program. The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work. This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force. You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright. Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-Conveying under any other circumstances is permitted solely under
-the conditions stated below. Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-4. Conveying Verbatim Copies.
-
-You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-5. Conveying Modified Source Versions.
-
-You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit. Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-6. Conveying Non-Source Forms.
-
-You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling. In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage. For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product. A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-"Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source. The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information. But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed. Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-7. Additional Terms.
-
-"Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law. If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it. (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.) You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10. If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term. If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-8. Termination.
-
-You may not propagate or modify a covered work except as expressly
-provided under this License. Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License. If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-9. Acceptance Not Required for Having Copies.
-
-You are not required to accept this License in order to receive or
-run a copy of the Program. Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance. However,
-nothing other than this License grants you permission to propagate or
-modify any covered work. These actions infringe copyright if you do
-not accept this License. Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-10. Automatic Licensing of Downstream Recipients.
-
-Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License. You are not responsible
-for enforcing compliance by third parties with this License.
-
-An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations. If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License. For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-11. Patents.
-
-A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based. The
-work thus licensed is called the contributor's "contributor version".
-
-A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version. For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement). To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients. "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License. You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-12. No Surrender of Others' Freedom.
-
-If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License. If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all. For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-13. Remote Network Interaction; Use with the GNU General Public License.
-
-Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software. This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
-
-Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
-combined work, and to convey the resulting work. The terms of this
-License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
-
-14. Revised Versions of this License.
-
-The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time. Such new versions
-will be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-Each version is given a distinguishing version number. If the
-Program specifies that a certain numbered version of the GNU Affero General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation. If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-Later license versions may give you additional or different
-permissions. However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-15. Disclaimer of Warranty.
-
-THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-16. Limitation of Liability.
-
-IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-17. Interpretation of Sections 15 and 16.
-
-If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-To do so, attach the following notices to the program. It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source. For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code. There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
-
-You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
-<https://www.gnu.org/licenses/>.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="priv/static/images/lasso-logo-readme.png" alt="Lasso RPC" height="60">
 </p>
 
-[![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/jaxernst/lasso-rpc/releases)
 
 ### Smart RPC aggregation for fault-tolerant and performant blockchain apps.
@@ -322,11 +322,9 @@ For security concerns, please review our [Security Policy](SECURITY.md).
 
 ---
 
-## License: AGPL-3.0
+## License: Apache-2.0
 
-- self-host it freely to make your RPCs better
-- modify it to make Lasso better
-- ⚠️ If you run a modified version as a service, you must publish your modifications
+Lasso RPC is licensed under the [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0). It permits use, modification, distribution, self-hosting, and commercial embedding subject to the license terms.
 
 See [LICENSE.md](LICENSE.md) for full terms.
 

--- a/lib/lasso/config/transport_policy.ex
+++ b/lib/lasso/config/transport_policy.ex
@@ -15,16 +15,14 @@ defmodule Lasso.Config.TransportPolicy do
     "eth_unsubscribe"
   ]
 
-  # Globally disallowed methods (stateful/account management)
+  # Methods that operate on the upstream node's own keystore. Provider
+  # configuration cannot re-enable these methods.
   @disallowed_methods [
     "eth_sendTransaction",
     "personal_sign",
     "eth_sign",
     "eth_signTransaction",
-    "eth_accounts",
-    "txpool_content",
-    "txpool_inspect",
-    "txpool_status"
+    "eth_accounts"
   ]
 
   @doc """

--- a/lib/lasso/core/providers/adapter_helpers.ex
+++ b/lib/lasso/core/providers/adapter_helpers.ex
@@ -61,11 +61,15 @@ defmodule Lasso.RPC.Providers.AdapterHelpers do
 
   @spec estimate_current_block(map()) :: non_neg_integer()
   def estimate_current_block(ctx) do
-    chain = Map.get(ctx, :chain, "ethereum")
+    case Map.get(ctx, :chain_id) do
+      chain_id when is_integer(chain_id) and chain_id > 0 ->
+        case ChainState.consensus_height(chain_id) do
+          {:ok, height} -> height
+          {:error, _} -> 0
+        end
 
-    case ChainState.consensus_height(chain) do
-      {:ok, height} -> height
-      {:error, _} -> 0
+      _ ->
+        0
     end
   end
 

--- a/lib/lasso/core/request/request_context.ex
+++ b/lib/lasso/core/request/request_context.ex
@@ -68,7 +68,11 @@ defmodule Lasso.RPC.RequestContext do
           # Execution parameters (immutable throughout pipeline)
           rpc_request: map() | nil,
           timeout_ms: timeout() | nil,
-          opts: RequestOptions.t() | nil
+          opts: RequestOptions.t() | nil,
+
+          # Set when declared parameter limits eliminate every candidate so the
+          # safety retry dispatches instead of failing the request outright.
+          bypass_param_limits: boolean()
         }
 
   defstruct request_id: nil,
@@ -105,7 +109,8 @@ defmodule Lasso.RPC.RequestContext do
             error: nil,
             rpc_request: nil,
             timeout_ms: nil,
-            opts: nil
+            opts: nil,
+            bypass_param_limits: false
 
   @doc """
   Creates a new request context with request_id and start_time.

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -197,7 +197,61 @@ defmodule Lasso.RPC.RequestPipeline do
   end
 
   @spec attempt_channels([Channel.t()], RequestContext.t()) :: result()
-  defp attempt_channels([], ctx) do
+  defp attempt_channels(channels, ctx), do: attempt_channels(channels, ctx, [])
+
+  @spec attempt_channels([Channel.t()], RequestContext.t(), [Channel.t()]) :: result()
+  defp attempt_channels([], ctx, [_ | _] = param_rejected) do
+    if ctx.attempted_channels == [] do
+      retry_param_rejected(param_rejected, ctx)
+    else
+      exhausted(ctx)
+    end
+  end
+
+  defp attempt_channels([], ctx, _param_rejected), do: exhausted(ctx)
+
+  defp attempt_channels([%Channel{} = channel | rest], %{bypass_param_limits: true} = ctx, _acc) do
+    execute_on_channel(channel, rest, ctx)
+  end
+
+  defp attempt_channels([%Channel{} = channel | rest], ctx, param_rejected)
+       when is_list(rest) do
+    %{"method" => method, "params" => params} = ctx.rpc_request
+
+    case AdapterFilter.validate_params(channel, method, params) do
+      :ok ->
+        execute_on_channel(channel, rest, ctx)
+
+      {:error, reason} ->
+        Logger.debug("Parameters invalid for channel, skipping",
+          channel: Channel.to_string(channel),
+          method: method,
+          reason: inspect(reason)
+        )
+
+        ctx = RequestContext.increment_retries(ctx)
+        attempt_channels(rest, ctx, param_rejected ++ [channel])
+    end
+  end
+
+  defp retry_param_rejected(channels, ctx) do
+    Logger.warning("All channels rejected by parameter limits, attempting anyway",
+      chain_id: ctx.chain_id,
+      method: ctx.method,
+      request_id: ctx.request_id,
+      candidates: length(channels)
+    )
+
+    :telemetry.execute([:lasso, :capabilities, :safety_override], %{count: 1}, %{
+      reason: :all_param_rejected,
+      method: ctx.method,
+      chain_id: ctx.chain_id
+    })
+
+    attempt_channels(channels, %{ctx | bypass_param_limits: true}, [])
+  end
+
+  defp exhausted(ctx) do
     Logger.warning("All channels exhausted",
       chain_id: ctx.chain_id,
       method: ctx.method,
@@ -212,26 +266,6 @@ defmodule Lasso.RPC.RequestPipeline do
       )
 
     finalize_error(jerr, ctx)
-  end
-
-  defp attempt_channels([%Channel{} = channel | rest], ctx) when is_list(rest) do
-    %{"method" => method, "params" => params} = ctx.rpc_request
-
-    # Validate params for this channel first
-    case AdapterFilter.validate_params(channel, method, params) do
-      :ok ->
-        execute_on_channel(channel, rest, ctx)
-
-      {:error, reason} ->
-        Logger.debug("Parameters invalid for channel, skipping",
-          channel: Channel.to_string(channel),
-          method: method,
-          reason: inspect(reason)
-        )
-
-        ctx = RequestContext.increment_retries(ctx)
-        attempt_channels(rest, ctx)
-    end
   end
 
   @spec execute_on_channel(Channel.t(), [Channel.t()], RequestContext.t()) :: result()

--- a/lib/lasso/core/streaming/upstream_subscription_pool.ex
+++ b/lib/lasso/core/streaming/upstream_subscription_pool.ex
@@ -34,8 +34,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     StreamSupervisor
   }
 
-  @max_readiness_retries 50
-  @readiness_retry_ms 100
+  @readiness_retry_base_ms 100
+  @readiness_retry_cap_ms 5_000
 
   @type profile :: String.t()
   @type chain_id :: pos_integer()
@@ -77,6 +77,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   @impl true
   def init({profile, chain_id}) do
     Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.provider_event(profile, chain_id))
+    Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.ws_connection(profile, chain_id))
     Phoenix.PubSub.subscribe(Lasso.PubSub, Lasso.Topics.instance_sub_manager_restarted(chain_id))
 
     dedupe_cfg =
@@ -134,6 +135,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
                 provider_constraint: provider_constraint,
                 establishment_generation: generation,
                 readiness_retries: 0,
+                retry_token: nil,
                 transient_excluded_providers: MapSet.new(),
                 markers: %{},
                 dedupe: nil,
@@ -165,6 +167,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
                   status: :establishing,
                   establishment_generation: generation,
                   readiness_retries: 0,
+                  retry_token: nil,
                   transient_excluded_providers: MapSet.new(),
                   noproc_retries: 0
               }
@@ -489,6 +492,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
         primary_provider_id: provider_id,
         instance_id: instance_id,
         readiness_retries: 0,
+        retry_token: nil,
         transient_excluded_providers: MapSet.new(),
         noproc_retries: 0
     }
@@ -550,34 +554,22 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
   defp retry_readiness(state, pool_key, generation, excluded_providers) do
     case Map.get(state.keys, pool_key) do
-      %{
-        status: :establishing,
-        establishment_generation: ^generation,
-        readiness_retries: retries
-      } = entry
-      when retries < @max_readiness_retries ->
+      %{status: :establishing, establishment_generation: ^generation, retry_token: nil} = entry ->
+        attempt = entry.readiness_retries
+
+        delay =
+          min(@readiness_retry_base_ms * Integer.pow(2, min(attempt, 6)), @readiness_retry_cap_ms)
+
+        token = make_ref()
+
         Process.send_after(
           self(),
-          {:retry_establish, pool_key, generation, excluded_providers},
-          @readiness_retry_ms
+          {:retry_establish, pool_key, generation, token, excluded_providers},
+          delay
         )
 
-        updated = %{entry | readiness_retries: retries + 1}
+        updated = %{entry | readiness_retries: attempt + 1, retry_token: token}
         {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated)}}
-
-      %{status: :establishing, establishment_generation: ^generation} = entry ->
-        if entry.provider_constraint do
-          Process.send_after(
-            self(),
-            {:retry_establish, pool_key, generation, excluded_providers},
-            1_000
-          )
-
-          updated = %{entry | readiness_retries: 0}
-          {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated)}}
-        else
-          {:noreply, mark_subscription_failed(state, pool_key, "No ready providers")}
-        end
 
       _ ->
         {:noreply, state}
@@ -703,11 +695,53 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  def handle_info({:retry_establish, pool_key, generation, excluded_providers}, state) do
+  def handle_info({:retry_establish, pool_key, generation, token, excluded_providers}, state) do
     case Map.get(state.keys, pool_key) do
-      %{status: :establishing, establishment_generation: ^generation} ->
+      %{status: :establishing, establishment_generation: ^generation, retry_token: ^token} = entry ->
+        updated = %{entry | retry_token: nil}
+        new_state = %{state | keys: Map.put(state.keys, pool_key, updated)}
         GenServer.cast(self(), {:establish_upstream, pool_key, generation, excluded_providers})
+        {:noreply, new_state}
+
+      _ ->
         {:noreply, state}
+    end
+  end
+
+  def handle_info({:ws_connected, provider_id, _connection_id}, state) do
+    new_state =
+      Enum.reduce(state.keys, state, fn {pool_key, entry}, acc ->
+        should_wake? =
+          entry.status == :establishing and entry.retry_token != :wake_pending and
+            (is_nil(entry.provider_constraint) or entry.provider_constraint == provider_id)
+
+        if should_wake? do
+          Process.send_after(
+            self(),
+            {:wake_establish, pool_key, entry.establishment_generation},
+            @readiness_retry_base_ms
+          )
+
+          updated = %{entry | retry_token: :wake_pending}
+          %{acc | keys: Map.put(acc.keys, pool_key, updated)}
+        else
+          acc
+        end
+      end)
+
+    {:noreply, new_state}
+  end
+
+  def handle_info({:wake_establish, pool_key, generation}, state) do
+    case Map.get(state.keys, pool_key) do
+      %{
+        status: :establishing,
+        establishment_generation: ^generation,
+        retry_token: :wake_pending
+      } = entry ->
+        updated = %{entry | retry_token: nil}
+        GenServer.cast(self(), {:establish_upstream, pool_key, generation, []})
+        {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated)}}
 
       _ ->
         {:noreply, state}
@@ -945,18 +979,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  # Routes a failover decision: a valid replacement provider goes to the
-  # StreamCoordinator for handoff; `nil` (no candidate available) marks the
-  # subscription as failed so clients receive a Failed event rather than
-  # silently lingering against a stale upstream.
   defp dispatch_failover(state, pool_key, _failed_provider_id, nil) do
-    case Map.get(state.keys, pool_key) do
-      %{provider_constraint: provider_constraint} when is_binary(provider_constraint) ->
-        retry_constrained_subscription(state, pool_key)
-
-      _ ->
-        mark_subscription_failed(state, pool_key, "No replacement provider available")
-    end
+    retry_pending_subscription(state, pool_key)
   end
 
   defp dispatch_failover(state, key, failed_provider_id, new_provider_id)
@@ -1024,7 +1048,10 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   defp transient_subscription_error?(%JError{retriable?: true}), do: true
   defp transient_subscription_error?(_reason), do: false
 
-  defp retry_constrained_subscription(state, pool_key) do
+  defp retry_constrained_subscription(state, pool_key),
+    do: retry_pending_subscription(state, pool_key)
+
+  defp retry_pending_subscription(state, pool_key) do
     case Map.get(state.keys, pool_key) do
       nil ->
         state
@@ -1040,11 +1067,13 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
             instance_id: nil,
             establishment_generation: generation,
             readiness_retries: 0,
+            retry_token: nil,
             transient_excluded_providers: MapSet.new()
         }
 
-        Process.send_after(self(), {:retry_establish, pool_key, generation, []}, 100)
-        %{state | keys: Map.put(state.keys, pool_key, updated)}
+        new_state = %{state | keys: Map.put(state.keys, pool_key, updated)}
+        {:noreply, scheduled_state} = retry_readiness(new_state, pool_key, generation, [])
+        scheduled_state
     end
   end
 

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -321,18 +321,22 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   """
   @spec signal_recovery(breaker_id()) :: :ok | {:error, :not_found}
   def signal_recovery(id) do
-    case GenServer.whereis(via_name(id)) do
+    case safe_whereis(via_name(id)) do
       nil ->
         {:error, :not_found}
 
-      _pid ->
-        case get_state(id) do
-          %{state: state} when state in [:open, :half_open] ->
-            GenServer.cast(via_name(id), {:report_external, {:ok, :success}})
-            :ok
+      pid ->
+        try do
+          case GenServer.call(pid, :get_state, @state_timeout) do
+            %{state: state} when state in [:open, :half_open] ->
+              GenServer.cast(pid, {:report_external, {:ok, :success}})
+              :ok
 
-          _ ->
-            :ok
+            _ ->
+              :ok
+          end
+        catch
+          :exit, _ -> {:error, :not_found}
         end
     end
   end
@@ -342,7 +346,11 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   """
   @spec signal_recovery_cast(breaker_id()) :: :ok
   def signal_recovery_cast(cb_id) do
-    GenServer.cast(via_name(cb_id), {:report_external, {:ok, :success}})
+    case safe_whereis(via_name(cb_id)) do
+      nil -> :ok
+      pid -> GenServer.cast(pid, {:report_external, {:ok, :success}})
+    end
+
     :ok
   end
 
@@ -351,12 +359,12 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   """
   @spec record_failure(breaker_id(), term()) :: :ok | {:error, :not_found}
   def record_failure(id, reason \\ :failure) do
-    case GenServer.whereis(via_name(id)) do
+    case safe_whereis(via_name(id)) do
       nil ->
         {:error, :not_found}
 
-      _pid ->
-        GenServer.cast(via_name(id), {:report_external, {:error, reason}})
+      pid ->
+        GenServer.cast(pid, {:report_external, {:error, reason}})
         :ok
     end
   end
@@ -368,19 +376,32 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @spec record_failure_sync(breaker_id(), term(), timeout()) ::
           {:ok, :closed | :open | :half_open} | {:error, :not_found | :timeout}
   def record_failure_sync(id, reason \\ :failure, timeout \\ 5_000) do
-    case GenServer.whereis(via_name(id)) do
+    case safe_whereis(via_name(id)) do
       nil ->
         {:error, :not_found}
 
-      _pid ->
+      pid ->
         try do
-          state = GenServer.call(via_name(id), {:report_external_sync, {:error, reason}}, timeout)
+          state = GenServer.call(pid, {:report_external_sync, {:error, reason}}, timeout)
           {:ok, state}
         catch
           :exit, {:timeout, _} -> {:error, :timeout}
           :exit, {:noproc, _} -> {:error, :not_found}
+          :exit, _ -> {:error, :not_found}
         end
     end
+  end
+
+  @doc """
+  Resolves a GenServer name without raising when its registry is unavailable.
+  """
+  @spec safe_whereis(GenServer.name()) :: pid() | nil
+  def safe_whereis(name) do
+    GenServer.whereis(name)
+  rescue
+    ArgumentError -> nil
+  catch
+    :exit, _ -> nil
   end
 
   # GenServer callbacks
@@ -1052,7 +1073,9 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   defp shared_breaker_penalty?(%JError{breaker_penalty?: penalty}, _state), do: penalty
   defp shared_breaker_penalty?(_, _state), do: false
 
-  @doc false
+  @doc """
+  Returns the registry name for a provider transport circuit breaker.
+  """
   @spec via_name({String.t(), atom()}) :: {:via, Registry, {Lasso.Registry, term()}}
   def via_name({instance_id, transport}) when is_binary(instance_id) do
     {:via, Registry, {Lasso.Registry, {:circuit_breaker, "#{instance_id}:#{transport}"}}}

--- a/lib/lasso/providers/probe_coordinator.ex
+++ b/lib/lasso/providers/probe_coordinator.ex
@@ -348,7 +348,9 @@ defmodule Lasso.Providers.ProbeCoordinator do
 
     request = Finch.build(:post, url, headers, body)
 
-    case Finch.request(request, Lasso.Finch, receive_timeout: @default_timeout_ms) do
+    case run_probe_request(fn ->
+           Finch.request(request, Lasso.Finch, receive_timeout: @default_timeout_ms)
+         end) do
       {:ok, %{status: status, body: resp_body}} when status in 200..299 ->
         case classify_response_body(resp_body, chain_id) do
           :ok ->
@@ -390,6 +392,14 @@ defmodule Lasso.Providers.ProbeCoordinator do
         write_probe_failure(instance_id, reason)
         {instance_id, {:failure, reason}}
     end
+  end
+
+  @doc false
+  @spec run_probe_request((-> term())) :: term()
+  def run_probe_request(request_fun) when is_function(request_fun, 0) do
+    request_fun.()
+  catch
+    :exit, reason -> {:error, {:request_exit, reason}}
   end
 
   @rate_limit_codes [-32_005, -32_007, -32_029]

--- a/lib/lasso/providers/restart_counter.ex
+++ b/lib/lasso/providers/restart_counter.ex
@@ -62,7 +62,19 @@ defmodule Lasso.Providers.RestartCounter do
   """
   @spec bump(key()) :: pos_integer()
   def bump(key) do
-    :ets.update_counter(@table, key, 1, {key, 0})
+    update_counter(@table, key)
+  end
+
+  @doc """
+  Increments a restart counter in the given ETS table.
+
+  Returns a conservative fallback count when the table owner is unavailable.
+  """
+  @spec update_counter(atom(), key()) :: pos_integer()
+  def update_counter(table, key) do
+    :ets.update_counter(table, key, 1, {key, 0})
+  rescue
+    ArgumentError -> 10
   end
 
   @doc """
@@ -70,8 +82,18 @@ defmodule Lasso.Providers.RestartCounter do
   """
   @spec clear(key()) :: :ok
   def clear(key) do
-    :ets.delete(@table, key)
+    clear_counter(@table, key)
+  end
+
+  @doc """
+  Clears a counter from the given ETS table, tolerating an unavailable table owner.
+  """
+  @spec clear_counter(atom(), key()) :: :ok
+  def clear_counter(table, key) do
+    :ets.delete(table, key)
     :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   @doc """

--- a/lib/lasso/rpc/method_registry.ex
+++ b/lib/lasso/rpc/method_registry.ex
@@ -39,6 +39,7 @@ defmodule Lasso.RPC.MethodRegistry do
       "eth_estimateGas",
       "eth_getStorageAt",
       "eth_getTransactionCount",
+      "eth_createAccessList",
       # EIP-1186 - archive nodes
       "eth_getProof"
     ],
@@ -46,12 +47,17 @@ defmodule Lasso.RPC.MethodRegistry do
     # Network/utility methods
     network: [
       "net_version",
-      "net_listening",
-      "net_peerCount",
       "web3_clientVersion",
       "web3_sha3",
-      "eth_protocolVersion",
       "eth_syncing"
+    ],
+
+    # Node-operator introspection is separated from application-facing network
+    # methods because hosted providers commonly withhold it by design.
+    node_admin: [
+      "net_listening",
+      "net_peerCount",
+      "eth_protocolVersion"
     ],
 
     # EIP-1559 methods (post-London fork)
@@ -62,7 +68,7 @@ defmodule Lasso.RPC.MethodRegistry do
 
     # EIP-4844 methods (post-Dencun, blob transactions)
     eip4844: [
-      "eth_getBlobBaseFee"
+      "eth_blobBaseFee"
     ],
 
     # Mempool/pending transaction methods

--- a/test/lasso/core/providers/adapter_helpers_test.exs
+++ b/test/lasso/core/providers/adapter_helpers_test.exs
@@ -1,0 +1,30 @@
+defmodule Lasso.RPC.Providers.AdapterHelpersTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
+  alias Lasso.RPC.Providers.AdapterHelpers
+
+  setup do
+    chain_id = 4_218_000 + System.unique_integer([:positive, :monotonic])
+    BlockSyncRegistry.clear_chain(chain_id)
+    on_exit(fn -> BlockSyncRegistry.clear_chain(chain_id) end)
+    {:ok, chain_id: chain_id}
+  end
+
+  describe "estimate_current_block/1" do
+    test "reads consensus using the integer chain ID", %{chain_id: chain_id} do
+      BlockSyncRegistry.put_height(chain_id, "provider_1", 1_000_000, :http, %{})
+
+      assert AdapterHelpers.estimate_current_block(%{chain: "ethereum", chain_id: chain_id}) ==
+               1_000_000
+    end
+
+    test "fails open when the context has only a chain slug" do
+      assert AdapterHelpers.estimate_current_block(%{chain: "ethereum"}) == 0
+    end
+
+    test "fails open when the chain ID is invalid" do
+      assert AdapterHelpers.estimate_current_block(%{chain_id: "ethereum"}) == 0
+    end
+  end
+end

--- a/test/lasso/core/request/param_limit_failopen_test.exs
+++ b/test/lasso/core/request/param_limit_failopen_test.exs
@@ -1,0 +1,57 @@
+defmodule Lasso.RPC.ParamLimitFailOpenTest do
+  use Lasso.Test.LassoIntegrationCase
+
+  alias Lasso.RPC.{RequestOptions, RequestPipeline}
+
+  defp wide_get_logs_params do
+    [%{"fromBlock" => "0x0", "toBlock" => "0x2710"}]
+  end
+
+  defp execute(chain, params) do
+    RequestPipeline.execute_via_channels(chain, "eth_getLogs", params, %RequestOptions{
+      profile: "public",
+      strategy: :load_balanced,
+      timeout_ms: 5_000
+    })
+  end
+
+  setup %{chain: chain} do
+    {:ok, _ids} =
+      setup_test_chain_with_providers(
+        chain,
+        [
+          %{
+            id: "tight_a",
+            behavior: :healthy,
+            capabilities: %{limits: %{max_block_range: 10}}
+          },
+          %{
+            id: "tight_b",
+            behavior: :healthy,
+            capabilities: %{limits: %{max_block_range: 50}}
+          }
+        ],
+        provider_type: :http
+      )
+
+    :ok
+  end
+
+  test "dispatches with a safety override when limits reject every candidate", %{chain: chain} do
+    ref =
+      :telemetry_test.attach_event_handlers(self(), [[:lasso, :capabilities, :safety_override]])
+
+    try do
+      result = execute(chain, wide_get_logs_params())
+
+      refute match?({:error, %{code: -32_000, message: "No channels available"}, _}, result)
+      assert elem(result, 2).attempted_channels != []
+
+      assert_receive {[:lasso, :capabilities, :safety_override], ^ref, _measurements,
+                      %{reason: :all_param_rejected}},
+                     2_000
+    after
+      :telemetry.detach(ref)
+    end
+  end
+end

--- a/test/lasso/providers/probe_coordinator_test.exs
+++ b/test/lasso/providers/probe_coordinator_test.exs
@@ -112,6 +112,20 @@ defmodule Lasso.Providers.ProbeCoordinatorTest do
     end
   end
 
+  describe "run_probe_request/1" do
+    test "converts Finch pool exits into probe errors" do
+      reason = {:shutdown, :idle_timeout}
+
+      assert ProbeCoordinator.run_probe_request(fn -> exit(reason) end) ==
+               {:error, {:request_exit, reason}}
+    end
+
+    test "preserves normal request results" do
+      assert ProbeCoordinator.run_probe_request(fn -> {:error, :timeout} end) ==
+               {:error, :timeout}
+    end
+  end
+
   describe "reload_instances/1" do
     test "picks up new instances after catalog rebuild" do
       {:ok, pid} = start_coordinator(@chain)

--- a/test/lasso/providers/restart_counter_test.exs
+++ b/test/lasso/providers/restart_counter_test.exs
@@ -1,0 +1,17 @@
+defmodule Lasso.Providers.RestartCounterTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Providers.RestartCounter
+
+  test "uses conservative backoff when the table is unavailable" do
+    assert RestartCounter.update_counter(:missing_restart_counter_table, {:block_sync, "missing"}) ==
+             10
+  end
+
+  test "clearing remains idempotent when the table is unavailable" do
+    assert RestartCounter.clear_counter(
+             :missing_restart_counter_table,
+             {:block_sync, "missing"}
+           ) == :ok
+  end
+end

--- a/test/lasso/rpc/circuit_breaker_test.exs
+++ b/test/lasso/rpc/circuit_breaker_test.exs
@@ -99,6 +99,11 @@ defmodule Lasso.RPC.CircuitBreakerTest do
     assert CircuitBreaker.get_state(id).state in [:half_open, :closed]
   end
 
+  test "registry lookup returns unavailable instead of raising when the registry is absent" do
+    name = {:via, Registry, {:missing_circuit_breaker_registry, {:provider, :http}}}
+    assert CircuitBreaker.safe_whereis(name) == nil
+  end
+
   test "record_failure increments failures and can open the circuit" do
     id = {"cb_provider_record", :http}
 

--- a/test/lasso/rpc/method_registry_test.exs
+++ b/test/lasso/rpc/method_registry_test.exs
@@ -1,0 +1,27 @@
+defmodule Lasso.RPC.MethodRegistryTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Config.TransportPolicy
+  alias Lasso.RPC.MethodRegistry
+
+  test "uses the EIP-4844 blob base fee method name" do
+    assert MethodRegistry.category_methods(:eip4844) == ["eth_blobBaseFee"]
+  end
+
+  test "registers each method in one category" do
+    methods = MethodRegistry.categories() |> Map.values() |> List.flatten()
+    assert Enum.uniq(methods) == methods
+  end
+
+  test "separates node introspection from application-facing network methods" do
+    assert "net_version" in MethodRegistry.category_methods(:network)
+    assert "net_peerCount" in MethodRegistry.category_methods(:node_admin)
+    refute "net_peerCount" in MethodRegistry.category_methods(:network)
+  end
+
+  test "allows read-only transaction-pool inspection" do
+    refute TransportPolicy.disallowed?("txpool_content")
+    refute TransportPolicy.disallowed?("txpool_inspect")
+    refute TransportPolicy.disallowed?("txpool_status")
+  end
+end

--- a/test/lasso/rpc/upstream_subscription_pool_test.exs
+++ b/test/lasso/rpc/upstream_subscription_pool_test.exs
@@ -150,6 +150,82 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
     end
   end
 
+  describe "provider readiness recovery" do
+    test "wakes a routed subscription when its provider reconnects", %{
+      chain: chain,
+      provider: provider,
+      profile: profile,
+      instance_id: instance_id
+    } do
+      [{manager_pid, _}] =
+        Registry.lookup(Lasso.Registry, {:instance_sub_manager, instance_id})
+
+      send(manager_pid, {:ws_disconnected, instance_id, %{reason: :readiness_test}})
+
+      assert TestHelper.eventually(fn ->
+               Lasso.Core.Streaming.InstanceSubscriptionManager.ensure_subscription(
+                 instance_id,
+                 {:newHeads}
+               ) == {:error, :not_connected}
+             end)
+
+      assert {:ok, _subscription_id} =
+               UpstreamSubscriptionPool.subscribe_client(profile, chain, self(), {:newHeads})
+
+      Process.sleep(25)
+      assert get_pool_state(chain).keys[{:newHeads}].status == :establishing
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_connection(profile, chain),
+        {:ws_connected, provider, "conn-ready-routed"}
+      )
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_conn_instance(instance_id),
+        {:ws_connected, instance_id, "conn-ready-routed"}
+      )
+
+      assert TestHelper.eventually(fn ->
+               get_pool_state(chain).keys[{:newHeads}].status == :active
+             end)
+
+      entry = get_pool_state(chain).keys[{:newHeads}]
+      assert entry.primary_provider_id == provider
+      assert entry.provider_constraint == nil
+    end
+
+    test "a stale readiness retry cannot resurrect an unsubscribed key", %{
+      chain: chain,
+      provider: provider,
+      profile: profile
+    } do
+      :ets.delete(:transport_channel_cache, {profile, chain, provider, :ws})
+
+      assert {:ok, subscription_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain,
+                 self(),
+                 {:newHeads},
+                 provider_id: provider
+               )
+
+      assert :ok =
+               UpstreamSubscriptionPool.unsubscribe_client(profile, chain, subscription_id)
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_connection(profile, chain),
+        {:ws_connected, provider, "conn-after-unsubscribe"}
+      )
+
+      Process.sleep(150)
+      assert get_pool_state(chain).keys == %{}
+    end
+  end
+
   describe "async subscription behavior" do
     test "first subscriber gets immediate response while upstream establishes", %{
       chain: chain,

--- a/test/support/lasso/testing/mock_http_provider.ex
+++ b/test/support/lasso/testing/mock_http_provider.ex
@@ -61,6 +61,7 @@ defmodule Lasso.Testing.MockHTTPProvider do
       type: "test",
       priority: Map.get(spec, :priority, 100),
       archival: Map.get(spec, :archival, true),
+      capabilities: Map.get(spec, :capabilities),
       # Mark as mock for routing
       __mock__: true
     }


### PR DESCRIPTION
## Summary

- semantically sync reusable routing resilience changes from `lasso-cloud` while preserving the standalone file-backed router boundary
- fail open when declared/discovered parameter limits reject every candidate, preventing stale capability evidence from causing a routing outage
- recover probes, circuit state, restart counters, and WebSocket subscriptions across transient process or connection failures
- correct JSON-RPC method policy metadata, including read-only `txpool_*` routing and the EIP-4844 `eth_blobBaseFee` name
- relicense the public router from AGPL-3.0 to Apache-2.0 in a separate commit

This PR does not change Lasso Cloud, deploy anything, or alter the OSS YAML/file-backed configuration authority.

## Provenance and sync frontier

- OSS base: `c4369bc9126bf08f08ac1ef9a3577cb67394cb5e`
- Cloud source inspected: `51e2aeb4e1aff7192f9d30fb917908e22fb628e4` (`origin/main`)
- Cloud interval reviewed: `fc6aebc3a243b4e9bb27e68881c7365273d34aef..51e2aeb4e1aff7192f9d30fb917908e22fb628e4`
- Prior curated boundary: #41 (`4eca7de4..fc6aebc`, merged as `f3e0e285`)
- Post-#41 OSS fixes reviewed and preserved: #42 and #44

The sync is semantic, not a directory copy. Cloud commit and path evidence follows.

### Included / adapted

- `b4e5525a` — adapted the core-owned portions from `lib/lasso/core/request/{request_context,request_pipeline}.ex`, `lib/lasso/config/transport_policy.ex`, and `lib/lasso/rpc/method_registry.ex`:
  - parameter-limit fail-open with explicit telemetry
  - read-only transaction-pool methods remain routable
  - JSON-RPC method registry corrections
  - retained the OSS test fixture's standalone runtime behavior while carrying declared capabilities into mock provider configuration
- `26025b95` — included reusable recovery changes from:
  - `lib/lasso/core/providers/adapter_helpers.ex`
  - `lib/lasso/core/streaming/upstream_subscription_pool.ex`
  - `lib/lasso/core/support/circuit_breaker.ex`
  - `lib/lasso/providers/{probe_coordinator,restart_counter}.ex`
  - adapted the associated tests to the OSS test layout

### Already present / no port needed

- `f308eff8` — vulnerable runtime dependency and Finch error-wrapper work is already present through OSS #44 (`c4369bc`)
- `8cec7d71` — duplicate provider rejection already preserves the original provider in the OSS transactional add path and has regression coverage
- `f07fe980` — OSS already protects file-backed runtime mutations during retry using dirty-profile tracking and snapshot fingerprints; the Cloud implementation is database/user-profile oriented
- `9b90a4e7` — OSS already rejects invalid/duplicate chain IDs and alias collisions before publication with stronger file-profile validation
- `be18a516` — OSS already retains configuration snapshots across store restarts through `ConfigStore.Owner` and ETS heir transfer

### Excluded

- `7f594b7a`, `0dc636a3`, `6276067a`, `97791726` — Cloud dashboard/demo crawler work
- the discovery probe, profile-builder UI, database persistence, and activation workflow portions of `b4e5525a`
- `a28ea321` — Cloud customer-provider probe-cost characterization tied to the excluded discovery workflow
- `530a55d8` — Cloud CU metering durability
- `8dc65935`, `98fb80eb` — hosted launch/runtime environment, Fly staging, and database-backed profile listener behavior
- `a775e3ef`, `bd8e482b`, `0ba2314f`, `db3b7b66`, `9ead0592` — database-backed system profiles, authorization, and Cloud profile-builder behavior
- `bfdbfb76`, `85a0ce74`, `59ea03f6`, `0cc0a7f1`, `c2cbd316`, `51e2aeb4` — Cloud dashboard, database hot-path, social identity, selector, and authentication-cookie changes
- all `lib/lasso_cloud/**`, Ecto/migrations, WorkOS, billing, entitlements, metering, tenant scoping, hosted deployment configuration, and proprietary profiles

### Deferred

- `c1af5024` operational profile fallback. It is potentially valuable, but it changes routing semantics and is coupled to Cloud fallback profiles/configuration. Porting it safely needs a standalone OSS design decision rather than importing hosted assumptions.
- the broader discovery/probe overhaul in `b4e5525a`. Only the independent routing safety and registry corrections are included here.

## Apache-2.0 checklist

- [x] `LICENSE.md` replaced with the unmodified official Apache License 2.0 text
- [x] README badge, link, and license section use `Apache-2.0` / `https://www.apache.org/licenses/LICENSE-2.0`
- [x] `CONTRIBUTING.md` documents Apache-2.0 inbound-equals-outbound terms
- [x] changelog includes the relicensing note
- [x] tracked-file scan contains no stale AGPL, GNU Affero, SPDX, or old badge references
- [x] no third-party notices or licenses were changed; no `NOTICE` file was added because no project attribution notice requiring one was found
- [x] **Pre-merge ownership gate:** confirm that Jackson Ernst and/or Digital Journey LLC has the right to relicense all first-party code in public `main`, including that no employment, work-for-hire, assignment, copied-code, or other agreement conflicts with Apache-2.0. Also confirm the correct copyright holder before adding or rewriting any copyright notice. This checklist is not legal advice.

Reachable-history and text-file blame scans show Jackson Ernst as the sole author in current public `HEAD`. Arvin Morawej commits found under `--all` remain only on an unmerged private-remote branch and are not reachable from public `HEAD`; authorship is evidence, not proof of ownership.

## Validation

- [x] `mix deps.get`
- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] focused changed-area tests — 65 tests, 0 failures, plus the integration-tagged parameter-limit regression
- [x] `mix test --include integration` — 1004 tests, 0 failures
- [x] `mix credo --strict` — 3459 modules/functions, no issues
- [x] `mkdir -p priv/plts && mix dialyzer --format github` — passed; 26 existing warnings skipped, zero new errors
- [x] `git diff --check`
- [x] official Apache text SHA-256 matches `https://www.apache.org/licenses/LICENSE-2.0.txt`: `cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30`
- [x] tracked-file AGPL scan — no matches
- [x] added-line proprietary-boundary scan — no Cloud modules, auth/billing/tenant systems, secrets, private URLs, or hosted credentials
- [x] GitHub CI clean Docker build and `/api/health` boot smoke
- [ ] `mix hex.audit` — blocked by two advisories already affecting the unchanged public base dependencies: Cowboy 2.17.0 / CVE-2026-65624 and Cowlib 2.18.0 / CVE-2026-59248. This PR does not broaden into another unrelated dependency upgrade; the CI advisory job will remain red until those base dependencies are addressed.

Local Docker build/boot was not run because this PR does not change Docker, configuration, or release behavior, and the task explicitly avoids interfering with running local containers. GitHub CI completed the clean Docker build and health smoke successfully.

## Compatibility and operations

- existing HTTP/WS routes, profile aliases, provider configuration, and YAML authority remain unchanged
- no database, Cloud control-plane call, or new routing hot-path dependency was introduced
- parameter limits now fail open only after every candidate was rejected and before any upstream dispatch; the override emits `[:lasso, :capabilities, :safety_override]`
- WebSocket subscriptions remain pending with bounded exponential retries and wake promptly on provider reconnection
- no migration, deployment, or restart-specific action is required

## Commits

- `7ab3ee3492961b19b47aa3c3b1ef74e297b75915` — curated runtime sync
- `295b0b2fe3d1a55aaa61e762fa7761cc98e66d7d` — Apache-2.0 relicensing
