### PR TITLE
Correct bounded execution CI and wire contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,40 @@ jobs:
         run: mix format --check-formatted
 
       - name: Run tests
-        # Integration tests are opt-in because they exercise external providers.
-        # Keep the PR gate deterministic; run them explicitly when validating
-        # provider integrations.
         run: mix test
+
+  integration:
+    name: Hermetic Integration Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: "1.18.4"
+          otp-version: "28.0"
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: deps
+          key: ${{ runner.os }}-deps-v2-${{ hashFiles('**/mix.lock') }}
+
+      - name: Cache build
+        uses: actions/cache@v4
+        with:
+          path: _build
+          key: ${{ runner.os }}-build-integration-28.0-1.18.4-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-build-integration-28.0-1.18.4-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Run hermetic integration tests
+        run: mix test --include integration
 
   lint:
     name: Lint (Credo)

--- a/docs/ROUTING.md
+++ b/docs/ROUTING.md
@@ -184,7 +184,7 @@ After tiering, Lasso attempts providers sequentially until success or all provid
 
 **Failure**: Provider is skipped and the next provider in the list is tried. Failures increment circuit breaker counters.
 
-**All Exhausted**: Returns `503 Service Unavailable` with details about which providers were tried and why they failed.
+**All Exhausted**: Returns HTTP `200 OK` with a standard JSON-RPC error response. The error uses code `-32000`, preserves the client's request ID, and does not expose internal provider-attempt details.
 
 See [API_REFERENCE.md](API_REFERENCE.md#error-responses) for error format details.
 

--- a/lib/lasso/core/request/request_context.ex
+++ b/lib/lasso/core/request/request_context.ex
@@ -147,7 +147,7 @@ defmodule Lasso.RPC.RequestContext do
 
   These are immutable throughout the pipeline execution:
   - rpc_request: The JSON-RPC request map being executed
-  - timeout_ms: Per-attempt timeout in milliseconds
+  - timeout_ms: Total request-envelope timeout in milliseconds
   - opts: The RequestOptions struct with routing configuration
   """
   @spec set_execution_params(t(), map(), integer(), RequestOptions.t()) :: t()

--- a/lib/lasso/core/request/request_options_builder.ex
+++ b/lib/lasso/core/request/request_options_builder.ex
@@ -72,7 +72,7 @@ defmodule Lasso.RPC.RequestOptions.Builder do
   - `:provider_override` / `:provider_id` - Force specific provider
   - `:transport` - Transport preference (:http, :ws, :both)
   - `:failover_on_override` - Retry on other providers if override fails (default: false)
-  - `:timeout_ms` - Per-attempt timeout (default: method-specific)
+  - `:timeout_ms` - Total request-envelope timeout (default: method-specific)
   - `:request_id` - Request tracing ID
   - `:request_context` - RequestContext for observability
 

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -66,7 +66,7 @@ defmodule Lasso.RPC.RequestPipeline do
   - `provider_override` - Force specific provider (optional)
   - `transport` - Transport preference (:http, :ws, :both)
   - `failover_on_override` - Retry on other providers if override fails
-  - `timeout_ms` - Per-attempt timeout in milliseconds
+  - `timeout_ms` - Total request-envelope timeout in milliseconds
   - `request_id` - Request tracing ID (optional)
   - `request_context` - Pre-created RequestContext (optional)
 

--- a/test/integration/attempt_evidence_integration_test.exs
+++ b/test/integration/attempt_evidence_integration_test.exs
@@ -246,7 +246,7 @@ defmodule Lasso.RPC.AttemptEvidenceIntegrationTest do
 
     assert event.metadata.outcome == :timeout
     assert event.metadata.censored
-    assert event.measurements.duration_ms >= 50
+    assert event.measurements.duration_ms >= 30
     assert event.measurements.duration_ms < 100
   end
 

--- a/test/lasso_web/controllers/rpc_controller_test.exs
+++ b/test/lasso_web/controllers/rpc_controller_test.exs
@@ -18,3 +18,57 @@ defmodule LassoWeb.RPCControllerTest do
     # StatusController was removed - status endpoint functionality moved elsewhere
   end
 end
+
+defmodule LassoWeb.RPCControllerWireContractTest do
+  use Lasso.Test.LassoIntegrationCase
+
+  import Phoenix.ConnTest
+
+  @endpoint LassoWeb.Endpoint
+
+  describe "JSON-RPC wire contract" do
+    test "provider exhaustion returns an HTTP 200 JSON-RPC error with the client ID", %{
+      chain: chain
+    } do
+      setup_providers([
+        %{id: "unavailable", priority: 10, behavior: :healthy, profile: "public"}
+      ])
+
+      instance_id = Lasso.Providers.Catalog.lookup_instance_id("public", chain, "unavailable")
+      Lasso.Test.CircuitBreakerHelper.force_open({instance_id, :http})
+
+      request = %{
+        "jsonrpc" => "2.0",
+        "method" => "eth_blockNumber",
+        "params" => [],
+        "id" => "client-request-42"
+      }
+
+      conn = post(build_conn(), "/rpc/#{chain}", request)
+
+      assert conn.status == 200
+
+      body = json_response(conn, 200)
+
+      assert Map.keys(body) |> Enum.sort() == ["error", "id", "jsonrpc"]
+      assert Map.keys(body["error"]) |> Enum.sort() == ["code", "data", "message"]
+      assert Map.keys(body["error"]["data"]) == ["retry_after_ms"]
+
+      assert %{
+               "jsonrpc" => "2.0",
+               "id" => "client-request-42",
+               "error" => %{
+                 "code" => -32_000,
+                 "message" => message,
+                 "data" => %{"retry_after_ms" => retry_after_ms}
+               }
+             } = body
+
+      assert is_integer(retry_after_ms) and retry_after_ms > 0
+
+      assert message ==
+               "No available channels for method: eth_blockNumber. All circuits open, " <>
+                 "retry after #{div(retry_after_ms, 1_000)}s"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- add a separately visible required hermetic integration job running `mix test --include integration`
- correct the first replay-safe attempt censoring boundary to the accepted 60% slice
- document `timeout_ms` as the total request envelope across the public request APIs
- reconcile routing documentation with JSON-RPC-over-HTTP 200 exhaustion behavior
- pin exhaustion status, JSON-RPC error shape/code, and client ID preservation at the HTTP endpoint

This is the isolated CI/public-contract correction slice for lasso-cloud#500 and follows the accepted lasso-cloud#528 runtime boundary. It does not change runtime ownership or transport behavior.

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix test --include integration` — 1,075 tests, 0 failures
- `mix dialyzer` — passed (24 existing warnings skipped)
- `mix hex.audit` — passed with two repository-ignored cowlib advisories
- clean Docker build and `/api/health` boot
- independent read-only review; all low-severity findings resolved

Tracking: jaxernst/lasso-cloud#500, #50
