### PR TITLE
Add bounded request execution envelope

### DIFF
--- a/lib/lasso/core/request/execution_envelope.ex
+++ b/lib/lasso/core/request/execution_envelope.ex
@@ -1,0 +1,197 @@
+defmodule Lasso.RPC.ExecutionEnvelope do
+  @moduledoc """
+  Immutable bounds and safety policy for one logical JSON-RPC item.
+
+  Callers replace the envelope with the value returned by admission and dispatch
+  accounting functions. The absolute monotonic deadline is never extended.
+  """
+
+  alias Lasso.RPC.MethodRegistry
+
+  @minimum_attempt_ms 25
+  @max_candidate_admissions 16
+  @max_replay_safe_dispatches 3
+
+  @type execution_safety ::
+          :replay_safe
+          | :raw_transaction_broadcast
+          | :upstream_signed
+          | :filter_create
+          | :filter_affine_read
+          | :filter_affine_consume
+          | :filter_affine_uninstall
+          | :subscription
+          | :unknown
+
+  @type t :: %__MODULE__{
+          request_id: String.t(),
+          started_at_us: integer(),
+          deadline_us: integer(),
+          original_timeout_ms: non_neg_integer(),
+          execution_safety: execution_safety(),
+          dispatch_limit: 1..3,
+          dispatch_count: 0..3,
+          candidate_admission_limit: 16,
+          candidate_admission_count: 0..16,
+          dispatched_channels: term()
+        }
+
+  @enforce_keys [
+    :request_id,
+    :started_at_us,
+    :deadline_us,
+    :original_timeout_ms,
+    :execution_safety,
+    :dispatch_limit
+  ]
+  defstruct @enforce_keys ++
+              [
+                dispatch_count: 0,
+                candidate_admission_limit: @max_candidate_admissions,
+                candidate_admission_count: 0,
+                dispatched_channels: MapSet.new()
+              ]
+
+  @spec new(String.t(), String.t(), non_neg_integer(), keyword()) :: t()
+  def new(request_id, method, timeout_ms, opts \\ [])
+      when is_binary(request_id) and is_binary(method) and is_integer(timeout_ms) and
+             timeout_ms >= 0 do
+    started_at_us =
+      case Keyword.get(opts, :started_at_us) do
+        value when is_integer(value) -> value
+        _ -> System.monotonic_time(:microsecond)
+      end
+
+    safety = classify(method)
+
+    %__MODULE__{
+      request_id: request_id,
+      started_at_us: started_at_us,
+      deadline_us: started_at_us + timeout_ms * 1_000,
+      original_timeout_ms: timeout_ms,
+      execution_safety: safety,
+      dispatch_limit: dispatch_limit(safety)
+    }
+  end
+
+  @spec classify(String.t()) :: execution_safety()
+  def classify("eth_sendRawTransaction"), do: :raw_transaction_broadcast
+
+  def classify(method)
+      when method in [
+             "eth_sendTransaction",
+             "eth_sign",
+             "eth_signTransaction",
+             "personal_sign",
+             "personal_sendTransaction"
+           ],
+      do: :upstream_signed
+
+  def classify(method) when method in ["eth_newFilter", "eth_newBlockFilter"],
+    do: :filter_create
+
+  def classify("eth_newPendingTransactionFilter"), do: :filter_create
+  def classify("eth_getFilterLogs"), do: :filter_affine_read
+  def classify("eth_getFilterChanges"), do: :filter_affine_consume
+  def classify("eth_uninstallFilter"), do: :filter_affine_uninstall
+  def classify(method) when method in ["eth_subscribe", "eth_unsubscribe"], do: :subscription
+
+  def classify(method) do
+    if replay_safe_read?(method), do: :replay_safe, else: :unknown
+  end
+
+  @spec remaining_ms(t(), integer()) :: non_neg_integer()
+  def remaining_ms(%__MODULE__{} = envelope, now_us \\ System.monotonic_time(:microsecond)) do
+    max(0, div(envelope.deadline_us - now_us, 1_000))
+  end
+
+  @spec admit_candidate(t(), integer()) ::
+          {:ok, t()} | {:error, :candidate_budget_exhausted | :deadline_exhausted}
+  def admit_candidate(envelope, now_us \\ System.monotonic_time(:microsecond))
+
+  def admit_candidate(%__MODULE__{} = envelope, now_us) when now_us >= envelope.deadline_us,
+    do: {:error, :deadline_exhausted}
+
+  def admit_candidate(%__MODULE__{candidate_admission_count: count} = envelope, _now_us)
+      when count < envelope.candidate_admission_limit do
+    {:ok, %{envelope | candidate_admission_count: count + 1}}
+  end
+
+  def admit_candidate(%__MODULE__{}, _now_us), do: {:error, :candidate_budget_exhausted}
+
+  @spec reserve_dispatch(t(), String.t(), :http | :ws, integer()) ::
+          {:ok, t(), pos_integer()}
+          | {:error, :deadline_exhausted | :dispatch_budget_exhausted | :duplicate_dispatch}
+  def reserve_dispatch(
+        %__MODULE__{} = envelope,
+        instance_id,
+        transport,
+        now_us \\ System.monotonic_time(:microsecond)
+      ) do
+    remaining_ms = remaining_ms(envelope, now_us)
+    channel_key = {instance_id, transport}
+
+    cond do
+      remaining_ms < @minimum_attempt_ms ->
+        {:error, :deadline_exhausted}
+
+      envelope.dispatch_count >= envelope.dispatch_limit ->
+        {:error, :dispatch_budget_exhausted}
+
+      MapSet.member?(envelope.dispatched_channels, channel_key) ->
+        {:error, :duplicate_dispatch}
+
+      true ->
+        updated = %{
+          envelope
+          | dispatch_count: envelope.dispatch_count + 1,
+            dispatched_channels: MapSet.put(envelope.dispatched_channels, channel_key)
+        }
+
+        {:ok, updated, attempt_timeout_ms(updated, remaining_ms)}
+    end
+  end
+
+  @spec release_dispatch(t(), String.t(), :http | :ws) :: t()
+  def release_dispatch(%__MODULE__{} = envelope, instance_id, transport) do
+    channel_key = {instance_id, transport}
+
+    if MapSet.member?(envelope.dispatched_channels, channel_key) do
+      %{
+        envelope
+        | dispatch_count: envelope.dispatch_count - 1,
+          dispatched_channels: MapSet.delete(envelope.dispatched_channels, channel_key)
+      }
+    else
+      envelope
+    end
+  end
+
+  defp dispatch_limit(:replay_safe), do: @max_replay_safe_dispatches
+  defp dispatch_limit(:raw_transaction_broadcast), do: 1
+  defp dispatch_limit(_safety), do: 1
+
+  defp attempt_timeout_ms(
+         %__MODULE__{execution_safety: :replay_safe, dispatch_count: 1} = envelope,
+         remaining_ms
+       ) do
+    min(remaining_ms, max(@minimum_attempt_ms, div(envelope.original_timeout_ms * 60, 100)))
+  end
+
+  defp attempt_timeout_ms(_envelope, remaining_ms), do: remaining_ms
+
+  defp replay_safe_read?(method) do
+    MethodRegistry.method_category(method) in [
+      :core,
+      :state,
+      :network,
+      :node_admin,
+      :eip1559,
+      :eip4844,
+      :batch,
+      :debug,
+      :trace,
+      :txpool
+    ] or method == "eth_getLogs"
+  end
+end

--- a/lib/lasso/core/request/execution_outcome.ex
+++ b/lib/lasso/core/request/execution_outcome.ex
@@ -1,0 +1,142 @@
+defmodule Lasso.RPC.ExecutionOutcome do
+  @moduledoc """
+  Versioned execution facts shared by admission, attempt, and request consumers.
+  """
+
+  @schema_version 1
+  @stages [:admission, :attempt, :request]
+  @causes [
+    :success,
+    :application,
+    :capability,
+    :capacity,
+    :provider_health,
+    :auth_config,
+    :policy,
+    :deadline,
+    :cancellation,
+    :unknown
+  ]
+  @completions [:not_dispatched, :responded, :possibly_applied, :cancelled_censored]
+  @dispositions [:returned, :failover, :profile_fallback, :degraded, :exhausted]
+  @evidence_effects [
+    :usable_success,
+    :reliability_failure,
+    :capacity_signal,
+    :capability_signal,
+    :neutral,
+    :censored
+  ]
+
+  @type t :: %__MODULE__{
+          schema_version: 1,
+          stage: :admission | :attempt | :request,
+          cause: atom(),
+          completion: atom(),
+          disposition: atom(),
+          evidence_effect: atom(),
+          request_id: String.t(),
+          attempt_id: String.t() | nil,
+          upstream_instance_id: String.t() | nil,
+          chain_id: pos_integer() | nil,
+          transport: :http | :ws | nil,
+          routing_intent: atom() | nil,
+          route_generation: non_neg_integer() | nil,
+          circuit_scope: :broad | :intent | nil,
+          circuit_epoch: non_neg_integer() | nil,
+          deadline_us: integer(),
+          dispatched_at_us: integer() | nil,
+          terminal_at_us: integer(),
+          io_duration_ms: number() | nil,
+          censoring_boundary_ms: number() | nil
+        }
+
+  @enforce_keys [
+    :stage,
+    :cause,
+    :completion,
+    :disposition,
+    :evidence_effect,
+    :request_id,
+    :deadline_us,
+    :terminal_at_us
+  ]
+  @derive Jason.Encoder
+  defstruct @enforce_keys ++
+              [
+                schema_version: @schema_version,
+                attempt_id: nil,
+                upstream_instance_id: nil,
+                chain_id: nil,
+                transport: nil,
+                routing_intent: nil,
+                route_generation: nil,
+                circuit_scope: nil,
+                circuit_epoch: nil,
+                dispatched_at_us: nil,
+                io_duration_ms: nil,
+                censoring_boundary_ms: nil
+              ]
+
+  @spec new(keyword()) :: t()
+  def new(attrs) do
+    outcome = struct!(__MODULE__, attrs)
+    validate!(outcome)
+  end
+
+  @spec validate!(t()) :: t()
+  def validate!(%__MODULE__{} = outcome) do
+    validate_member!(:stage, outcome.stage, @stages)
+    validate_member!(:cause, outcome.cause, @causes)
+    validate_member!(:completion, outcome.completion, @completions)
+    validate_member!(:disposition, outcome.disposition, @dispositions)
+    validate_member!(:evidence_effect, outcome.evidence_effect, @evidence_effects)
+
+    validate_attempt!(outcome)
+    validate_admission!(outcome)
+    validate_timing!(outcome)
+
+    outcome
+  end
+
+  defp validate_attempt!(%__MODULE__{stage: stage}) when stage != :attempt, do: :ok
+
+  defp validate_attempt!(outcome) do
+    if is_nil(outcome.attempt_id), do: raise(ArgumentError, "attempt outcomes require attempt_id")
+
+    if is_nil(outcome.upstream_instance_id) or is_nil(outcome.chain_id) or
+         is_nil(outcome.transport) or is_nil(outcome.routing_intent) or
+         is_nil(outcome.route_generation) or is_nil(outcome.circuit_scope) or
+         is_nil(outcome.circuit_epoch) or is_nil(outcome.dispatched_at_us) do
+      raise ArgumentError, "attempt outcomes require bounded routing and dispatch identity"
+    end
+
+    if outcome.evidence_effect == :usable_success and is_nil(outcome.io_duration_ms),
+      do: raise(ArgumentError, "usable success requires io_duration_ms")
+
+    if outcome.cause in [:deadline, :cancellation] and is_nil(outcome.censoring_boundary_ms),
+      do: raise(ArgumentError, "deadline and cancellation attempts require a censoring boundary")
+
+    if is_nil(outcome.io_duration_ms) == is_nil(outcome.censoring_boundary_ms),
+      do: raise(ArgumentError, "attempt outcomes require exactly one timing observation")
+  end
+
+  defp validate_admission!(%__MODULE__{stage: stage}) when stage != :admission, do: :ok
+
+  defp validate_admission!(outcome) do
+    if outcome.completion != :not_dispatched,
+      do: raise(ArgumentError, "admission outcomes must be not_dispatched")
+
+    if outcome.evidence_effect != :neutral,
+      do: raise(ArgumentError, "admission outcomes cannot fabricate attempt evidence")
+  end
+
+  defp validate_timing!(outcome) do
+    if outcome.dispatched_at_us && outcome.terminal_at_us < outcome.dispatched_at_us,
+      do: raise(ArgumentError, "terminal time cannot precede dispatch time")
+  end
+
+  defp validate_member!(field, value, allowed) do
+    if value not in allowed, do: raise(ArgumentError, "invalid #{field}: #{inspect(value)}")
+  end
+end

--- a/lib/lasso/core/request/request_context.ex
+++ b/lib/lasso/core/request/request_context.ex
@@ -10,7 +10,7 @@ defmodule Lasso.RPC.RequestContext do
   - Result or error shapes
   """
 
-  alias Lasso.RPC.{Channel, RequestOptions, Response}
+  alias Lasso.RPC.{Channel, ExecutionEnvelope, RequestOptions, Response}
 
   @type channel_attempt :: {Channel.t(), :success | {:error, term()}}
 
@@ -68,6 +68,7 @@ defmodule Lasso.RPC.RequestContext do
           # Execution parameters (immutable throughout pipeline)
           rpc_request: map() | nil,
           timeout_ms: timeout() | nil,
+          execution_envelope: ExecutionEnvelope.t() | nil,
           opts: RequestOptions.t() | nil,
 
           # Set when declared parameter limits eliminate every candidate so the
@@ -109,6 +110,7 @@ defmodule Lasso.RPC.RequestContext do
             error: nil,
             rpc_request: nil,
             timeout_ms: nil,
+            execution_envelope: nil,
             opts: nil,
             bypass_param_limits: false
 
@@ -151,7 +153,19 @@ defmodule Lasso.RPC.RequestContext do
   @spec set_execution_params(t(), map(), integer(), RequestOptions.t()) :: t()
   def set_execution_params(%__MODULE__{} = ctx, rpc_request, timeout_ms, %RequestOptions{} = opts)
       when is_map(rpc_request) and is_integer(timeout_ms) do
-    %{ctx | rpc_request: rpc_request, timeout_ms: timeout_ms, opts: opts}
+    envelope =
+      ctx.execution_envelope ||
+        ExecutionEnvelope.new(ctx.request_id, ctx.method, timeout_ms,
+          started_at_us: ctx.start_time || System.monotonic_time(:microsecond)
+        )
+
+    %{
+      ctx
+      | rpc_request: rpc_request,
+        timeout_ms: timeout_ms,
+        opts: opts,
+        execution_envelope: envelope
+    }
   end
 
   @doc """

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -28,6 +28,7 @@ defmodule Lasso.RPC.RequestPipeline do
 
   alias Lasso.RPC.{
     Channel,
+    ExecutionEnvelope,
     RequestContext,
     Selection,
     TransportRegistry
@@ -211,27 +212,38 @@ defmodule Lasso.RPC.RequestPipeline do
   defp attempt_channels([], ctx, _param_rejected), do: exhausted(ctx)
 
   defp attempt_channels([%Channel{} = channel | rest], %{bypass_param_limits: true} = ctx, _acc) do
-    execute_on_channel(channel, rest, ctx)
+    case ExecutionEnvelope.admit_candidate(ctx.execution_envelope) do
+      {:ok, envelope} -> execute_on_channel(channel, rest, %{ctx | execution_envelope: envelope})
+      {:error, reason} -> finalize_bounded_error(ctx, reason)
+    end
   end
 
   defp attempt_channels([%Channel{} = channel | rest], ctx, param_rejected)
        when is_list(rest) do
-    %{"method" => method, "params" => params} = ctx.rpc_request
+    case ExecutionEnvelope.admit_candidate(ctx.execution_envelope) do
+      {:ok, envelope} ->
+        ctx = %{ctx | execution_envelope: envelope}
+        %{"method" => method, "params" => params} = ctx.rpc_request
 
-    case AdapterFilter.validate_params(channel, method, params) do
-      :ok ->
-        execute_on_channel(channel, rest, ctx)
+        case AdapterFilter.validate_params(channel, method, params) do
+          :ok ->
+            execute_on_channel(channel, rest, ctx)
+
+          {:error, reason} ->
+            Logger.debug("Parameters invalid for channel, skipping",
+              channel: Channel.to_string(channel),
+              method: method,
+              reason: inspect(reason)
+            )
+
+            Observability.record_admission_rejection(ctx, channel, :parameter_constraint)
+            ctx = RequestContext.increment_retries(ctx)
+            attempt_channels(rest, ctx, param_rejected ++ [channel])
+        end
 
       {:error, reason} ->
-        Logger.debug("Parameters invalid for channel, skipping",
-          channel: Channel.to_string(channel),
-          method: method,
-          reason: inspect(reason)
-        )
-
-        Observability.record_admission_rejection(ctx, channel, :parameter_constraint)
-        ctx = RequestContext.increment_retries(ctx)
-        attempt_channels(rest, ctx, param_rejected ++ [channel])
+        Observability.record_admission_rejection(ctx, channel, reason)
+        finalize_bounded_error(ctx, reason)
     end
   end
 
@@ -272,6 +284,44 @@ defmodule Lasso.RPC.RequestPipeline do
   @spec execute_on_channel(Channel.t(), [Channel.t()], RequestContext.t()) :: result()
   defp execute_on_channel(%Channel{instance_id: instance_id} = channel, rest_channels, ctx)
        when is_binary(instance_id) do
+    case ExecutionEnvelope.reserve_dispatch(
+           ctx.execution_envelope,
+           instance_id,
+           channel.transport
+         ) do
+      {:ok, envelope, attempt_timeout_ms} ->
+        execute_reserved_channel(
+          channel,
+          instance_id,
+          rest_channels,
+          %{ctx | execution_envelope: envelope},
+          attempt_timeout_ms
+        )
+
+      {:error, reason} ->
+        Observability.record_admission_rejection(ctx, channel, reason)
+
+        case reason do
+          :duplicate_dispatch -> attempt_channels(rest_channels, ctx)
+          :dispatch_budget_exhausted -> finalize_dispatch_exhaustion(ctx)
+          _ -> finalize_bounded_error(ctx, reason)
+        end
+    end
+  end
+
+  defp execute_on_channel(channel, rest_channels, ctx) do
+    Observability.record_admission_rejection(ctx, channel, :missing_instance_identity)
+
+    Logger.error("Channel has no stable upstream instance identity",
+      channel: Channel.to_string(channel),
+      request_id: ctx.request_id
+    )
+
+    ctx = RequestContext.increment_retries(ctx)
+    attempt_channels(rest_channels, ctx)
+  end
+
+  defp execute_reserved_channel(channel, instance_id, rest_channels, ctx, attempt_timeout_ms) do
     cb_state =
       instance_id
       |> InstanceState.read_circuit(channel.transport)
@@ -283,19 +333,51 @@ defmodule Lasso.RPC.RequestPipeline do
         circuit_breaker_state: cb_state
     }
 
+    dispatch_ref = make_ref()
+    caller = self()
+
     on_terminal = fn result, attempt_elapsed_ms ->
       Observability.record_attempt(ctx, channel, instance_id, result,
         attempt_elapsed_ms: attempt_elapsed_ms
       )
     end
 
-    case execute_with_circuit_breaker(
-           channel,
-           instance_id,
-           ctx.rpc_request,
-           ctx.timeout_ms,
-           on_terminal
-         ) do
+    on_dispatch = fn dispatched_at_us ->
+      send(caller, {:bounded_dispatch_confirmed, dispatch_ref, dispatched_at_us})
+    end
+
+    execution_result =
+      execute_with_circuit_breaker(
+        channel,
+        instance_id,
+        ctx.rpc_request,
+        attempt_timeout_ms,
+        on_terminal,
+        on_dispatch
+      )
+
+    dispatched? =
+      receive do
+        {:bounded_dispatch_confirmed, ^dispatch_ref, _dispatched_at_us} -> true
+      after
+        0 -> false
+      end
+
+    ctx =
+      if dispatched? do
+        ctx
+      else
+        envelope =
+          ExecutionEnvelope.release_dispatch(
+            ctx.execution_envelope,
+            instance_id,
+            channel.transport
+          )
+
+        %{ctx | execution_envelope: envelope}
+      end
+
+    case execution_result do
       # Function executed - examine what it returned
       {:executed, {:ok, result, io_ms}} ->
         handle_success(result, io_ms, channel, ctx)
@@ -365,18 +447,6 @@ defmodule Lasso.RPC.RequestPipeline do
         ctx = RequestContext.increment_retries(ctx)
         attempt_channels(rest_channels, ctx)
     end
-  end
-
-  defp execute_on_channel(channel, rest_channels, ctx) do
-    Observability.record_admission_rejection(ctx, channel, :missing_instance_identity)
-
-    Logger.error("Channel has no stable upstream instance identity",
-      channel: Channel.to_string(channel),
-      request_id: ctx.request_id
-    )
-
-    ctx = RequestContext.increment_retries(ctx)
-    attempt_channels(rest_channels, ctx)
   end
 
   @spec handle_success(any(), number(), Channel.t(), RequestContext.t()) :: result()
@@ -524,6 +594,42 @@ defmodule Lasso.RPC.RequestPipeline do
     {:error, jerr, ctx}
   end
 
+  defp finalize_bounded_error(ctx, reason) do
+    {message, category} =
+      case reason do
+        :deadline_exhausted ->
+          {"Request deadline exhausted", :timeout}
+
+        :dispatch_budget_exhausted ->
+          {"Request dispatch budget exhausted", :provider_error}
+
+        :candidate_budget_exhausted ->
+          {"Candidate admission budget exhausted", :local_capacity_rejection}
+      end
+
+    code = if category == :local_capacity_rejection, do: -32_005, else: -32_000
+
+    jerr =
+      JError.new(code, message,
+        category: category,
+        retriable?: false,
+        data: %{reason: reason}
+      )
+
+    finalize_error(jerr, ctx)
+  end
+
+  defp finalize_dispatch_exhaustion(
+         %RequestContext{attempted_channels: [_ | _] = attempted_channels} = ctx
+       ) do
+    {channel, {:error, reason}} = List.last(attempted_channels)
+    ctx = RequestContext.set_executed_channel(ctx, channel)
+    finalize_error(JError.from(reason, provider_id: channel.provider_id), ctx)
+  end
+
+  defp finalize_dispatch_exhaustion(ctx),
+    do: finalize_bounded_error(ctx, :dispatch_budget_exhausted)
+
   # CircuitBreaker.call returns:
   # - {:executed, fun_result} - Function executed, fun_result is what Channel.request returned
   # - {:executed, {:exception, {kind, error, stacktrace}}} - Function raised an exception
@@ -543,7 +649,8 @@ defmodule Lasso.RPC.RequestPipeline do
           String.t(),
           map(),
           timeout(),
-          CircuitBreaker.terminal_callback()
+          CircuitBreaker.terminal_callback(),
+          (integer() -> term())
         ) ::
           CircuitBreaker.call_result(circuit_breaker_result())
   defp execute_with_circuit_breaker(
@@ -551,13 +658,15 @@ defmodule Lasso.RPC.RequestPipeline do
          instance_id,
          rpc_request,
          timeout,
-         on_terminal
+         on_terminal,
+         on_dispatch
        ) do
     attempt_fun = fn -> Channel.request(channel, rpc_request, timeout) end
     cb_id = {instance_id, channel.transport}
 
     CircuitBreaker.call(cb_id, attempt_fun, timeout,
       on_terminal: on_terminal,
+      on_dispatch: on_dispatch,
       dispatch: dispatch_mode(channel.transport_module)
     )
   end

--- a/lib/lasso/core/support/attempt_lifecycle.ex
+++ b/lib/lasso/core/support/attempt_lifecycle.ex
@@ -10,6 +10,7 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   @dispatch_settle_timeout 1_000
 
   @type terminal_callback :: CircuitBreaker.terminal_callback() | nil
+  @type dispatch_callback :: (integer() -> term()) | nil
   @type dispatch_context :: {pid(), reference()}
 
   @spec run(
@@ -18,7 +19,20 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
           reference(),
           (-> term()),
           non_neg_integer(),
+          terminal_callback()
+        ) :: term()
+  def run(caller_pid, breaker_id, token, fun, timeout, terminal_callback) do
+    run(caller_pid, breaker_id, token, fun, timeout, terminal_callback, nil, :immediate)
+  end
+
+  @spec run(
+          pid(),
+          CircuitBreaker.breaker_id(),
+          reference(),
+          (-> term()),
+          non_neg_integer(),
           terminal_callback(),
+          dispatch_callback(),
           :immediate | :deferred
         ) :: term()
   def run(
@@ -28,22 +42,24 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         fun,
         timeout,
         terminal_callback,
+        dispatch_callback,
         dispatch_mode \\ :immediate
       ) do
     lifecycle_ref = make_ref()
 
     {lifecycle_pid, monitor_ref} =
       spawn_monitor(fn ->
-        execute(
-          caller_pid,
-          lifecycle_ref,
-          breaker_id,
-          token,
-          fun,
-          timeout,
-          terminal_callback,
-          dispatch_mode
-        )
+        execute(%{
+          caller_pid: caller_pid,
+          lifecycle_ref: lifecycle_ref,
+          breaker_id: breaker_id,
+          token: token,
+          fun: fun,
+          timeout: timeout,
+          terminal_callback: terminal_callback,
+          dispatch_callback: dispatch_callback,
+          dispatch_mode: dispatch_mode
+        })
       end)
 
     receive do
@@ -149,40 +165,25 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     with :ok <- authorize_dispatch(context), do: confirm_dispatched(context)
   end
 
-  defp execute(
-         caller_pid,
-         lifecycle_ref,
-         breaker_id,
-         token,
-         fun,
-         timeout,
-         terminal_callback,
-         dispatch_mode
-       ) do
+  defp execute(context) do
     Process.flag(:trap_exit, true)
-    caller_monitor = Process.monitor(caller_pid)
+    caller_monitor = Process.monitor(context.caller_pid)
 
-    case CircuitBreaker.claim_attempt(breaker_id, token, caller_pid) do
+    case CircuitBreaker.claim_attempt(context.breaker_id, context.token, context.caller_pid) do
       :ok ->
-        if Process.alive?(caller_pid) do
-          start_attempt(%{
-            caller_pid: caller_pid,
-            caller_monitor: caller_monitor,
-            lifecycle_ref: lifecycle_ref,
-            breaker_id: breaker_id,
-            token: token,
-            fun: fun,
-            timeout: timeout,
-            terminal_callback: terminal_callback,
-            dispatch_mode: dispatch_mode
-          })
+        if Process.alive?(context.caller_pid) do
+          start_attempt(Map.put(context, :caller_monitor, caller_monitor))
         else
-          CircuitBreaker.release_attempt(breaker_id, token)
+          CircuitBreaker.release_attempt(context.breaker_id, context.token)
         end
 
       {:error, reason} ->
         Process.demonitor(caller_monitor, [:flush])
-        send(caller_pid, {lifecycle_ref, {:__attempt_lifecycle_rejected__, reason}})
+
+        send(context.caller_pid, {
+          context.lifecycle_ref,
+          {:__attempt_lifecycle_rejected__, reason}
+        })
     end
   end
 
@@ -204,12 +205,8 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         [:link, :monitor]
       )
 
+    phase = initial_phase(context)
     send(task_pid, {:run_attempt, task_ref})
-
-    phase =
-      if context.dispatch_mode == :immediate,
-        do: {:dispatched, System.monotonic_time(:microsecond)},
-        else: :predispatch
 
     loop(
       Map.merge(context, %{
@@ -236,10 +233,12 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
       when dispatch_ref == state.dispatch_ref ->
         case confirmation_rejection(state) do
           nil ->
+            {phase, transition} = confirm_phase(state.phase)
+            maybe_invoke_dispatch_callback(state.dispatch_callback, transition)
             send(requester, {:attempt_dispatch_confirmed, confirmation_ref})
 
             state
-            |> Map.put(:phase, confirm_phase(state.phase))
+            |> Map.put(:phase, phase)
             |> resolve_pending_terminal()
 
           reason ->
@@ -305,11 +304,25 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     end
   end
 
-  defp confirm_phase({:dispatching, _authorized_at_us}),
-    do: {:dispatched, System.monotonic_time(:microsecond)}
+  defp initial_phase(%{dispatch_mode: :immediate} = context) do
+    dispatched_at_us = System.monotonic_time(:microsecond)
+    invoke_dispatch_callback(context.dispatch_callback, dispatched_at_us)
+    {:dispatched, dispatched_at_us}
+  end
 
-  defp confirm_phase({:dispatched, _time} = phase), do: phase
-  defp confirm_phase(:predispatch), do: {:dispatched, System.monotonic_time(:microsecond)}
+  defp initial_phase(_context), do: :predispatch
+
+  defp confirm_phase({:dispatching, _authorized_at_us}) do
+    dispatched_at_us = System.monotonic_time(:microsecond)
+    {{:dispatched, dispatched_at_us}, {:transitioned, dispatched_at_us}}
+  end
+
+  defp confirm_phase({:dispatched, _dispatched_at_us} = phase), do: {phase, :unchanged}
+
+  defp confirm_phase(:predispatch) do
+    dispatched_at_us = System.monotonic_time(:microsecond)
+    {{:dispatched, dispatched_at_us}, {:transitioned, dispatched_at_us}}
+  end
 
   defp confirmation_rejection(%{phase: :aborted}), do: :aborted
 
@@ -509,8 +522,8 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     )
 
     Process.demonitor(state.caller_monitor, [:flush])
-    send(state.caller_pid, {state.lifecycle_ref, result})
     invoke_terminal_callback(state.terminal_callback, result, elapsed_ms)
+    send(state.caller_pid, {state.lifecycle_ref, result})
   end
 
   defp finalize_timeout(state, elapsed_ms) do
@@ -600,4 +613,22 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
     :ok
   end
+
+  defp invoke_dispatch_callback(nil, _dispatched_at_us), do: :ok
+
+  defp invoke_dispatch_callback(callback, dispatched_at_us) when is_function(callback, 1) do
+    try do
+      callback.(dispatched_at_us)
+    catch
+      kind, error ->
+        Logger.error("Attempt dispatch callback failed", kind: kind, error: inspect(error))
+    end
+
+    :ok
+  end
+
+  defp maybe_invoke_dispatch_callback(callback, {:transitioned, dispatched_at_us}),
+    do: invoke_dispatch_callback(callback, dispatched_at_us)
+
+  defp maybe_invoke_dispatch_callback(_callback, :unchanged), do: :ok
 end

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -184,6 +184,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
           fun,
           timeout,
           Keyword.get(opts, :on_terminal),
+          Keyword.get(opts, :on_dispatch),
           Keyword.get(opts, :dispatch, :immediate)
         )
 
@@ -242,6 +243,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
          fun,
          timeout,
          terminal_callback,
+         dispatch_callback,
          dispatch_mode
        ) do
     case AttemptLifecycle.run(
@@ -251,6 +253,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
            fun,
            timeout,
            terminal_callback,
+           dispatch_callback,
            dispatch_mode
          ) do
       {:__attempt_lifecycle_rejected__, :timeout} -> {:rejected, :admission_timeout}

--- a/priv/fixtures/execution_outcomes_v1.json
+++ b/priv/fixtures/execution_outcomes_v1.json
@@ -1,0 +1,45 @@
+[
+  {
+    "schema_version": 1,
+    "stage": "admission",
+    "cause": "capacity",
+    "completion": "not_dispatched",
+    "disposition": "failover",
+    "evidence_effect": "neutral",
+    "request_id": "fixture-capacity",
+    "deadline_us": 200000,
+    "terminal_at_us": 100000
+  },
+  {
+    "schema_version": 1,
+    "stage": "attempt",
+    "cause": "deadline",
+    "completion": "possibly_applied",
+    "disposition": "failover",
+    "evidence_effect": "reliability_failure",
+    "request_id": "fixture-timeout",
+    "attempt_id": "fixture-attempt-1",
+    "upstream_instance_id": "fixture-instance-1",
+    "chain_id": 1,
+    "transport": "http",
+    "routing_intent": "default",
+    "route_generation": 4,
+    "circuit_scope": "broad",
+    "circuit_epoch": 2,
+    "deadline_us": 200000,
+    "dispatched_at_us": 100000,
+    "terminal_at_us": 200000
+    ,"censoring_boundary_ms": 100
+  },
+  {
+    "schema_version": 1,
+    "stage": "request",
+    "cause": "deadline",
+    "completion": "possibly_applied",
+    "disposition": "exhausted",
+    "evidence_effect": "neutral",
+    "request_id": "fixture-request-deadline",
+    "deadline_us": 200000,
+    "terminal_at_us": 200000
+  }
+]

--- a/test/lasso/core/request/execution_envelope_test.exs
+++ b/test/lasso/core/request/execution_envelope_test.exs
@@ -1,0 +1,94 @@
+defmodule Lasso.RPC.ExecutionEnvelopeTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.RPC.ExecutionEnvelope
+
+  test "one absolute deadline bounds every attempt" do
+    envelope =
+      ExecutionEnvelope.new("request-1", "eth_blockNumber", 100, started_at_us: 1_000_000)
+
+    assert {:ok, first, 60} =
+             ExecutionEnvelope.reserve_dispatch(envelope, "upstream-1", :http, 1_000_000)
+
+    assert first.deadline_us == envelope.deadline_us
+
+    assert {:ok, second, 49} =
+             ExecutionEnvelope.reserve_dispatch(first, "upstream-2", :http, 1_051_000)
+
+    assert second.deadline_us == envelope.deadline_us
+
+    assert {:error, :deadline_exhausted} =
+             ExecutionEnvelope.reserve_dispatch(second, "upstream-3", :http, 1_076_000)
+  end
+
+  test "replay-safe work dispatches at most three distinct channels" do
+    envelope = ExecutionEnvelope.new("request-1", "eth_call", 1_000, started_at_us: 0)
+
+    assert {:ok, envelope, _} = ExecutionEnvelope.reserve_dispatch(envelope, "one", :http, 0)
+    assert {:ok, envelope, _} = ExecutionEnvelope.reserve_dispatch(envelope, "two", :http, 0)
+    assert {:ok, envelope, _} = ExecutionEnvelope.reserve_dispatch(envelope, "three", :ws, 0)
+
+    assert {:error, :dispatch_budget_exhausted} =
+             ExecutionEnvelope.reserve_dispatch(envelope, "four", :http, 0)
+  end
+
+  test "a concrete upstream transport is dispatched once" do
+    envelope = ExecutionEnvelope.new("request-1", "eth_call", 1_000, started_at_us: 0)
+    assert {:ok, envelope, _} = ExecutionEnvelope.reserve_dispatch(envelope, "one", :http, 0)
+
+    assert {:error, :duplicate_dispatch} =
+             ExecutionEnvelope.reserve_dispatch(envelope, "one", :http, 0)
+  end
+
+  test "unsafe and unknown methods permit one dispatch" do
+    for method <- [
+          "eth_sendTransaction",
+          "eth_newFilter",
+          "eth_getFilterChanges",
+          "eth_uninstallFilter",
+          "vendor_privateMethod"
+        ] do
+      envelope = ExecutionEnvelope.new(method, method, 1_000, started_at_us: 0)
+      assert {:ok, envelope, _} = ExecutionEnvelope.reserve_dispatch(envelope, "one", :http, 0)
+
+      assert {:error, :dispatch_budget_exhausted} =
+               ExecutionEnvelope.reserve_dispatch(envelope, "two", :http, 0)
+    end
+  end
+
+  test "raw transactions remain single-dispatch until broadcast arbitration owns completion" do
+    envelope = ExecutionEnvelope.new("tx", "eth_sendRawTransaction", 1_000, started_at_us: 0)
+    assert {:ok, envelope, _} = ExecutionEnvelope.reserve_dispatch(envelope, "one", :http, 0)
+
+    assert {:error, :dispatch_budget_exhausted} =
+             ExecutionEnvelope.reserve_dispatch(envelope, "two", :http, 0)
+  end
+
+  test "candidate admission is capped at sixteen" do
+    envelope = ExecutionEnvelope.new("request-1", "eth_call", 1_000, started_at_us: 0)
+
+    envelope =
+      Enum.reduce(1..16, envelope, fn _, current ->
+        assert {:ok, next} = ExecutionEnvelope.admit_candidate(current, 0)
+        next
+      end)
+
+    assert {:error, :candidate_budget_exhausted} = ExecutionEnvelope.admit_candidate(envelope, 0)
+  end
+
+  test "candidate admission stops at the absolute deadline" do
+    envelope = ExecutionEnvelope.new("request-1", "eth_call", 100, started_at_us: 1_000)
+    assert {:error, :deadline_exhausted} = ExecutionEnvelope.admit_candidate(envelope, 101_000)
+  end
+
+  test "zero timeout constructs an expired envelope" do
+    envelope = ExecutionEnvelope.new("request-1", "eth_call", 0, started_at_us: 1_000)
+    assert {:error, :deadline_exhausted} = ExecutionEnvelope.admit_candidate(envelope, 1_000)
+  end
+
+  test "registered non-read work is not assumed replay-safe" do
+    for method <- ["eth_submitWork", "eth_submitHashrate", "eth_accounts"] do
+      assert ExecutionEnvelope.classify(method) == :unknown
+    end
+  end
+end

--- a/test/lasso/core/request/execution_outcome_test.exs
+++ b/test/lasso/core/request/execution_outcome_test.exs
@@ -1,0 +1,101 @@
+defmodule Lasso.RPC.ExecutionOutcomeTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.RPC.ExecutionOutcome
+
+  test "constructs the accepted versioned attempt facts" do
+    outcome =
+      ExecutionOutcome.new(
+        stage: :attempt,
+        cause: :provider_health,
+        completion: :possibly_applied,
+        disposition: :failover,
+        evidence_effect: :reliability_failure,
+        request_id: "request-1",
+        attempt_id: "attempt-1",
+        upstream_instance_id: "instance-1",
+        chain_id: 1,
+        transport: :http,
+        routing_intent: :default,
+        route_generation: 7,
+        circuit_scope: :broad,
+        circuit_epoch: 3,
+        deadline_us: 200,
+        dispatched_at_us: 100,
+        terminal_at_us: 150,
+        censoring_boundary_ms: 50
+      )
+
+    assert outcome.schema_version == 1
+    assert outcome.stage == :attempt
+    assert outcome.completion == :possibly_applied
+  end
+
+  test "admission outcomes cannot claim a dispatch completion" do
+    assert_raise ArgumentError, ~r/admission outcomes must be not_dispatched/, fn ->
+      ExecutionOutcome.new(
+        stage: :admission,
+        cause: :capacity,
+        completion: :responded,
+        disposition: :exhausted,
+        evidence_effect: :capacity_signal,
+        request_id: "request-1",
+        deadline_us: 200,
+        terminal_at_us: 150
+      )
+    end
+  end
+
+  test "attempt outcomes require a unique attempt id" do
+    assert_raise ArgumentError, ~r/attempt outcomes require attempt_id/, fn ->
+      ExecutionOutcome.new(
+        stage: :attempt,
+        cause: :success,
+        completion: :responded,
+        disposition: :returned,
+        evidence_effect: :usable_success,
+        request_id: "request-1",
+        deadline_us: 200,
+        terminal_at_us: 150
+      )
+    end
+  end
+
+  test "shared version-one fixtures validate without reinterpretation" do
+    fixture_path = Path.join(:code.priv_dir(:lasso), "fixtures/execution_outcomes_v1.json")
+    fixtures = fixture_path |> File.read!() |> Jason.decode!()
+
+    assert Enum.map(fixtures, & &1["stage"]) == ["admission", "attempt", "request"]
+
+    for fixture <- fixtures do
+      attrs =
+        fixture
+        |> Map.drop(["schema_version"])
+        |> Map.new(fn
+          {key, value}
+          when key in [
+                 "stage",
+                 "cause",
+                 "completion",
+                 "disposition",
+                 "evidence_effect",
+                 "transport",
+                 "routing_intent",
+                 "circuit_scope"
+               ] ->
+            {String.to_existing_atom(key), String.to_existing_atom(value)}
+
+          {key, value} ->
+            {String.to_existing_atom(key), value}
+        end)
+
+      assert %ExecutionOutcome{schema_version: 1} = ExecutionOutcome.new(Map.to_list(attrs))
+    end
+  end
+
+  test "fixtures declare the supported schema version" do
+    fixture_path = Path.join(:code.priv_dir(:lasso), "fixtures/execution_outcomes_v1.json")
+    fixtures = fixture_path |> File.read!() |> Jason.decode!()
+    assert Enum.all?(fixtures, &(&1["schema_version"] == 1))
+  end
+end

--- a/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
+++ b/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
@@ -80,6 +80,72 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     refute_receive :attempt_dispatched, 100
   end
 
+  test "dispatch receipt survives lifecycle death after deferred confirmation" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    result =
+      CircuitBreaker.call(
+        id,
+        fn ->
+          :ok = AttemptLifecycle.mark_dispatched(AttemptLifecycle.dispatch_context())
+          Process.sleep(:infinity)
+        end,
+        1_000,
+        dispatch: :deferred,
+        on_dispatch: fn dispatched_at_us ->
+          send(test_pid, {:dispatch_receipt, dispatched_at_us})
+          Process.exit(self(), :kill)
+        end
+      )
+
+    assert_receive {:dispatch_receipt, dispatched_at_us}, 1_000
+    assert is_integer(dispatched_at_us)
+    assert {:executed, {:exception, {:exit, :killed, []}}} = result
+  end
+
+  test "repeated deferred confirmation emits one dispatch receipt" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    assert {:executed, :ok} =
+             CircuitBreaker.call(
+               id,
+               fn ->
+                 context = AttemptLifecycle.dispatch_context()
+                 :ok = AttemptLifecycle.mark_dispatched(context)
+                 :ok = AttemptLifecycle.confirm_dispatched(context)
+               end,
+               1_000,
+               dispatch: :deferred,
+               on_dispatch: fn dispatched_at_us ->
+                 send(test_pid, {:dispatch_receipt, dispatched_at_us})
+               end
+             )
+
+    assert_receive {:dispatch_receipt, _dispatched_at_us}, 1_000
+    refute_receive {:dispatch_receipt, _dispatched_at_us}, 100
+  end
+
+  test "immediate dispatch receipt is emitted before the worker becomes runnable" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    assert {:executed, :ok} =
+             CircuitBreaker.call(
+               id,
+               fn ->
+                 send(test_pid, :worker_ran)
+                 :ok
+               end,
+               1_000,
+               on_dispatch: fn _dispatched_at_us -> send(test_pid, :dispatch_receipt) end
+             )
+
+    assert_receive :dispatch_receipt, 1_000
+    assert_receive :worker_ran, 1_000
+  end
+
   test "a completed operation wins over caller death" do
     id = start_half_open_breaker()
     test_pid = self()


### PR DESCRIPTION
## Summary

Implements the first bounded execution slice for #50 and [lasso-cloud#500](https://github.com/jaxernst/lasso-cloud/issues/500):

- establishes one immutable monotonic execution envelope per JSON-RPC item;
- preserves an existing envelope across re-entry instead of resetting deadline or budgets;
- applies a 16-candidate admission ceiling and a conservative positive replay-safe-read classification;
- limits replay-safe work to three distinct upstream/transport dispatches and all unsafe/unknown work to one pending dedicated arbiters;
- refuses dispatch below the 25ms useful-attempt floor and caps the first replay-safe attempt at 60% of the original deadline;
- derives each upstream attempt timeout from the same absolute deadline remainder;
- records dispatch at `AttemptLifecycle`’s irreversible transition, before immediate work becomes runnable or deferred confirmation is returned;
- distinguishes and refunds predispatch circuit/transport rejection without allowing lifecycle-death races to erase confirmed work;
- defines and validates canonical execution outcome v1 facts and deterministic admission/attempt/request fixtures.

## Deliberate boundary

This PR does not claim the whole bounded-execution contract. It does not yet implement raw-transaction concurrent broadcast/arbitration, filter affinity handles, batch fair parallelism, Cloud profile fallback, route-generation propagation, fast ETS circuit admission, single epoch-bearing half-open leases, bulkheads/queueing, or final transport cancellation/overload gates. Raw transactions, filters, upstream-signed methods, subscriptions, and unknown/vendor methods therefore remain single-dispatch.

## Correctness details

- Candidate rejection never consumes a dispatch.
- Duplicate `{instance_id, transport}` candidates are skipped and cannot redispatch.
- Confirmed dispatch survives lifecycle owner death.
- Immediate dispatch receipts precede making the worker runnable.
- Repeated deferred confirmation emits one receipt.
- Zero timeout creates an already-expired envelope.
- Attempt outcomes require bounded route/circuit identity and exactly one I/O duration or censoring observation.
- Dispatch exhaustion preserves the latest truthful upstream error rather than fabricating another attempt.

## Verification

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test` — 1,074 tests, 0 failures, 116 excluded
- `MIX_ENV=test mix credo --strict` — no issues
- `MIX_ENV=test mix dialyzer` — clean
- `git diff --check`

One initial full-suite run hit an existing short recovery-timer race in `CircuitBreakerTest` (`:half_open` observed where the assertion expected transient `:open`). The test passed five isolated seeded reruns and the subsequent full suite passed.

## Independent review

Two required independent reviewers inspected the actual diff through multiple fix loops:

- BEAM/OTP runtime review: **approved**, including immediate/deferred receipt ordering, lifecycle-death accounting, and exactly-once dispatch transition.
- Adversarial distributed-systems review: **approved**, including safety defaults, predispatch accounting, envelope preservation, and outcome fixture/schema truthfulness.

Closes #50 only when the remaining contract slices are merged; this PR is intentionally a reviewable foundation.