### PR TITLE
Add fast breaker admission and bounded control

### DIFF
--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -5,6 +5,8 @@ defmodule Lasso.Application do
 
   use Application
 
+  alias Lasso.Core.Support.CircuitBreaker.Storage, as: CircuitBreakerStorage
+
   @impl true
   def start(_type, _args) do
     # Store application start time for uptime calculation
@@ -30,6 +32,8 @@ defmodule Lasso.Application do
       read_concurrency: true,
       write_concurrency: true
     ])
+
+    CircuitBreakerStorage.create_tables!()
 
     :ets.new(:block_sync_registry, [
       :set,

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -352,6 +352,7 @@ defmodule Lasso.RPC.RequestPipeline do
         instance_id,
         ctx.rpc_request,
         attempt_timeout_ms,
+        ctx.execution_envelope.deadline_us,
         on_terminal,
         on_dispatch
       )
@@ -435,10 +436,10 @@ defmodule Lasso.RPC.RequestPipeline do
         ctx = RequestContext.increment_retries(ctx)
         attempt_channels(rest_channels, ctx)
 
-      {:rejected, :not_found} ->
-        Observability.record_admission_rejection(ctx, channel, :circuit_breaker_not_found)
+      {:rejected, :admission_unavailable} ->
+        Observability.record_admission_rejection(ctx, channel, :admission_unavailable)
 
-        Logger.error("Circuit breaker not found",
+        Logger.error("Circuit breaker admission unavailable",
           channel: Channel.to_string(channel),
           request_id: ctx.request_id
         )
@@ -649,6 +650,7 @@ defmodule Lasso.RPC.RequestPipeline do
           String.t(),
           map(),
           timeout(),
+          integer(),
           CircuitBreaker.terminal_callback(),
           (integer() -> term())
         ) ::
@@ -658,6 +660,7 @@ defmodule Lasso.RPC.RequestPipeline do
          instance_id,
          rpc_request,
          timeout,
+         deadline_us,
          on_terminal,
          on_dispatch
        ) do
@@ -665,6 +668,7 @@ defmodule Lasso.RPC.RequestPipeline do
     cb_id = {instance_id, channel.transport}
 
     CircuitBreaker.call(cb_id, attempt_fun, timeout,
+      deadline_us: deadline_us,
       on_terminal: on_terminal,
       on_dispatch: on_dispatch,
       dispatch: dispatch_mode(channel.transport_module)

--- a/lib/lasso/core/support/attempt_lifecycle.ex
+++ b/lib/lasso/core/support/attempt_lifecycle.ex
@@ -251,14 +251,21 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
     case claim_receipt(context.receipt, context.caller_pid) do
       :ok ->
-        if Process.alive?(context.caller_pid) do
+        if Process.alive?(context.caller_pid) and
+             System.monotonic_time(:microsecond) < context.deadline_us do
           start_attempt(Map.put(context, :caller_monitor, caller_monitor))
         else
           release_receipt(context.receipt)
+
+          send(context.caller_pid, {
+            context.lifecycle_ref,
+            {:__attempt_lifecycle_rejected__, :timeout}
+          })
         end
 
       {:error, reason} ->
         Process.demonitor(caller_monitor, [:flush])
+        abandon_unclaimed_receipt(context.receipt, context.caller_pid)
 
         send(context.caller_pid, {
           context.lifecycle_ref,
@@ -354,9 +361,7 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         handle_task_death(state, reason)
 
       {:attempt_caller_timeout, lifecycle_ref} when lifecycle_ref == state.lifecycle_ref ->
-        if is_nil(state.pending_terminal),
-          do: handle_interruption(state, :timeout),
-          else: loop(state)
+        loop(state)
     after
       remaining_timeout(state) ->
         handle_interruption(state, :timeout)
@@ -485,11 +490,14 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   end
 
   defp handle_interruption(%{phase: {:dispatching, _}} = state, terminal) do
-    loop(%{
+    loop(
       state
-      | pending_terminal: terminal,
-        settle_deadline_us: System.monotonic_time(:microsecond) + @dispatch_settle_timeout * 1_000
-    })
+      |> Map.put(:pending_terminal, terminal)
+      |> Map.put(
+        :settle_deadline_us,
+        System.monotonic_time(:microsecond) + @dispatch_settle_timeout * 1_000
+      )
+    )
   end
 
   defp handle_interruption(%{phase: :predispatch} = state, :caller_down) do
@@ -668,13 +676,11 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     max(System.monotonic_time(:microsecond) - dispatched_at_us, 0) / 1000
   end
 
-  defp remaining_timeout(%{pending_terminal: nil, deadline_us: deadline_us}) do
-    remaining_ms(deadline_us, 0)
-  end
-
-  defp remaining_timeout(%{settle_deadline_us: settle_deadline_us})
-       when is_integer(settle_deadline_us) do
-    remaining_ms(settle_deadline_us, 1)
+  defp remaining_timeout(state) do
+    case Map.fetch(state, :settle_deadline_us) do
+      {:ok, settle_deadline_us} -> remaining_ms(settle_deadline_us, 1)
+      :error -> remaining_ms(state.deadline_us, 0)
+    end
   end
 
   defp remaining_ms(deadline_us, minimum) do
@@ -687,10 +693,10 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   defp claim_receipt(%AdmissionReceipt{kind: :closed}, _caller_pid), do: :ok
 
   defp claim_receipt(
-         %AdmissionReceipt{kind: :half_open, breaker_id: id, token: token},
+         %AdmissionReceipt{kind: :half_open, breaker_id: id, token: token} = receipt,
          caller_pid
        ) do
-    CircuitBreaker.claim_attempt(id, token, caller_pid)
+    CircuitBreaker.claim_attempt(id, token, caller_pid, receipt)
   end
 
   defp claim_receipt(%AdmissionReceipt{kind: :legacy, breaker_id: id, token: token}, caller_pid) do
@@ -718,6 +724,12 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   defp release_receipt(%AdmissionReceipt{kind: :legacy, breaker_id: id, token: token}) do
     CircuitBreaker.release_attempt(id, token)
   end
+
+  defp abandon_unclaimed_receipt(%AdmissionReceipt{kind: :half_open} = receipt, caller_pid) do
+    CircuitBreaker.abandon_unclaimed(receipt, caller_pid)
+  end
+
+  defp abandon_unclaimed_receipt(_receipt, _caller_pid), do: :ok
 
   defp legacy_receipt(breaker_id, token) do
     %AdmissionReceipt{

--- a/lib/lasso/core/support/attempt_lifecycle.ex
+++ b/lib/lasso/core/support/attempt_lifecycle.ex
@@ -4,6 +4,7 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   require Logger
 
   alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.CircuitBreaker.AdmissionReceipt
   alias Lasso.JSONRPC.Error, as: JError
 
   @dispatch_context_key :lasso_attempt_dispatch_context
@@ -15,6 +16,18 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
   @spec run(
           pid(),
+          AdmissionReceipt.t(),
+          (-> term()),
+          non_neg_integer(),
+          terminal_callback()
+        ) :: term()
+  def run(caller_pid, receipt, fun, timeout, terminal_callback) do
+    run(caller_pid, receipt, fun, timeout, terminal_callback, nil, :immediate)
+  end
+
+  @doc false
+  @spec run(
+          pid(),
           CircuitBreaker.breaker_id(),
           reference(),
           (-> term()),
@@ -22,9 +35,102 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
           terminal_callback()
         ) :: term()
   def run(caller_pid, breaker_id, token, fun, timeout, terminal_callback) do
-    run(caller_pid, breaker_id, token, fun, timeout, terminal_callback, nil, :immediate)
+    receipt = legacy_receipt(breaker_id, token)
+    run(caller_pid, receipt, fun, timeout, terminal_callback, nil, :immediate)
   end
 
+  @spec run(
+          pid(),
+          AdmissionReceipt.t(),
+          (-> term()),
+          non_neg_integer(),
+          terminal_callback(),
+          dispatch_callback(),
+          :immediate | :deferred
+        ) :: term()
+  def run(
+        caller_pid,
+        %AdmissionReceipt{} = receipt,
+        fun,
+        timeout,
+        terminal_callback,
+        dispatch_callback,
+        dispatch_mode
+      ) do
+    deadline_us = System.monotonic_time(:microsecond) + timeout * 1_000
+
+    run(
+      caller_pid,
+      receipt,
+      fun,
+      timeout,
+      terminal_callback,
+      dispatch_callback,
+      dispatch_mode,
+      deadline_us
+    )
+  end
+
+  @doc false
+  def run(caller_pid, breaker_id, token, fun, timeout, terminal_callback, dispatch_mode) do
+    receipt = legacy_receipt(breaker_id, token)
+    run(caller_pid, receipt, fun, timeout, terminal_callback, nil, dispatch_mode)
+  end
+
+  @doc false
+  @spec run(
+          pid(),
+          AdmissionReceipt.t(),
+          (-> term()),
+          non_neg_integer(),
+          terminal_callback(),
+          dispatch_callback(),
+          :immediate | :deferred,
+          integer()
+        ) :: term()
+  def run(
+        caller_pid,
+        %AdmissionReceipt{} = receipt,
+        fun,
+        timeout,
+        terminal_callback,
+        dispatch_callback,
+        dispatch_mode,
+        deadline_us
+      ) do
+    lifecycle_ref = make_ref()
+
+    {lifecycle_pid, monitor_ref} =
+      spawn_monitor(fn ->
+        execute(%{
+          caller_pid: caller_pid,
+          lifecycle_ref: lifecycle_ref,
+          receipt: receipt,
+          breaker_id: receipt.breaker_id,
+          fun: fun,
+          timeout: timeout,
+          terminal_callback: terminal_callback,
+          dispatch_callback: dispatch_callback,
+          dispatch_mode: dispatch_mode,
+          deadline_us: deadline_us
+        })
+      end)
+
+    receive do
+      {^lifecycle_ref, result} ->
+        Process.demonitor(monitor_ref, [:flush])
+        result
+
+      {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, reason} ->
+        {:exception, {:exit, reason, []}}
+    after
+      timeout + 5_000 ->
+        Process.exit(lifecycle_pid, :kill)
+        {:exception, {:exit, :attempt_lifecycle_timeout, []}}
+    end
+  end
+
+  @doc false
   @spec run(
           pid(),
           CircuitBreaker.breaker_id(),
@@ -43,37 +149,10 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         timeout,
         terminal_callback,
         dispatch_callback,
-        dispatch_mode \\ :immediate
+        dispatch_mode
       ) do
-    lifecycle_ref = make_ref()
-
-    {lifecycle_pid, monitor_ref} =
-      spawn_monitor(fn ->
-        execute(%{
-          caller_pid: caller_pid,
-          lifecycle_ref: lifecycle_ref,
-          breaker_id: breaker_id,
-          token: token,
-          fun: fun,
-          timeout: timeout,
-          terminal_callback: terminal_callback,
-          dispatch_callback: dispatch_callback,
-          dispatch_mode: dispatch_mode
-        })
-      end)
-
-    receive do
-      {^lifecycle_ref, result} ->
-        Process.demonitor(monitor_ref, [:flush])
-        result
-
-      {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, reason} ->
-        {:exception, {:exit, reason, []}}
-    after
-      timeout + 5_000 ->
-        Process.exit(lifecycle_pid, :kill)
-        {:exception, {:exit, :attempt_lifecycle_timeout, []}}
-    end
+    receipt = legacy_receipt(breaker_id, token)
+    run(caller_pid, receipt, fun, timeout, terminal_callback, dispatch_callback, dispatch_mode)
   end
 
   @doc false
@@ -169,12 +248,12 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     Process.flag(:trap_exit, true)
     caller_monitor = Process.monitor(context.caller_pid)
 
-    case CircuitBreaker.claim_attempt(context.breaker_id, context.token, context.caller_pid) do
+    case claim_receipt(context.receipt, context.caller_pid) do
       :ok ->
         if Process.alive?(context.caller_pid) do
           start_attempt(Map.put(context, :caller_monitor, caller_monitor))
         else
-          CircuitBreaker.release_attempt(context.breaker_id, context.token)
+          release_receipt(context.receipt)
         end
 
       {:error, reason} ->
@@ -216,7 +295,6 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         task_monitor: task_monitor,
         phase: phase,
         started_at_us: System.monotonic_time(:microsecond),
-        deadline_us: System.monotonic_time(:microsecond) + context.timeout * 1_000,
         pending_terminal: nil,
         pending_result: nil
       })
@@ -410,12 +488,12 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
   defp handle_interruption(%{phase: :predispatch} = state, :caller_down) do
     stop_task(state)
-    CircuitBreaker.release_attempt(state.breaker_id, state.token)
+    release_receipt(state.receipt)
   end
 
   defp handle_interruption(%{phase: :aborted} = state, :caller_down) do
     stop_task(state)
-    CircuitBreaker.release_attempt(state.breaker_id, state.token)
+    release_receipt(state.receipt)
   end
 
   defp handle_interruption(%{phase: :predispatch} = state, :timeout) do
@@ -465,7 +543,7 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
              breaker_penalty?: false
            ), elapsed_ms}
 
-        CircuitBreaker.report_attempt(state.breaker_id, state.token, cancellation)
+        report_receipt(state.receipt, cancellation)
         invoke_terminal_callback(state.terminal_callback, cancellation, elapsed_ms)
 
       :none ->
@@ -509,17 +587,13 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   end
 
   defp finalize_predispatch(state, result) do
-    CircuitBreaker.release_attempt(state.breaker_id, state.token)
+    release_receipt(state.receipt)
     Process.demonitor(state.caller_monitor, [:flush])
     send(state.caller_pid, {state.lifecycle_ref, result})
   end
 
   defp finalize_dispatched(state, result, elapsed_ms) do
-    CircuitBreaker.report_attempt(
-      state.breaker_id,
-      state.token,
-      breaker_result(result, state.terminal_callback)
-    )
+    report_receipt(state.receipt, breaker_result(result, state.terminal_callback))
 
     Process.demonitor(state.caller_monitor, [:flush])
     invoke_terminal_callback(state.terminal_callback, result, elapsed_ms)
@@ -599,6 +673,47 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   defp remaining_ms(deadline_us, minimum) do
     remaining_us = max(deadline_us - System.monotonic_time(:microsecond), 0)
     max(div(remaining_us + 999, 1_000), minimum)
+  end
+
+  defp claim_receipt(%AdmissionReceipt{kind: :closed}, _caller_pid), do: :ok
+
+  defp claim_receipt(%AdmissionReceipt{kind: :half_open}, _caller_pid), do: :ok
+
+  defp claim_receipt(%AdmissionReceipt{kind: :legacy, breaker_id: id, token: token}, caller_pid) do
+    CircuitBreaker.claim_attempt(id, token, caller_pid)
+  end
+
+  defp report_receipt(%AdmissionReceipt{kind: :closed} = receipt, result) do
+    CircuitBreaker.report_closed(receipt, result)
+  end
+
+  defp report_receipt(%AdmissionReceipt{kind: :half_open} = receipt, result) do
+    CircuitBreaker.report_half_open(receipt, result)
+  end
+
+  defp report_receipt(%AdmissionReceipt{kind: :legacy, breaker_id: id, token: token}, result) do
+    CircuitBreaker.report_attempt(id, token, result)
+  end
+
+  defp release_receipt(%AdmissionReceipt{kind: :closed}), do: :ok
+
+  defp release_receipt(%AdmissionReceipt{kind: :half_open} = receipt) do
+    CircuitBreaker.release_half_open(receipt)
+  end
+
+  defp release_receipt(%AdmissionReceipt{kind: :legacy, breaker_id: id, token: token}) do
+    CircuitBreaker.release_attempt(id, token)
+  end
+
+  defp legacy_receipt(breaker_id, token) do
+    %AdmissionReceipt{
+      breaker_id: breaker_id,
+      kind: :legacy,
+      generation: 0,
+      epoch: 1,
+      owner_pid: self(),
+      token: token
+    }
   end
 
   defp invoke_terminal_callback(nil, _result, _elapsed_ms), do: :ok

--- a/lib/lasso/core/support/attempt_lifecycle.ex
+++ b/lib/lasso/core/support/attempt_lifecycle.ex
@@ -124,9 +124,10 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
       {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, reason} ->
         {:exception, {:exit, reason, []}}
     after
-      timeout + 5_000 ->
-        Process.exit(lifecycle_pid, :kill)
-        {:exception, {:exit, :attempt_lifecycle_timeout, []}}
+      deadline_wait_ms(deadline_us) ->
+        send(lifecycle_pid, {:attempt_caller_timeout, lifecycle_ref})
+        Process.demonitor(monitor_ref, [:flush])
+        {:__attempt_lifecycle_rejected__, :timeout}
     end
   end
 
@@ -351,6 +352,11 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
       {:EXIT, task_pid, reason} when task_pid == state.task_pid ->
         handle_task_death(state, reason)
+
+      {:attempt_caller_timeout, lifecycle_ref} when lifecycle_ref == state.lifecycle_ref ->
+        if is_nil(state.pending_terminal),
+          do: handle_interruption(state, :timeout),
+          else: loop(state)
     after
       remaining_timeout(state) ->
         handle_interruption(state, :timeout)
@@ -482,7 +488,7 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     loop(%{
       state
       | pending_terminal: terminal,
-        deadline_us: System.monotonic_time(:microsecond) + @dispatch_settle_timeout * 1_000
+        settle_deadline_us: System.monotonic_time(:microsecond) + @dispatch_settle_timeout * 1_000
     })
   end
 
@@ -666,8 +672,9 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     remaining_ms(deadline_us, 0)
   end
 
-  defp remaining_timeout(%{deadline_us: deadline_us}) do
-    remaining_ms(deadline_us, 1)
+  defp remaining_timeout(%{settle_deadline_us: settle_deadline_us})
+       when is_integer(settle_deadline_us) do
+    remaining_ms(settle_deadline_us, 1)
   end
 
   defp remaining_ms(deadline_us, minimum) do
@@ -675,9 +682,16 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     max(div(remaining_us + 999, 1_000), minimum)
   end
 
+  defp deadline_wait_ms(deadline_us), do: remaining_ms(deadline_us, 0)
+
   defp claim_receipt(%AdmissionReceipt{kind: :closed}, _caller_pid), do: :ok
 
-  defp claim_receipt(%AdmissionReceipt{kind: :half_open}, _caller_pid), do: :ok
+  defp claim_receipt(
+         %AdmissionReceipt{kind: :half_open, breaker_id: id, token: token},
+         caller_pid
+       ) do
+    CircuitBreaker.claim_attempt(id, token, caller_pid)
+  end
 
   defp claim_receipt(%AdmissionReceipt{kind: :legacy, breaker_id: id, token: token}, caller_pid) do
     CircuitBreaker.claim_attempt(id, token, caller_pid)

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -40,6 +40,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   use GenServer
   require Logger
   alias Lasso.Core.Support.{AttemptLifecycle, ErrorNormalizer}
+  alias Lasso.Core.Support.CircuitBreaker.Snapshot
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.Catalog
 
@@ -57,7 +58,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     :success_count,
     :config,
     inflight_count: 0,
-    half_open_max_inflight: 3,
+    half_open_max_inflight: 1,
     opened_by_category: nil,
     recovery_timer_ref: nil,
     last_open_error: nil,
@@ -67,6 +68,9 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     effective_recovery_delay: nil,
     recovery_timer_gen: 0,
     transition_generation: 0,
+    process_epoch: nil,
+    ready?: false,
+    control_health: :healthy,
     shared_mode: false,
     inflight_attempts: %{}
   ]
@@ -453,7 +457,19 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       Map.get(config, :category_recovery_timeouts, %{})
       |> Map.merge(default_category_recovery_timeouts, fn _k, v1, _v2 -> v1 end)
 
-    half_open_max_inflight = Map.get(config, :half_open_max_inflight, 3)
+    half_open_max_inflight = 1
+
+    previous_snapshot =
+      case Snapshot.lookup({instance_id, transport}) do
+        {:ok, snapshot} -> snapshot
+        :missing -> nil
+      end
+
+    {initial_state, transition_generation, control_health} =
+      case previous_snapshot do
+        nil -> {:closed, 1, :healthy}
+        %Snapshot{generation: generation} -> {:half_open, generation + 1, :degraded}
+      end
 
     state = %__MODULE__{
       instance_id: instance_id,
@@ -465,13 +481,16 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       category_recovery_timeouts: category_recovery_timeouts,
       half_open_max_inflight: half_open_max_inflight,
       inflight_count: 0,
-      state: :closed,
+      state: initial_state,
       failure_count: 0,
       last_failure_time: nil,
       success_count: 0,
       config: config,
       max_recovery_timeout: Map.get(config, :max_recovery_timeout, 600_000),
-      transition_generation: 0,
+      transition_generation: transition_generation,
+      process_epoch: System.unique_integer([:positive, :monotonic]),
+      ready?: true,
+      control_health: control_health,
       shared_mode: Map.get(config, :shared_mode, false),
       inflight_attempts: %{}
     }
@@ -1159,9 +1178,23 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         recovery_deadline_ms: state.recovery_deadline_ms
       }
     })
-  rescue
-    ArgumentError -> :ok
+
+    Snapshot.put(%Snapshot{
+      breaker_id: {state.instance_id, state.transport},
+      state: state.state,
+      generation: state.transition_generation,
+      epoch: state.process_epoch,
+      owner_pid: self(),
+      ready?: state.ready?,
+      recovery_deadline_us: recovery_deadline_us(state.recovery_deadline_ms),
+      half_open_capacity: state.half_open_max_inflight,
+      half_open_inflight: state.inflight_count,
+      control_health: state.control_health
+    })
   end
+
+  defp recovery_deadline_us(nil), do: nil
+  defp recovery_deadline_us(deadline_ms), do: deadline_ms * 1_000
 
   defp publish_circuit_event(state, from, to, reason, error \\ nil) do
     error_info =

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -237,10 +237,29 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @doc false
-  @spec claim_attempt(breaker_id(), binary() | reference(), pid()) ::
+  @spec claim_attempt(breaker_id(), reference(), pid()) ::
           :ok | {:error, :not_found | :token_not_found | :owner_mismatch | :timeout}
   def claim_attempt(id, token, caller_pid) do
     GenServer.call(via_name(id), {:claim_attempt, token, caller_pid}, @attempt_state_timeout)
+  catch
+    :exit, {:timeout, _} -> {:error, :timeout}
+    :exit, {:noproc, _} -> {:error, :not_found}
+    :exit, {:normal, _} -> {:error, :not_found}
+    :exit, _reason -> {:error, :not_found}
+  end
+
+  @doc false
+  @spec claim_attempt(breaker_id(), binary() | reference(), pid(), AdmissionReceipt.t()) ::
+          :ok | {:error, :not_found | :token_not_found | :owner_mismatch | :timeout}
+  def claim_attempt(id, token, caller_pid, receipt) do
+    now_us = System.monotonic_time(:microsecond)
+    timeout_ms = max(div(receipt.deadline_us - now_us + 999, 1_000), 1)
+
+    GenServer.call(
+      via_name(id),
+      {:claim_attempt, token, caller_pid, receipt.generation, receipt.epoch, receipt.deadline_us},
+      timeout_ms
+    )
   catch
     :exit, {:timeout, _} -> {:error, :timeout}
     :exit, {:noproc, _} -> {:error, :not_found}
@@ -269,7 +288,10 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @doc false
   @spec report_half_open(AdmissionReceipt.t(), term()) :: :ok
   def report_half_open(%AdmissionReceipt{kind: :half_open} = receipt, result) do
-    GenServer.cast(via_name(receipt.breaker_id), {:report, receipt.token, result})
+    GenServer.cast(
+      via_name(receipt.breaker_id),
+      {:report, receipt.token, receipt.generation, receipt.epoch, result}
+    )
   end
 
   @doc false
@@ -286,7 +308,20 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @doc false
   @spec release_half_open(AdmissionReceipt.t()) :: :ok
   def release_half_open(%AdmissionReceipt{kind: :half_open} = receipt) do
-    GenServer.cast(via_name(receipt.breaker_id), {:release, receipt.token})
+    GenServer.cast(
+      via_name(receipt.breaker_id),
+      {:release, receipt.token, receipt.generation, receipt.epoch}
+    )
+  end
+
+  @doc false
+  def abandon_unclaimed(%AdmissionReceipt{kind: :half_open} = receipt, caller_pid) do
+    delete_unclaimed_lease(receipt, caller_pid)
+
+    GenServer.cast(
+      via_name(receipt.breaker_id),
+      {:abandon_unclaimed, receipt.token, receipt.generation, receipt.epoch, caller_pid}
+    )
   end
 
   defp execute_with_receipt(
@@ -535,11 +570,27 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       inflight_attempts: %{}
     }
 
-    state = recover_persisted_lease(state)
+    state = state |> recover_persisted_lease() |> restore_recovery_timer()
     initialize_control_ring(state)
     write_ets_state(state)
 
-    {:ok, state}
+    {:ok, state, {:continue, :reconcile_persisted_lease}}
+  end
+
+  @impl true
+  def handle_continue(:reconcile_persisted_lease, state) do
+    breaker_id = {state.instance_id, state.transport}
+
+    new_state =
+      Enum.reduce(state.inflight_attempts, state, fn {token, _attempt}, current_state ->
+        case :ets.lookup(Storage.lease_table(), breaker_id) do
+          [{^breaker_id, %{token: ^token}}] -> current_state
+          _ -> apply_attempt_release(current_state, token)
+        end
+      end)
+
+    write_ets_state(new_state)
+    {:noreply, new_state}
   end
 
   @impl true
@@ -550,6 +601,31 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @impl true
   def handle_call({:admit, now_ms, deadline_us}, from, state) do
     handle_admission(now_ms, deadline_us, from, state)
+  end
+
+  @impl true
+  def handle_call({:claim_attempt, token, caller_pid}, {lifecycle_pid, _tag}, state) do
+    case Map.fetch(state.inflight_attempts, token) do
+      {:ok, %{owner_pid: ^caller_pid, owner_monitor: owner_monitor} = attempt} ->
+        Process.demonitor(owner_monitor, [:flush])
+        lifecycle_monitor = Process.monitor(lifecycle_pid)
+
+        claimed_attempt = %{
+          attempt
+          | owner_pid: lifecycle_pid,
+            owner_monitor: lifecycle_monitor,
+            claimed?: true
+        }
+
+        attempts = Map.put(state.inflight_attempts, token, claimed_attempt)
+        {:reply, :ok, %{state | inflight_attempts: attempts}}
+
+      {:ok, _attempt} ->
+        {:reply, {:error, :owner_mismatch}, state}
+
+      :error ->
+        {:reply, {:error, :token_not_found}, state}
+    end
   end
 
   @impl true
@@ -580,7 +656,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       true ->
         admitted_state = prepare_exceptional_generation(state)
 
-        case persist_exceptional_lease(admitted_state, token, owner_pid) do
+        case persist_exceptional_lease(admitted_state, token, owner_pid, deadline_us) do
           {:ok, receipt, new_state} ->
             write_ets_state(new_state)
             {:reply, {:ok, receipt}, new_state}
@@ -629,29 +705,42 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @impl true
-  def handle_call({:claim_attempt, token, caller_pid}, {lifecycle_pid, _tag}, state) do
-    case Map.fetch(state.inflight_attempts, token) do
-      {:ok, %{owner_pid: ^caller_pid, owner_monitor: owner_monitor} = attempt} ->
-        Process.demonitor(owner_monitor, [:flush])
-        lifecycle_monitor = Process.monitor(lifecycle_pid)
+  def handle_call(
+        {:claim_attempt, token, caller_pid, expected_generation, expected_epoch, deadline_us},
+        {lifecycle_pid, _tag},
+        state
+      ) do
+    cond do
+      System.monotonic_time(:microsecond) >= deadline_us ->
+        {:reply, {:error, :timeout}, state}
 
-        claimed_attempt = %{
-          attempt
-          | owner_pid: lifecycle_pid,
-            owner_monitor: lifecycle_monitor,
-            claimed?: true
-        }
+      expected_generation != state.transition_generation or
+          expected_epoch != state.process_epoch ->
+        {:reply, {:error, :not_found}, state}
 
-        attempts = Map.put(state.inflight_attempts, token, claimed_attempt)
-        persist_claimed_owner({state.instance_id, state.transport}, token, lifecycle_pid)
+      true ->
+        case Map.fetch(state.inflight_attempts, token) do
+          {:ok, %{owner_pid: ^caller_pid, owner_monitor: owner_monitor} = attempt} ->
+            persist_claimed_owner({state.instance_id, state.transport}, token, lifecycle_pid)
+            Process.demonitor(owner_monitor, [:flush])
+            lifecycle_monitor = Process.monitor(lifecycle_pid)
 
-        {:reply, :ok, %{state | inflight_attempts: attempts}}
+            claimed_attempt = %{
+              attempt
+              | owner_pid: lifecycle_pid,
+                owner_monitor: lifecycle_monitor,
+                claimed?: true
+            }
 
-      {:ok, _attempt} ->
-        {:reply, {:error, :owner_mismatch}, state}
+            attempts = Map.put(state.inflight_attempts, token, claimed_attempt)
+            {:reply, :ok, %{state | inflight_attempts: attempts}}
 
-      :error ->
-        {:reply, {:error, :token_not_found}, state}
+          {:ok, _attempt} ->
+            {:reply, {:error, :owner_mismatch}, state}
+
+          :error ->
+            {:reply, {:error, :token_not_found}, state}
+        end
     end
   end
 
@@ -727,8 +816,22 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @impl true
-  def handle_cast({:report, token, result}, state) do
-    new_state = apply_attempt_report(state, token, result)
+  def handle_cast({:report, token, generation, epoch, result}, state) do
+    new_state = apply_attempt_report(state, token, generation, epoch, result)
+    write_ets_state(new_state)
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_cast({:release, token, generation, epoch}, state) do
+    new_state = apply_attempt_release(state, token, generation, epoch)
+    write_ets_state(new_state)
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_cast({:abandon_unclaimed, token, generation, epoch, caller_pid}, state) do
+    new_state = abandon_unclaimed_attempt(state, token, generation, epoch, caller_pid)
     write_ets_state(new_state)
     {:noreply, new_state}
   end
@@ -952,14 +1055,15 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     }
   end
 
-  defp persist_exceptional_lease(state, token, owner_pid) do
+  defp persist_exceptional_lease(state, token, owner_pid, deadline_us) do
     breaker_id = {state.instance_id, state.transport}
 
     lease = %{
       token: token,
       owner_pid: owner_pid,
       generation: state.transition_generation,
-      epoch: state.process_epoch
+      epoch: state.process_epoch,
+      claimed?: false
     }
 
     if :ets.insert_new(Storage.lease_table(), {breaker_id, lease}) do
@@ -972,7 +1076,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         epoch: state.process_epoch,
         owner_pid: owner_pid,
         owner_monitor: owner_monitor,
-        claimed?: true
+        claimed?: false
       }
 
       new_state = %{
@@ -987,7 +1091,8 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         generation: state.transition_generation,
         epoch: state.process_epoch,
         owner_pid: self(),
-        token: token
+        token: token,
+        deadline_us: deadline_us
       }
 
       {:ok, receipt, new_state}
@@ -1022,17 +1127,53 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     end
   end
 
+  defp delete_unclaimed_lease(receipt, caller_pid) do
+    case :ets.lookup(Storage.lease_table(), receipt.breaker_id) do
+      [
+        {breaker_id,
+         %{
+           token: token,
+           owner_pid: ^caller_pid,
+           generation: generation,
+           epoch: epoch,
+           claimed?: false
+         } = lease}
+      ]
+      when breaker_id == receipt.breaker_id and token == receipt.token and
+             generation == receipt.generation and epoch == receipt.epoch ->
+        :ets.select_delete(Storage.lease_table(), [{{breaker_id, lease}, [], [true]}])
+
+      _ ->
+        0
+    end
+  rescue
+    ArgumentError -> 0
+  end
+
   defp persist_claimed_owner(breaker_id, token, lifecycle_pid) do
     case :ets.lookup(Storage.lease_table(), breaker_id) do
       [{^breaker_id, %{token: ^token} = lease}] ->
-        :ets.insert(Storage.lease_table(), {breaker_id, %{lease | owner_pid: lifecycle_pid}})
+        :ets.insert(
+          Storage.lease_table(),
+          {breaker_id, lease |> Map.put(:owner_pid, lifecycle_pid) |> Map.put(:claimed?, true)}
+        )
 
       _ ->
         :ok
     end
   end
 
-  defp apply_attempt_report(state, token, result) do
+  defp apply_attempt_report(state, token, result),
+    do:
+      apply_attempt_report(state, token, state.transition_generation, state.process_epoch, result)
+
+  defp apply_attempt_report(state, token, generation, epoch, result) do
+    if generation == state.transition_generation and epoch == state.process_epoch,
+      do: do_apply_attempt_report(state, token, result),
+      else: state
+  end
+
+  defp do_apply_attempt_report(state, token, result) do
     case take_attempt(state, token) do
       {:ok, attempt, state_without_attempt} ->
         cond do
@@ -1068,6 +1209,28 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         release_half_open_attempt(state_without_attempt, attempt)
 
       :error ->
+        state
+    end
+  end
+
+  defp apply_attempt_release(state, token, generation, epoch) do
+    if generation == state.transition_generation and epoch == state.process_epoch,
+      do: apply_attempt_release(state, token),
+      else: state
+  end
+
+  defp abandon_unclaimed_attempt(state, token, generation, epoch, caller_pid) do
+    case Map.fetch(state.inflight_attempts, token) do
+      {:ok,
+       %{
+         transition_generation: ^generation,
+         epoch: ^epoch,
+         owner_pid: ^caller_pid,
+         claimed?: false
+       }} ->
+        apply_attempt_release(state, token)
+
+      _ ->
         state
     end
   end
@@ -1133,7 +1296,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     case :ets.lookup(Storage.lease_table(), breaker_id) do
       [
         {^breaker_id,
-         %{
+         lease = %{
            token: token,
            owner_pid: owner_pid,
            generation: generation,
@@ -1152,7 +1315,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
             epoch: epoch,
             owner_pid: owner_pid,
             owner_monitor: owner_monitor,
-            claimed?: true
+            claimed?: Map.get(lease, :claimed?, false)
           }
 
           %{
@@ -1183,14 +1346,25 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     end
   end
 
+  defp restore_recovery_timer(%{state: :open, recovery_deadline_ms: deadline_ms} = state)
+       when is_integer(deadline_ms) do
+    generation = state.recovery_timer_gen + 1
+    remaining_ms = max(deadline_ms - System.monotonic_time(:millisecond), 0)
+
+    %{
+      state
+      | recovery_timer_gen: generation,
+        recovery_timer_ref: schedule_recovery_timer(remaining_ms, generation)
+    }
+  end
+
+  defp restore_recovery_timer(state), do: state
+
   defp ensure_control_ring_generation(state) do
     breaker_id = {state.instance_id, state.transport}
 
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
-      [
-        {^breaker_id, generation, epoch, owner_pid, _capacity, _head, _tail, _wakeup,
-         _diagnostics, _ring_ref}
-      ]
+      [{^breaker_id, generation, epoch, owner_pid, _capacity, _wakeup, _diagnostics, _ring_ref}]
       when generation == state.transition_generation and epoch == state.process_epoch and
              owner_pid == self() ->
         :ok

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -315,6 +315,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @doc false
+  @spec abandon_unclaimed(AdmissionReceipt.t(), pid()) :: :ok
   def abandon_unclaimed(%AdmissionReceipt{kind: :half_open} = receipt, caller_pid) do
     delete_unclaimed_lease(receipt, caller_pid)
 

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -40,7 +40,15 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   use GenServer
   require Logger
   alias Lasso.Core.Support.{AttemptLifecycle, ErrorNormalizer}
-  alias Lasso.Core.Support.CircuitBreaker.Snapshot
+
+  alias Lasso.Core.Support.CircuitBreaker.{
+    Admission,
+    AdmissionReceipt,
+    ControlRing,
+    Snapshot,
+    Storage
+  }
+
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.Catalog
 
@@ -71,6 +79,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     process_epoch: nil,
     ready?: false,
     control_health: :healthy,
+    control_ring_capacity: 64,
     shared_mode: false,
     inflight_attempts: %{}
   ]
@@ -120,13 +129,13 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   - `:circuit_open` - Circuit is open due to failures
   - `:half_open_busy` - Circuit is half-open but at max inflight capacity
   - `:admission_timeout` - Admission check timed out
-  - `:not_found` - Circuit breaker process not found
+  - `:admission_unavailable` - Snapshot or live ready owner is unavailable
   """
-  @admit_timeout 500
   @attempt_state_timeout 500
 
   @typedoc "Reasons why the circuit breaker rejected execution"
-  @type rejection_reason :: :circuit_open | :half_open_busy | :admission_timeout | :not_found
+  @type rejection_reason ::
+          :circuit_open | :half_open_busy | :admission_timeout | :admission_unavailable
 
   @typedoc "Result of a circuit breaker call - separates execution status from function result"
   @type call_result(result) :: {:executed, result} | {:rejected, rejection_reason()}
@@ -136,37 +145,16 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @spec call(breaker_id(), (-> result), non_neg_integer(), keyword()) :: call_result(result)
         when result: term()
   def call({instance_id, transport} = id, fun, timeout \\ 30_000, opts \\ []) do
-    now_ms = System.monotonic_time(:millisecond)
     admit_start_us = System.monotonic_time(:microsecond)
-    admit_deadline_us = admit_start_us + @admit_timeout * 1_000
-
-    decision =
-      try do
-        GenServer.call(via_name(id), {:admit, now_ms, admit_deadline_us}, @admit_timeout)
-      catch
-        :exit, {:timeout, _} ->
-          Logger.warning("Circuit breaker admission timeout",
-            instance_id: instance_id,
-            transport: transport
-          )
-
-          {:deny, :admission_timeout}
-
-        :exit, {:noproc, _} ->
-          Logger.warning("Circuit breaker not found",
-            instance_id: instance_id,
-            transport: transport
-          )
-
-          {:deny, :not_found}
-      end
+    deadline_us = Keyword.get(opts, :deadline_us, admit_start_us + timeout * 1_000)
+    decision = admit(id, deadline_us)
 
     admit_call_ms = div(System.monotonic_time(:microsecond) - admit_start_us, 1000)
 
     decision_tag =
       case decision do
-        {:allow, _} -> :allow
-        {:deny, reason} -> reason
+        {:ok, _} -> :allow
+        {:error, reason} -> reason
         other -> other
       end
 
@@ -181,28 +169,70 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     )
 
     case decision do
-      {:allow, token} ->
-        execute_with_token(
-          id,
-          token,
+      {:ok, receipt} ->
+        execute_with_receipt(
+          receipt,
           fun,
           timeout,
+          deadline_us,
           Keyword.get(opts, :on_terminal),
           Keyword.get(opts, :on_dispatch),
           Keyword.get(opts, :dispatch, :immediate)
         )
 
-      {:deny, :open} ->
+      {:error, :circuit_open} ->
         {:rejected, :circuit_open}
 
-      {:deny, :half_open_busy} ->
+      {:error, :half_open_busy} ->
         {:rejected, :half_open_busy}
 
-      {:deny, :admission_timeout} ->
+      {:error, :admission_timeout} ->
         {:rejected, :admission_timeout}
 
-      {:deny, :not_found} ->
-        {:rejected, :not_found}
+      {:error, :admission_unavailable} ->
+        Logger.warning("Circuit breaker admission unavailable",
+          instance_id: instance_id,
+          transport: transport
+        )
+
+        {:rejected, :admission_unavailable}
+    end
+  end
+
+  @doc false
+  @spec admit(breaker_id(), integer()) ::
+          {:ok, AdmissionReceipt.t()} | {:error, rejection_reason()}
+  def admit(id, deadline_us) when is_integer(deadline_us) do
+    case Admission.check(id, deadline_us) do
+      {:ok, receipt} -> {:ok, receipt}
+      {:error, reason} -> {:error, reason}
+      {:exceptional, snapshot} -> admit_exceptional(snapshot, deadline_us)
+    end
+  end
+
+  defp admit_exceptional(snapshot, deadline_us) do
+    now_us = System.monotonic_time(:microsecond)
+
+    if now_us >= deadline_us do
+      {:error, :admission_timeout}
+    else
+      token = Base.url_encode64(:crypto.strong_rand_bytes(18), padding: false)
+      timeout_ms = max(div(deadline_us - now_us + 999, 1_000), 1)
+
+      request =
+        {:admit_exceptional, token, self(), snapshot.generation, snapshot.epoch, deadline_us}
+
+      try do
+        GenServer.call(snapshot.owner_pid, request, timeout_ms)
+      catch
+        :exit, {:timeout, _} ->
+          GenServer.cast(snapshot.owner_pid, {:release, token})
+          GenServer.cast(via_name(snapshot.breaker_id), {:release, token})
+          {:error, :admission_timeout}
+
+        :exit, _reason ->
+          {:error, :admission_unavailable}
+      end
     end
   end
 
@@ -219,6 +249,12 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @doc false
+  @spec report_closed(AdmissionReceipt.t(), term()) :: :ok | {:error, :saturated | :stale}
+  def report_closed(%AdmissionReceipt{kind: :closed} = receipt, result) do
+    ControlRing.enqueue(receipt, control_signal(result, receipt.breaker_id))
+  end
+
+  @doc false
   @spec report_attempt(breaker_id(), reference(), term()) ::
           :ok | {:error, :not_found | :timeout}
   def report_attempt(id, token, result) do
@@ -228,6 +264,12 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     :exit, {:noproc, _} -> {:error, :not_found}
     :exit, {:normal, _} -> {:error, :not_found}
     :exit, _reason -> {:error, :not_found}
+  end
+
+  @doc false
+  @spec report_half_open(AdmissionReceipt.t(), term()) :: :ok
+  def report_half_open(%AdmissionReceipt{kind: :half_open} = receipt, result) do
+    GenServer.cast(via_name(receipt.breaker_id), {:report, receipt.token, result})
   end
 
   @doc false
@@ -241,27 +283,33 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     :exit, _reason -> {:error, :not_found}
   end
 
-  defp execute_with_token(
-         id,
-         token,
+  @doc false
+  @spec release_half_open(AdmissionReceipt.t()) :: :ok
+  def release_half_open(%AdmissionReceipt{kind: :half_open} = receipt) do
+    GenServer.cast(via_name(receipt.breaker_id), {:release, receipt.token})
+  end
+
+  defp execute_with_receipt(
+         receipt,
          fun,
          timeout,
+         deadline_us,
          terminal_callback,
          dispatch_callback,
          dispatch_mode
        ) do
     case AttemptLifecycle.run(
            self(),
-           id,
-           token,
+           receipt,
            fun,
            timeout,
            terminal_callback,
            dispatch_callback,
-           dispatch_mode
+           dispatch_mode,
+           deadline_us
          ) do
       {:__attempt_lifecycle_rejected__, :timeout} -> {:rejected, :admission_timeout}
-      {:__attempt_lifecycle_rejected__, _reason} -> {:rejected, :not_found}
+      {:__attempt_lifecycle_rejected__, _reason} -> {:rejected, :admission_unavailable}
       result -> {:executed, result}
     end
   end
@@ -334,49 +382,25 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @doc """
-  Signals that external health monitoring has detected the provider is reachable.
+  Accepts a legacy external health signal without changing circuit state.
 
-  Used by health probes to indicate a provider appears to be responding. The
-  circuit breaker uses this signal to attempt recovery when appropriate.
-
-  ## Behavior by Circuit State
-
-  - **Open**: Triggers transition to half-open state (recovery attempt)
-  - **Half-open**: Counts toward success threshold for closing circuit
-  - **Closed**: No-op (circuit doesn't need recovery signals)
+  Recovery authority belongs to the cooldown/probation transition and accepted
+  current-epoch half-open lease outcomes.
   """
   @spec signal_recovery(breaker_id()) :: :ok | {:error, :not_found}
   def signal_recovery(id) do
     case safe_whereis(via_name(id)) do
-      nil ->
-        {:error, :not_found}
-
-      pid ->
-        try do
-          case GenServer.call(pid, :get_state, @state_timeout) do
-            %{state: state} when state in [:open, :half_open] ->
-              GenServer.cast(pid, {:report_external, {:ok, :success}})
-              :ok
-
-            _ ->
-              :ok
-          end
-        catch
-          :exit, _ -> {:error, :not_found}
-        end
+      nil -> {:error, :not_found}
+      _pid -> :ok
     end
   end
 
   @doc """
-  Fire-and-forget version of signal_recovery/1. Does not check current state.
+  Fire-and-forget compatibility form of `signal_recovery/1`.
   """
   @spec signal_recovery_cast(breaker_id()) :: :ok
   def signal_recovery_cast(cb_id) do
-    case safe_whereis(via_name(cb_id)) do
-      nil -> :ok
-      pid -> GenServer.cast(pid, {:report_external, {:ok, :success}})
-    end
-
+    _ = safe_whereis(via_name(cb_id))
     :ok
   end
 
@@ -465,10 +489,18 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         :missing -> nil
       end
 
+    previous_control? = :ets.member(Storage.control_meta_table(), {instance_id, transport})
+
     {initial_state, transition_generation, control_health} =
-      case previous_snapshot do
-        nil -> {:closed, 1, :healthy}
-        %Snapshot{generation: generation} -> {:half_open, generation + 1, :degraded}
+      case {previous_snapshot, previous_control?} do
+        {nil, false} ->
+          {:closed, 1, :healthy}
+
+        {nil, true} ->
+          {:half_open, 1, :degraded}
+
+        {%Snapshot{generation: generation}, _control?} ->
+          {:half_open, generation + 1, :degraded}
       end
 
     state = %__MODULE__{
@@ -491,10 +523,13 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       process_epoch: System.unique_integer([:positive, :monotonic]),
       ready?: true,
       control_health: control_health,
+      control_ring_capacity: Map.get(config, :control_ring_capacity, 64),
       shared_mode: Map.get(config, :shared_mode, false),
       inflight_attempts: %{}
     }
 
+    state = recover_persisted_lease(state)
+    initialize_control_ring(state)
     write_ets_state(state)
 
     {:ok, state}
@@ -508,6 +543,45 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @impl true
   def handle_call({:admit, now_ms, deadline_us}, from, state) do
     handle_admission(now_ms, deadline_us, from, state)
+  end
+
+  @impl true
+  def handle_call(
+        {:admit_exceptional, token, owner_pid, expected_generation, expected_epoch, deadline_us},
+        _from,
+        state
+      ) do
+    now_us = System.monotonic_time(:microsecond)
+
+    cond do
+      now_us >= deadline_us ->
+        {:reply, {:error, :admission_timeout}, state}
+
+      expected_epoch != state.process_epoch or
+          expected_generation != state.transition_generation ->
+        {:reply, {:error, :admission_unavailable}, state}
+
+      state.state == :open and not recovery_eligible?(state, now_us) ->
+        {:reply, {:error, :circuit_open}, state}
+
+      state.state == :half_open and state.inflight_count >= state.half_open_max_inflight ->
+        {:reply, {:error, :half_open_busy}, state}
+
+      state.state == :closed and state.control_health != :degraded ->
+        {:reply, {:error, :admission_unavailable}, state}
+
+      true ->
+        admitted_state = prepare_exceptional_generation(state)
+
+        case persist_exceptional_lease(admitted_state, token, owner_pid) do
+          {:ok, receipt, new_state} ->
+            write_ets_state(new_state)
+            {:reply, {:ok, receipt}, new_state}
+
+          :busy ->
+            {:reply, {:error, :half_open_busy}, state}
+        end
+    end
   end
 
   @impl true
@@ -534,6 +608,11 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       end
 
     {:reply, {:ok, remaining}, state}
+  end
+
+  @impl true
+  def handle_call({:report_external_sync, {:ok, _result}}, _from, state) do
+    {:reply, state.state, state}
   end
 
   @impl true
@@ -570,12 +649,16 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
   @impl true
   def handle_call({:report_attempt, token, result}, _from, state) do
-    {:reply, :ok, apply_attempt_report(state, token, result)}
+    new_state = apply_attempt_report(state, token, result)
+    write_ets_state(new_state)
+    {:reply, :ok, new_state}
   end
 
   @impl true
   def handle_call({:release_attempt, token}, _from, state) do
-    {:reply, :ok, apply_attempt_release(state, token)}
+    new_state = apply_attempt_release(state, token)
+    write_ets_state(new_state)
+    {:reply, :ok, new_state}
   end
 
   defp handle_admission(now_ms, deadline_us, {caller_pid, _tag} = from, state) do
@@ -637,12 +720,21 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
   @impl true
   def handle_cast({:report, token, result}, state) do
-    {:noreply, apply_attempt_report(state, token, result)}
+    new_state = apply_attempt_report(state, token, result)
+    write_ets_state(new_state)
+    {:noreply, new_state}
   end
 
   @impl true
   def handle_cast({:release, token}, state) do
-    {:noreply, apply_attempt_release(state, token)}
+    new_state = apply_attempt_release(state, token)
+    write_ets_state(new_state)
+    {:noreply, new_state}
+  end
+
+  @impl true
+  def handle_cast({:report_external, {:ok, _result}}, state) do
+    {:noreply, state}
   end
 
   @impl true
@@ -719,6 +811,26 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @impl true
+  def handle_info(
+        {:breaker_control_ready, breaker_id, generation, epoch},
+        %{instance_id: instance_id, transport: transport} = state
+      )
+      when breaker_id == {instance_id, transport} do
+    state = maybe_enter_control_probation(state, generation, epoch)
+
+    signals =
+      ControlRing.drain(
+        breaker_id,
+        state.control_ring_capacity,
+        generation,
+        epoch
+      )
+
+    new_state = Enum.reduce(signals, state, &apply_control_signal(&1, &2, generation, epoch))
+    {:noreply, new_state}
+  end
+
+  @impl true
   def handle_info({:attempt_proactive_recovery, gen}, state)
       when gen == state.recovery_timer_gen do
     case state.state do
@@ -764,8 +876,13 @@ defmodule Lasso.Core.Support.CircuitBreaker do
            _attempt ->
              false
          end) do
-      {token, _attempt} -> {:noreply, apply_attempt_release(state, token)}
-      nil -> {:noreply, state}
+      {token, _attempt} ->
+        new_state = apply_attempt_release(state, token)
+        write_ets_state(new_state)
+        {:noreply, new_state}
+
+      nil ->
+        {:noreply, state}
     end
   end
 
@@ -776,6 +893,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     attempt = %{
       admission_state: admission_state,
       transition_generation: state.transition_generation,
+      counted_generation: state.transition_generation,
       owner_pid: caller_pid,
       owner_monitor: owner_monitor,
       claimed?: false
@@ -790,6 +908,86 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     {token, new_state}
   end
 
+  defp recovery_eligible?(state, now_us) do
+    is_nil(state.recovery_deadline_ms) or now_us >= state.recovery_deadline_ms * 1_000
+  end
+
+  defp prepare_exceptional_generation(%{state: :half_open} = state), do: state
+
+  defp prepare_exceptional_generation(%{state: :open} = state) do
+    :telemetry.execute([:lasso, :circuit_breaker, :half_open], %{count: 1}, %{
+      instance_id: state.instance_id,
+      transport: state.transport,
+      from_state: :open,
+      to_state: :half_open,
+      reason: :attempt_recovery,
+      consecutive_open_count: state.consecutive_open_count
+    })
+
+    prepare_probation(state)
+  end
+
+  defp prepare_exceptional_generation(state), do: prepare_probation(state)
+
+  defp prepare_probation(state) do
+    cancel_recovery_timer(state.recovery_timer_ref)
+
+    %{
+      state
+      | state: :half_open,
+        success_count: 0,
+        inflight_count: 0,
+        recovery_timer_ref: nil,
+        recovery_timer_gen: state.recovery_timer_gen + 1,
+        transition_generation: state.transition_generation + 1,
+        control_health: :healthy
+    }
+  end
+
+  defp persist_exceptional_lease(state, token, owner_pid) do
+    breaker_id = {state.instance_id, state.transport}
+
+    lease = %{
+      token: token,
+      owner_pid: owner_pid,
+      generation: state.transition_generation,
+      epoch: state.process_epoch
+    }
+
+    if :ets.insert_new(Storage.lease_table(), {breaker_id, lease}) do
+      owner_monitor = Process.monitor(owner_pid)
+
+      attempt = %{
+        admission_state: :half_open,
+        transition_generation: state.transition_generation,
+        counted_generation: state.transition_generation,
+        epoch: state.process_epoch,
+        owner_pid: owner_pid,
+        owner_monitor: owner_monitor,
+        claimed?: true
+      }
+
+      new_state = %{
+        state
+        | inflight_attempts: Map.put(state.inflight_attempts, token, attempt),
+          inflight_count: state.inflight_count + 1
+      }
+
+      receipt = %AdmissionReceipt{
+        breaker_id: breaker_id,
+        kind: :half_open,
+        generation: state.transition_generation,
+        epoch: state.process_epoch,
+        owner_pid: self(),
+        token: token
+      }
+
+      {:ok, receipt, new_state}
+    else
+      :busy
+    end
+  end
+
   defp take_attempt(state, token) do
     case Map.pop(state.inflight_attempts, token) do
       {nil, _attempts} ->
@@ -797,6 +995,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
       {attempt, attempts} ->
         demonitor_attempt_owner(attempt)
+        delete_persisted_lease({state.instance_id, state.transport}, token)
         {:ok, attempt, %{state | inflight_attempts: attempts}}
     end
   end
@@ -808,6 +1007,13 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
   defp demonitor_attempt_owner(_attempt), do: :ok
 
+  defp delete_persisted_lease(breaker_id, token) do
+    case :ets.lookup(Storage.lease_table(), breaker_id) do
+      [{^breaker_id, %{token: ^token}}] -> :ets.delete(Storage.lease_table(), breaker_id)
+      _ -> :ok
+    end
+  end
+
   defp apply_attempt_report(state, token, result) do
     case take_attempt(state, token) do
       {:ok, attempt, state_without_attempt} ->
@@ -815,7 +1021,8 @@ defmodule Lasso.Core.Support.CircuitBreaker do
           neutral_attempt_result?(result) ->
             release_half_open_attempt(state_without_attempt, attempt)
 
-          attempt.transition_generation != state.transition_generation ->
+          attempt.transition_generation != state.transition_generation or
+              (Map.has_key?(attempt, :epoch) and attempt.epoch != state.process_epoch) ->
             release_half_open_attempt(state_without_attempt, attempt)
 
           true ->
@@ -849,7 +1056,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
   defp release_half_open_attempt(
          %{transition_generation: generation} = state,
-         %{admission_state: :half_open, transition_generation: generation}
+         %{admission_state: :half_open, counted_generation: generation}
        ) do
     %{state | inflight_count: max(state.inflight_count - 1, 0)}
   end
@@ -862,6 +1069,162 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   defp normalize_transport_result({:error, _reason} = error_tuple), do: error_tuple
   defp normalize_transport_result(:ok), do: {:ok, :ok}
   defp normalize_transport_result(other), do: other
+
+  defp control_signal(result, {instance_id, transport}) do
+    case normalize_transport_result(result) do
+      {:ok, _value} ->
+        :success
+
+      {:error, :unsupported_method} ->
+        :neutral
+
+      {:error, %JError{category: category}}
+      when category in [:local_capacity_rejection, :cancelled] ->
+        :neutral
+
+      {:error, %JError{} = error} ->
+        if error.retriable?,
+          do: {:failure, error.category, error.breaker_penalty?},
+          else: :neutral
+
+      {:error, reason} ->
+        error = ErrorNormalizer.normalize(reason, instance_id: instance_id, transport: transport)
+
+        if error.retriable?,
+          do: {:failure, error.category, error.breaker_penalty?},
+          else: :neutral
+
+      _other ->
+        {:failure, :internal_error, false}
+    end
+  end
+
+  defp initialize_control_ring(state) do
+    ControlRing.initialize(
+      {state.instance_id, state.transport},
+      state.transition_generation,
+      state.process_epoch,
+      self(),
+      capacity: state.control_ring_capacity
+    )
+  end
+
+  defp recover_persisted_lease(state) do
+    breaker_id = {state.instance_id, state.transport}
+
+    case :ets.lookup(Storage.lease_table(), breaker_id) do
+      [
+        {^breaker_id,
+         %{
+           token: token,
+           owner_pid: owner_pid,
+           generation: generation,
+           epoch: epoch
+         }}
+      ]
+      when is_binary(token) and is_pid(owner_pid) and is_integer(generation) and
+             is_integer(epoch) ->
+        if Process.alive?(owner_pid) do
+          owner_monitor = Process.monitor(owner_pid)
+
+          attempt = %{
+            admission_state: :half_open,
+            transition_generation: generation,
+            counted_generation: state.transition_generation,
+            epoch: epoch,
+            owner_pid: owner_pid,
+            owner_monitor: owner_monitor,
+            claimed?: true
+          }
+
+          %{
+            state
+            | inflight_attempts: %{token => attempt},
+              inflight_count: 1,
+              state: :half_open,
+              control_health: :degraded
+          }
+        else
+          :ets.delete(Storage.lease_table(), breaker_id)
+          state
+        end
+
+      [] ->
+        state
+
+      [_corrupt] ->
+        :ets.delete(Storage.lease_table(), breaker_id)
+
+        :telemetry.execute(
+          [:lasso, :circuit_breaker, :lease_corrupt],
+          %{count: 1},
+          %{breaker_id: breaker_id}
+        )
+
+        %{state | state: :half_open, control_health: :degraded}
+    end
+  end
+
+  defp ensure_control_ring_generation(state) do
+    breaker_id = {state.instance_id, state.transport}
+
+    case :ets.lookup(Storage.control_meta_table(), breaker_id) do
+      [{^breaker_id, generation, epoch, owner_pid, _capacity, _wakeup, _diagnostics}]
+      when generation == state.transition_generation and epoch == state.process_epoch and
+             owner_pid == self() ->
+        :ok
+
+      _ ->
+        initialize_control_ring(state)
+    end
+  end
+
+  defp maybe_enter_control_probation(state, generation, epoch) do
+    case Snapshot.lookup({state.instance_id, state.transport}) do
+      {:ok,
+       %Snapshot{
+         generation: ^generation,
+         epoch: ^epoch,
+         control_health: :degraded
+       }} ->
+        probation = %{
+          state
+          | state: :half_open,
+            success_count: 0,
+            inflight_count: 0,
+            transition_generation: state.transition_generation + 1,
+            control_health: :healthy
+        }
+
+        initialize_control_ring(probation)
+        write_ets_state(probation)
+        probation
+
+      _ ->
+        state
+    end
+  end
+
+  defp apply_control_signal(_signal, state, generation, epoch)
+       when state.transition_generation != generation or state.process_epoch != epoch,
+       do: state
+
+  defp apply_control_signal(:neutral, state, _generation, _epoch), do: state
+
+  defp apply_control_signal(:success, state, _generation, _epoch) do
+    classify_and_update_state_for_report({:ok, :control_success}, state)
+  end
+
+  defp apply_control_signal({:failure, category, breaker_penalty?}, state, _generation, _epoch) do
+    error =
+      JError.new(-32_000, "Bounded breaker control failure",
+        category: category,
+        retriable?: true,
+        breaker_penalty?: breaker_penalty?
+      )
+
+    classify_and_update_state_for_report({:error, error}, state)
+  end
 
   defp classify_and_handle_result(result, state) do
     case result do
@@ -1170,6 +1533,8 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   defp write_ets_state(state) do
+    ensure_control_ring_generation(state)
+
     :ets.insert(:lasso_instance_state, {
       {:circuit, state.instance_id, state.transport},
       %{

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -857,14 +857,6 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
   @impl true
   def handle_cast(:open, state) do
-    :telemetry.execute([:lasso, :circuit_breaker, :open], %{count: 1}, %{
-      instance_id: state.instance_id,
-      transport: state.transport,
-      from_state: state.state,
-      to_state: :open,
-      reason: :manual_open
-    })
-
     cancel_recovery_timer(state.recovery_timer_ref)
     delay = state.base_recovery_timeout
     delay_with_jitter = add_jitter(delay)
@@ -884,21 +876,22 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         effective_recovery_delay: delay
     }
 
-    publish_circuit_event(new_state, state.state, :open, :manual_open)
     write_ets_state(new_state)
+
+    :telemetry.execute([:lasso, :circuit_breaker, :open], %{count: 1}, %{
+      instance_id: state.instance_id,
+      transport: state.transport,
+      from_state: state.state,
+      to_state: :open,
+      reason: :manual_open
+    })
+
+    publish_circuit_event(new_state, state.state, :open, :manual_open)
     {:noreply, new_state}
   end
 
   @impl true
   def handle_cast(:close, state) do
-    :telemetry.execute([:lasso, :circuit_breaker, :close], %{count: 1}, %{
-      instance_id: state.instance_id,
-      transport: state.transport,
-      from_state: state.state,
-      to_state: :closed,
-      reason: :manual_close
-    })
-
     cancel_recovery_timer(state.recovery_timer_ref)
 
     new_state = %{
@@ -917,8 +910,17 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         transition_generation: state.transition_generation + 1
     }
 
-    publish_circuit_event(new_state, state.state, :closed, :manual_close)
     write_ets_state(new_state)
+
+    :telemetry.execute([:lasso, :circuit_breaker, :close], %{count: 1}, %{
+      instance_id: state.instance_id,
+      transport: state.transport,
+      from_state: state.state,
+      to_state: :closed,
+      reason: :manual_close
+    })
+
+    publish_circuit_event(new_state, state.state, :closed, :manual_close)
     {:noreply, new_state}
   end
 
@@ -947,15 +949,6 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       when gen == state.recovery_timer_gen do
     case state.state do
       :open ->
-        :telemetry.execute([:lasso, :circuit_breaker, :proactive_recovery], %{count: 1}, %{
-          instance_id: state.instance_id,
-          transport: state.transport,
-          from_state: :open,
-          to_state: :half_open,
-          reason: :proactive_recovery,
-          consecutive_open_count: state.consecutive_open_count
-        })
-
         new_state = %{
           state
           | state: :half_open,
@@ -965,8 +958,18 @@ defmodule Lasso.Core.Support.CircuitBreaker do
             transition_generation: state.transition_generation + 1
         }
 
-        publish_circuit_event(new_state, :open, :half_open, :proactive_recovery)
         write_ets_state(new_state)
+
+        :telemetry.execute([:lasso, :circuit_breaker, :proactive_recovery], %{count: 1}, %{
+          instance_id: state.instance_id,
+          transport: state.transport,
+          from_state: :open,
+          to_state: :half_open,
+          reason: :proactive_recovery,
+          consecutive_open_count: state.consecutive_open_count
+        })
+
+        publish_circuit_event(new_state, :open, :half_open, :proactive_recovery)
         {:noreply, new_state}
 
       _other_state ->
@@ -1532,14 +1535,6 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   defp reset_to_closed(state, from_state, result) do
-    :telemetry.execute([:lasso, :circuit_breaker, :close], %{count: 1}, %{
-      instance_id: state.instance_id,
-      transport: state.transport,
-      from_state: from_state,
-      to_state: :closed,
-      reason: :recovered
-    })
-
     new_state = %{
       state
       | state: :closed,
@@ -1556,8 +1551,17 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         transition_generation: state.transition_generation + 1
     }
 
-    publish_circuit_event(new_state, from_state, :closed, :recovered)
     write_ets_state(new_state)
+
+    :telemetry.execute([:lasso, :circuit_breaker, :close], %{count: 1}, %{
+      instance_id: state.instance_id,
+      transport: state.transport,
+      from_state: from_state,
+      to_state: :closed,
+      reason: :recovered
+    })
+
+    publish_circuit_event(new_state, from_state, :closed, :recovered)
     {:reply, {:ok, result}, new_state}
   end
 
@@ -1583,31 +1587,9 @@ defmodule Lasso.Core.Support.CircuitBreaker do
           state.base_recovery_timeout
       end
 
-    :telemetry.execute(
-      [:lasso, :circuit_breaker, :failure],
-      %{count: 1},
-      %{
-        instance_id: state.instance_id,
-        transport: state.transport,
-        error_category: error_category,
-        circuit_state: state.state
-      }
-    )
-
     case state.state do
       :closed ->
         if new_failure_count >= threshold do
-          :telemetry.execute([:lasso, :circuit_breaker, :open], %{count: 1}, %{
-            instance_id: state.instance_id,
-            transport: state.transport,
-            from_state: :closed,
-            to_state: :open,
-            reason: :failure_threshold_exceeded,
-            error_category: error_category,
-            failure_count: new_failure_count,
-            recovery_timeout_ms: adjusted_recovery_timeout
-          })
-
           delay = adjusted_recovery_timeout
           delay_with_jitter = add_jitter(delay)
           new_gen = state.recovery_timer_gen + 1
@@ -1628,11 +1610,25 @@ defmodule Lasso.Core.Support.CircuitBreaker do
               last_open_error: extract_error_info(error)
           }
 
-          publish_circuit_event(new_state, :closed, :open, :failure_threshold_exceeded, error)
           write_ets_state(new_state)
+          emit_failure_event(state, error_category)
+
+          :telemetry.execute([:lasso, :circuit_breaker, :open], %{count: 1}, %{
+            instance_id: state.instance_id,
+            transport: state.transport,
+            from_state: :closed,
+            to_state: :open,
+            reason: :failure_threshold_exceeded,
+            error_category: error_category,
+            failure_count: new_failure_count,
+            recovery_timeout_ms: adjusted_recovery_timeout
+          })
+
+          publish_circuit_event(new_state, :closed, :open, :failure_threshold_exceeded, error)
           {:reply, {:error, :circuit_opening}, new_state}
         else
           new_state = %{state | failure_count: new_failure_count, last_failure_time: current_time}
+          emit_failure_event(state, error_category)
           {:reply, {:error, error}, new_state}
         end
 
@@ -1645,18 +1641,6 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         new_gen = state.recovery_timer_gen + 1
         now = System.monotonic_time(:millisecond)
         timer_ref = schedule_recovery_timer(delay_with_jitter, new_gen)
-
-        :telemetry.execute([:lasso, :circuit_breaker, :open], %{count: 1}, %{
-          instance_id: state.instance_id,
-          transport: state.transport,
-          from_state: :half_open,
-          to_state: :open,
-          reason: :reopen_due_to_failure,
-          error_category: error_category,
-          failure_count: new_failure_count,
-          recovery_timeout_ms: delay,
-          consecutive_open_count: new_consecutive_open_count
-        })
 
         new_state = %{
           state
@@ -1675,8 +1659,22 @@ defmodule Lasso.Core.Support.CircuitBreaker do
             opened_by_category: error_category
         }
 
-        publish_circuit_event(new_state, :half_open, :open, :reopen_due_to_failure, error)
         write_ets_state(new_state)
+        emit_failure_event(state, error_category)
+
+        :telemetry.execute([:lasso, :circuit_breaker, :open], %{count: 1}, %{
+          instance_id: state.instance_id,
+          transport: state.transport,
+          from_state: :half_open,
+          to_state: :open,
+          reason: :reopen_due_to_failure,
+          error_category: error_category,
+          failure_count: new_failure_count,
+          recovery_timeout_ms: delay,
+          consecutive_open_count: new_consecutive_open_count
+        })
+
+        publish_circuit_event(new_state, :half_open, :open, :reopen_due_to_failure, error)
         {:reply, {:error, :circuit_reopening}, new_state}
 
       :open ->
@@ -1686,8 +1684,22 @@ defmodule Lasso.Core.Support.CircuitBreaker do
             last_failure_time: current_time
         }
 
+        emit_failure_event(state, error_category)
         {:reply, {:error, :circuit_open}, new_state}
     end
+  end
+
+  defp emit_failure_event(state, error_category) do
+    :telemetry.execute(
+      [:lasso, :circuit_breaker, :failure],
+      %{count: 1},
+      %{
+        instance_id: state.instance_id,
+        transport: state.transport,
+        error_category: error_category,
+        circuit_state: state.state
+      }
+    )
   end
 
   defp should_attempt_recovery?(state) do

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -237,7 +237,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @doc false
-  @spec claim_attempt(breaker_id(), reference(), pid()) ::
+  @spec claim_attempt(breaker_id(), binary() | reference(), pid()) ::
           :ok | {:error, :not_found | :token_not_found | :owner_mismatch | :timeout}
   def claim_attempt(id, token, caller_pid) do
     GenServer.call(via_name(id), {:claim_attempt, token, caller_pid}, @attempt_state_timeout)
@@ -491,16 +491,22 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
     previous_control? = :ets.member(Storage.control_meta_table(), {instance_id, transport})
 
-    {initial_state, transition_generation, control_health} =
+    now_us = System.monotonic_time(:microsecond)
+
+    {initial_state, transition_generation, control_health, recovery_deadline_ms} =
       case {previous_snapshot, previous_control?} do
         {nil, false} ->
-          {:closed, 1, :healthy}
+          {:closed, 1, :healthy, nil}
 
         {nil, true} ->
-          {:half_open, 1, :degraded}
+          {:half_open, 1, :degraded, nil}
+
+        {%Snapshot{state: :open, recovery_deadline_us: deadline_us, generation: generation}, _}
+        when is_integer(deadline_us) and deadline_us > now_us ->
+          {:open, generation + 1, :degraded, div(deadline_us + 999, 1_000)}
 
         {%Snapshot{generation: generation}, _control?} ->
-          {:half_open, generation + 1, :degraded}
+          {:half_open, generation + 1, :degraded, nil}
       end
 
     state = %__MODULE__{
@@ -523,7 +529,8 @@ defmodule Lasso.Core.Support.CircuitBreaker do
       process_epoch: System.unique_integer([:positive, :monotonic]),
       ready?: true,
       control_health: control_health,
-      control_ring_capacity: Map.get(config, :control_ring_capacity, 64),
+      control_ring_capacity: ControlRing.capacity(Map.get(config, :control_ring_capacity, 64)),
+      recovery_deadline_ms: recovery_deadline_ms,
       shared_mode: Map.get(config, :shared_mode, false),
       inflight_attempts: %{}
     }
@@ -636,6 +643,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
         }
 
         attempts = Map.put(state.inflight_attempts, token, claimed_attempt)
+        persist_claimed_owner({state.instance_id, state.transport}, token, lifecycle_pid)
 
         {:reply, :ok, %{state | inflight_attempts: attempts}}
 
@@ -1014,6 +1022,16 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     end
   end
 
+  defp persist_claimed_owner(breaker_id, token, lifecycle_pid) do
+    case :ets.lookup(Storage.lease_table(), breaker_id) do
+      [{^breaker_id, %{token: ^token} = lease}] ->
+        :ets.insert(Storage.lease_table(), {breaker_id, %{lease | owner_pid: lifecycle_pid}})
+
+      _ ->
+        :ok
+    end
+  end
+
   defp apply_attempt_report(state, token, result) do
     case take_attempt(state, token) do
       {:ok, attempt, state_without_attempt} ->
@@ -1169,7 +1187,10 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     breaker_id = {state.instance_id, state.transport}
 
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
-      [{^breaker_id, generation, epoch, owner_pid, _capacity, _wakeup, _diagnostics}]
+      [
+        {^breaker_id, generation, epoch, owner_pid, _capacity, _head, _tail, _wakeup,
+         _diagnostics, _ring_ref}
+      ]
       when generation == state.transition_generation and epoch == state.process_epoch and
              owner_pid == self() ->
         :ok

--- a/lib/lasso/core/support/circuit_breaker/admission.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission.ex
@@ -10,19 +10,10 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
           {:ok, AdmissionReceipt.t()} | {:exceptional, Snapshot.t()} | {:error, rejection()}
   def check(breaker_id, deadline_us, now_us \\ System.monotonic_time(:microsecond))
       when is_integer(deadline_us) and is_integer(now_us) do
-    result =
-      case Snapshot.lookup(breaker_id) do
-        {:ok, snapshot} -> classify(snapshot, deadline_us, now_us)
-        :missing -> {:error, :admission_unavailable}
-      end
-
-    :telemetry.execute(
-      [:lasso, :circuit_breaker, :snapshot_admission],
-      %{snapshot_lookups: 1, synchronous_owner_calls: 0},
-      %{breaker_id: breaker_id, decision: decision(result)}
-    )
-
-    result
+    case Snapshot.lookup(breaker_id) do
+      {:ok, snapshot} -> classify(snapshot, deadline_us, now_us)
+      :missing -> {:error, :admission_unavailable}
+    end
   rescue
     ArgumentError -> {:error, :admission_unavailable}
   end
@@ -83,8 +74,4 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
 
   defp classify_live(%Snapshot{}, _deadline_us, _now_us),
     do: {:error, :admission_unavailable}
-
-  defp decision({:ok, _receipt}), do: :allow
-  defp decision({:exceptional, _snapshot}), do: :exceptional
-  defp decision({:error, reason}), do: reason
 end

--- a/lib/lasso/core/support/circuit_breaker/admission.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission.ex
@@ -40,7 +40,11 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
       else: {:error, :admission_unavailable}
   end
 
-  defp classify_live(%Snapshot{state: :closed} = snapshot, _deadline_us, _now_us) do
+  defp classify_live(
+         %Snapshot{state: :closed, control_health: :healthy} = snapshot,
+         _deadline_us,
+         _now_us
+       ) do
     {:ok,
      %AdmissionReceipt{
        breaker_id: snapshot.breaker_id,
@@ -49,6 +53,16 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
        epoch: snapshot.epoch,
        owner_pid: snapshot.owner_pid
      }}
+  end
+
+  defp classify_live(
+         %Snapshot{state: :closed, control_health: :degraded} = snapshot,
+         deadline_us,
+         now_us
+       ) do
+    if now_us >= deadline_us,
+      do: {:error, :admission_timeout},
+      else: {:exceptional, snapshot}
   end
 
   defp classify_live(

--- a/lib/lasso/core/support/circuit_breaker/admission.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission.ex
@@ -1,0 +1,75 @@
+defmodule Lasso.Core.Support.CircuitBreaker.Admission do
+  @moduledoc false
+
+  alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, Snapshot}
+
+  @type rejection ::
+          :admission_unavailable | :circuit_open | :half_open_busy | :admission_timeout
+
+  @spec check({String.t(), :http | :ws}, integer(), integer()) ::
+          {:ok, AdmissionReceipt.t()} | {:exceptional, Snapshot.t()} | {:error, rejection()}
+  def check(breaker_id, deadline_us, now_us \\ System.monotonic_time(:microsecond))
+      when is_integer(deadline_us) and is_integer(now_us) do
+    result =
+      case Snapshot.lookup(breaker_id) do
+        {:ok, snapshot} -> classify(snapshot, deadline_us, now_us)
+        :missing -> {:error, :admission_unavailable}
+      end
+
+    :telemetry.execute(
+      [:lasso, :circuit_breaker, :snapshot_admission],
+      %{snapshot_lookups: 1, synchronous_owner_calls: 0},
+      %{breaker_id: breaker_id, decision: decision(result)}
+    )
+
+    result
+  rescue
+    ArgumentError -> {:error, :admission_unavailable}
+  end
+
+  defp classify(%Snapshot{ready?: false}, _deadline_us, _now_us),
+    do: {:error, :admission_unavailable}
+
+  defp classify(%Snapshot{owner_pid: owner_pid}, _deadline_us, _now_us)
+       when not is_pid(owner_pid),
+       do: {:error, :admission_unavailable}
+
+  defp classify(%Snapshot{owner_pid: owner_pid} = snapshot, deadline_us, now_us) do
+    if Process.alive?(owner_pid),
+      do: classify_live(snapshot, deadline_us, now_us),
+      else: {:error, :admission_unavailable}
+  end
+
+  defp classify_live(%Snapshot{state: :closed} = snapshot, _deadline_us, _now_us) do
+    {:ok,
+     %AdmissionReceipt{
+       breaker_id: snapshot.breaker_id,
+       kind: :closed,
+       generation: snapshot.generation,
+       epoch: snapshot.epoch,
+       owner_pid: snapshot.owner_pid
+     }}
+  end
+
+  defp classify_live(
+         %Snapshot{state: :open, recovery_deadline_us: recovery_deadline_us},
+         _deadline_us,
+         now_us
+       )
+       when is_integer(recovery_deadline_us) and now_us < recovery_deadline_us,
+       do: {:error, :circuit_open}
+
+  defp classify_live(%Snapshot{state: state} = snapshot, deadline_us, now_us)
+       when state in [:open, :half_open] do
+    if now_us >= deadline_us,
+      do: {:error, :admission_timeout},
+      else: {:exceptional, snapshot}
+  end
+
+  defp classify_live(%Snapshot{}, _deadline_us, _now_us),
+    do: {:error, :admission_unavailable}
+
+  defp decision({:ok, _receipt}), do: :allow
+  defp decision({:exceptional, _snapshot}), do: :exceptional
+  defp decision({:error, reason}), do: reason
+end

--- a/lib/lasso/core/support/circuit_breaker/admission.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission.ex
@@ -42,17 +42,21 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
 
   defp classify_live(
          %Snapshot{state: :closed, control_health: :healthy} = snapshot,
-         _deadline_us,
-         _now_us
+         deadline_us,
+         now_us
        ) do
-    {:ok,
-     %AdmissionReceipt{
-       breaker_id: snapshot.breaker_id,
-       kind: :closed,
-       generation: snapshot.generation,
-       epoch: snapshot.epoch,
-       owner_pid: snapshot.owner_pid
-     }}
+    if now_us >= deadline_us do
+      {:error, :admission_timeout}
+    else
+      {:ok,
+       %AdmissionReceipt{
+         breaker_id: snapshot.breaker_id,
+         kind: :closed,
+         generation: snapshot.generation,
+         epoch: snapshot.epoch,
+         owner_pid: snapshot.owner_pid
+       }}
+    end
   end
 
   defp classify_live(

--- a/lib/lasso/core/support/circuit_breaker/admission.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission.ex
@@ -30,10 +30,6 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
   defp classify(%Snapshot{ready?: false}, _deadline_us, _now_us),
     do: {:error, :admission_unavailable}
 
-  defp classify(%Snapshot{owner_pid: owner_pid}, _deadline_us, _now_us)
-       when not is_pid(owner_pid),
-       do: {:error, :admission_unavailable}
-
   defp classify(%Snapshot{owner_pid: owner_pid} = snapshot, deadline_us, now_us) do
     if Process.alive?(owner_pid),
       do: classify_live(snapshot, deadline_us, now_us),
@@ -54,7 +50,8 @@ defmodule Lasso.Core.Support.CircuitBreaker.Admission do
          kind: :closed,
          generation: snapshot.generation,
          epoch: snapshot.epoch,
-         owner_pid: snapshot.owner_pid
+         owner_pid: snapshot.owner_pid,
+         deadline_us: deadline_us
        }}
     end
   end

--- a/lib/lasso/core/support/circuit_breaker/admission_receipt.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission_receipt.ex
@@ -1,0 +1,16 @@
+defmodule Lasso.Core.Support.CircuitBreaker.AdmissionReceipt do
+  @moduledoc false
+
+  @enforce_keys [:breaker_id, :kind, :generation, :epoch, :owner_pid]
+  defstruct @enforce_keys ++ [token: nil]
+
+  @type kind :: :closed | :half_open
+  @type t :: %__MODULE__{
+          breaker_id: {String.t(), :http | :ws},
+          kind: kind(),
+          generation: non_neg_integer(),
+          epoch: pos_integer(),
+          owner_pid: pid(),
+          token: reference() | nil
+        }
+end

--- a/lib/lasso/core/support/circuit_breaker/admission_receipt.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission_receipt.ex
@@ -4,13 +4,13 @@ defmodule Lasso.Core.Support.CircuitBreaker.AdmissionReceipt do
   @enforce_keys [:breaker_id, :kind, :generation, :epoch, :owner_pid]
   defstruct @enforce_keys ++ [token: nil]
 
-  @type kind :: :closed | :half_open
+  @type kind :: :closed | :half_open | :legacy
   @type t :: %__MODULE__{
           breaker_id: {String.t(), :http | :ws},
           kind: kind(),
           generation: non_neg_integer(),
           epoch: pos_integer(),
           owner_pid: pid(),
-          token: reference() | nil
+          token: binary() | reference() | nil
         }
 end

--- a/lib/lasso/core/support/circuit_breaker/admission_receipt.ex
+++ b/lib/lasso/core/support/circuit_breaker/admission_receipt.ex
@@ -2,7 +2,7 @@ defmodule Lasso.Core.Support.CircuitBreaker.AdmissionReceipt do
   @moduledoc false
 
   @enforce_keys [:breaker_id, :kind, :generation, :epoch, :owner_pid]
-  defstruct @enforce_keys ++ [token: nil]
+  defstruct @enforce_keys ++ [token: nil, deadline_us: nil]
 
   @type kind :: :closed | :half_open | :legacy
   @type t :: %__MODULE__{
@@ -11,6 +11,7 @@ defmodule Lasso.Core.Support.CircuitBreaker.AdmissionReceipt do
           generation: non_neg_integer(),
           epoch: pos_integer(),
           owner_pid: pid(),
-          token: binary() | reference() | nil
+          token: binary() | reference() | nil,
+          deadline_us: integer() | nil
         }
 end

--- a/lib/lasso/core/support/circuit_breaker/control_ring.ex
+++ b/lib/lasso/core/support/circuit_breaker/control_ring.ex
@@ -4,27 +4,32 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
   alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, Snapshot, Storage}
 
   @default_capacity 64
+  @maximum_capacity 1_024
   @empty :empty
 
   @type signal :: :success | {:failure, atom(), boolean()} | :neutral
 
+  @spec capacity(term()) :: pos_integer()
+  def capacity(value) when is_integer(value) and value > 0, do: min(value, @maximum_capacity)
+  def capacity(_value), do: @default_capacity
+
   @spec initialize({String.t(), :http | :ws}, pos_integer(), pos_integer(), pid(), keyword()) ::
           :ok
   def initialize(breaker_id, generation, epoch, owner_pid, opts \\ []) do
-    capacity = Keyword.get(opts, :capacity, @default_capacity)
+    capacity = capacity(Keyword.get(opts, :capacity, @default_capacity))
+    head = :atomics.new(1, signed: false)
+    tail = :atomics.new(1, signed: false)
     wakeup = :atomics.new(1, signed: false)
     diagnostics = :atomics.new(1, signed: false)
+    ring_ref = make_ref()
 
-    clear_slots(breaker_id)
-
-    Enum.each(0..(capacity - 1), fn index ->
-      true = :ets.insert(Storage.control_table(), {{breaker_id, index}, @empty})
-    end)
+    reset_slots(breaker_id, capacity, ring_ref)
 
     true =
       :ets.insert(
         Storage.control_meta_table(),
-        {breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics}
+        {breaker_id, generation, epoch, owner_pid, capacity, head, tail, wakeup, diagnostics,
+         ring_ref}
       )
 
     :ok
@@ -44,10 +49,24 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
           [signal()]
   def drain(breaker_id, limit, generation, epoch) do
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
-      [{^breaker_id, ^generation, ^epoch, _owner_pid, capacity, wakeup, _diagnostics}] ->
-        signals = take_slots(breaker_id, min(limit, capacity), capacity)
+      [
+        {^breaker_id, ^generation, ^epoch, _owner_pid, capacity, head, tail, wakeup, _diagnostics,
+         ring_ref}
+      ] ->
+        signals = take_slots(breaker_id, min(limit, capacity), capacity, head, ring_ref)
         :atomics.put(wakeup, 1, 0)
-        maybe_notify_remaining(breaker_id, generation, epoch, capacity, wakeup)
+
+        maybe_notify_remaining(
+          breaker_id,
+          generation,
+          epoch,
+          capacity,
+          head,
+          tail,
+          wakeup,
+          ring_ref
+        )
+
         signals
 
       _ ->
@@ -60,12 +79,15 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
   @spec stats({String.t(), :http | :ws}) :: map() | {:error, :not_found}
   def stats(breaker_id) do
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
-      [{^breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics}] ->
+      [
+        {^breaker_id, generation, epoch, owner_pid, capacity, head, tail, wakeup, diagnostics,
+         _ring_ref}
+      ] ->
         %{
           generation: generation,
           epoch: epoch,
           capacity: capacity,
-          occupied: occupied_count(breaker_id, capacity),
+          occupied: min(max(:atomics.get(tail, 1) - :atomics.get(head, 1), 0), capacity),
           wakeup_pending: :atomics.get(wakeup, 1),
           dropped: :atomics.get(diagnostics, 1),
           owner_pid: owner_pid
@@ -80,14 +102,23 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
          %AdmissionReceipt{breaker_id: breaker_id, generation: generation, epoch: epoch} =
            receipt,
          signal,
-         {breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics}
+         {breaker_id, generation, epoch, owner_pid, capacity, head, tail, wakeup, diagnostics,
+          ring_ref}
        ) do
-    start = rem(System.unique_integer([:positive, :monotonic]), capacity)
+    case reserve_ticket(head, tail, capacity) do
+      {:ok, ticket} ->
+        key = {breaker_id, rem(ticket, capacity)}
+        value = {ticket, generation, epoch, signal}
+        match_spec = [{{key, {ring_ref, @empty}}, [], [{:const, {key, {ring_ref, value}}}]}]
 
-    case reserve_slot(breaker_id, signal, generation, epoch, start, capacity) do
-      :ok ->
-        notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
-        :ok
+        case :ets.select_replace(Storage.control_table(), match_spec) do
+          1 ->
+            notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
+            :ok
+
+          0 ->
+            {:error, :stale}
+        end
 
       :full ->
         :atomics.add(diagnostics, 1, 1)
@@ -98,19 +129,20 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
 
   defp enqueue_with_meta(_receipt, _signal, _meta), do: {:error, :stale}
 
-  defp reserve_slot(breaker_id, signal, generation, epoch, start, capacity) do
-    Enum.reduce_while(0..(capacity - 1), :full, fn offset, _acc ->
-      index = rem(start + offset, capacity)
-      key = {breaker_id, index}
-      value = {generation, epoch, signal}
+  defp reserve_ticket(head, tail, capacity) do
+    head_value = :atomics.get(head, 1)
+    tail_value = :atomics.get(tail, 1)
 
-      match_spec = [{{key, @empty}, [], [{:const, {key, value}}]}]
+    cond do
+      tail_value - head_value >= capacity ->
+        :full
 
-      case :ets.select_replace(Storage.control_table(), match_spec) do
-        1 -> {:halt, :ok}
-        0 -> {:cont, :full}
-      end
-    end)
+      :atomics.compare_exchange(tail, 1, tail_value, tail_value + 1) in [:ok, tail_value] ->
+        {:ok, tail_value}
+
+      true ->
+        reserve_ticket(head, tail, capacity)
+    end
   end
 
   defp notify_once(owner_pid, breaker_id, generation, epoch, wakeup) do
@@ -123,49 +155,59 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
     end
   end
 
-  defp take_slots(breaker_id, limit, capacity) do
-    Enum.reduce_while(0..(capacity - 1), [], fn index, signals ->
-      if length(signals) >= limit do
-        {:halt, Enum.reverse(signals)}
-      else
-        key = {breaker_id, index}
+  defp take_slots(_breaker_id, 0, _capacity, _head, _ring_ref), do: []
 
-        case :ets.lookup(Storage.control_table(), key) do
-          [{^key, {_generation, _epoch, signal} = value}] ->
-            match_spec = [{{key, value}, [], [{:const, {key, @empty}}]}]
+  defp take_slots(breaker_id, limit, capacity, head, ring_ref) do
+    ticket = :atomics.get(head, 1)
+    key = {breaker_id, rem(ticket, capacity)}
 
-            case :ets.select_replace(Storage.control_table(), match_spec) do
-              1 -> {:cont, [signal | signals]}
-              0 -> {:cont, signals}
-            end
+    case :ets.lookup(Storage.control_table(), key) do
+      [{^key, {^ring_ref, {^ticket, _generation, _epoch, signal} = value}}] ->
+        match_spec = [{{key, {ring_ref, value}}, [], [{:const, {key, {ring_ref, @empty}}}]}]
 
-          _ ->
-            {:cont, signals}
+        case :ets.select_replace(Storage.control_table(), match_spec) do
+          1 ->
+            :atomics.add(head, 1, 1)
+            [signal | take_slots(breaker_id, limit - 1, capacity, head, ring_ref)]
+
+          0 ->
+            []
         end
-      end
-    end)
+
+      _ ->
+        []
+    end
   end
 
-  defp maybe_notify_remaining(breaker_id, generation, epoch, capacity, wakeup) do
-    if occupied_count(breaker_id, capacity) > 0 do
+  defp maybe_notify_remaining(
+         breaker_id,
+         generation,
+         epoch,
+         capacity,
+         head,
+         tail,
+         wakeup,
+         ring_ref
+       ) do
+    ticket = :atomics.get(head, 1)
+    key = {breaker_id, rem(ticket, capacity)}
+
+    if :atomics.get(tail, 1) > ticket and
+         match?(
+           [{^key, {^ring_ref, {^ticket, _, _, _}}}],
+           :ets.lookup(Storage.control_table(), key)
+         ) do
       case :ets.lookup(Storage.control_meta_table(), breaker_id) do
-        [{^breaker_id, ^generation, ^epoch, owner_pid, ^capacity, ^wakeup, _diagnostics}] ->
+        [
+          {^breaker_id, ^generation, ^epoch, owner_pid, ^capacity, ^head, ^tail, ^wakeup,
+           _diagnostics, ^ring_ref}
+        ] ->
           notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
 
         _ ->
           :ok
       end
     end
-  end
-
-  defp occupied_count(breaker_id, capacity) do
-    Enum.count(0..(capacity - 1), fn index ->
-      case :ets.lookup(Storage.control_table(), {breaker_id, index}) do
-        [{{^breaker_id, ^index}, @empty}] -> false
-        [{{^breaker_id, ^index}, _signal}] -> true
-        [] -> false
-      end
-    end)
   end
 
   defp degrade(receipt) do
@@ -189,9 +231,39 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
     end
   end
 
-  defp clear_slots(breaker_id) do
-    :ets.select_delete(Storage.control_table(), [
-      {{{breaker_id, :_}, :_}, [], [true]}
-    ])
+  @spec delete({String.t(), :http | :ws}) :: :ok
+  def delete(breaker_id) do
+    capacity = previous_capacity(breaker_id)
+    Enum.each(0..(capacity - 1), &:ets.delete(Storage.control_table(), {breaker_id, &1}))
+    :ets.delete(Storage.control_meta_table(), breaker_id)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp reset_slots(breaker_id, capacity, ring_ref) do
+    reset_capacity = max(capacity, previous_capacity(breaker_id))
+
+    Enum.each(0..(reset_capacity - 1), fn index ->
+      :ets.delete(Storage.control_table(), {breaker_id, index})
+    end)
+
+    Enum.each(0..(capacity - 1), fn index ->
+      :ets.insert(Storage.control_table(), {{breaker_id, index}, {ring_ref, @empty}})
+    end)
+  end
+
+  defp previous_capacity(breaker_id) do
+    case :ets.lookup(Storage.control_meta_table(), breaker_id) do
+      [
+        {^breaker_id, _generation, _epoch, _owner, capacity, _head, _tail, _wakeup, _diagnostics,
+         _ring_ref}
+      ]
+      when is_integer(capacity) and capacity > 0 ->
+        min(capacity, @maximum_capacity)
+
+      _ ->
+        @default_capacity
+    end
   end
 end

--- a/lib/lasso/core/support/circuit_breaker/control_ring.ex
+++ b/lib/lasso/core/support/circuit_breaker/control_ring.ex
@@ -17,8 +17,6 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
           :ok
   def initialize(breaker_id, generation, epoch, owner_pid, opts \\ []) do
     capacity = capacity(Keyword.get(opts, :capacity, @default_capacity))
-    head = :atomics.new(1, signed: false)
-    tail = :atomics.new(1, signed: false)
     wakeup = :atomics.new(1, signed: false)
     diagnostics = :atomics.new(1, signed: false)
     ring_ref = make_ref()
@@ -28,8 +26,7 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
     true =
       :ets.insert(
         Storage.control_meta_table(),
-        {breaker_id, generation, epoch, owner_pid, capacity, head, tail, wakeup, diagnostics,
-         ring_ref}
+        {breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics, ring_ref}
       )
 
     :ok
@@ -50,23 +47,11 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
   def drain(breaker_id, limit, generation, epoch) do
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
       [
-        {^breaker_id, ^generation, ^epoch, _owner_pid, capacity, head, tail, wakeup, _diagnostics,
-         ring_ref}
+        {^breaker_id, ^generation, ^epoch, _owner_pid, capacity, wakeup, _diagnostics, ring_ref}
       ] ->
-        signals = take_slots(breaker_id, min(limit, capacity), capacity, head, ring_ref)
+        signals = take_slots(breaker_id, min(limit, capacity), capacity, ring_ref)
         :atomics.put(wakeup, 1, 0)
-
-        maybe_notify_remaining(
-          breaker_id,
-          generation,
-          epoch,
-          capacity,
-          head,
-          tail,
-          wakeup,
-          ring_ref
-        )
-
+        maybe_notify_remaining(breaker_id, generation, epoch, capacity, wakeup, ring_ref)
         signals
 
       _ ->
@@ -80,14 +65,13 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
   def stats(breaker_id) do
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
       [
-        {^breaker_id, generation, epoch, owner_pid, capacity, head, tail, wakeup, diagnostics,
-         _ring_ref}
+        {^breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics, ring_ref}
       ] ->
         %{
           generation: generation,
           epoch: epoch,
           capacity: capacity,
-          occupied: min(max(:atomics.get(tail, 1) - :atomics.get(head, 1), 0), capacity),
+          occupied: occupied_count(breaker_id, capacity, ring_ref),
           wakeup_pending: :atomics.get(wakeup, 1),
           dropped: :atomics.get(diagnostics, 1),
           owner_pid: owner_pid
@@ -102,23 +86,15 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
          %AdmissionReceipt{breaker_id: breaker_id, generation: generation, epoch: epoch} =
            receipt,
          signal,
-         {breaker_id, generation, epoch, owner_pid, capacity, head, tail, wakeup, diagnostics,
-          ring_ref}
+         {breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics, ring_ref}
        ) do
-    case reserve_ticket(head, tail, capacity) do
-      {:ok, ticket} ->
-        key = {breaker_id, rem(ticket, capacity)}
-        value = {ticket, generation, epoch, signal}
-        match_spec = [{{key, {ring_ref, @empty}}, [], [{:const, {key, {ring_ref, value}}}]}]
+    sequence = System.unique_integer([:positive, :monotonic])
+    start = rem(sequence, capacity)
 
-        case :ets.select_replace(Storage.control_table(), match_spec) do
-          1 ->
-            notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
-            :ok
-
-          0 ->
-            {:error, :stale}
-        end
+    case reserve_slot(breaker_id, signal, generation, epoch, sequence, start, capacity, ring_ref) do
+      :ok ->
+        notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
+        :ok
 
       :full ->
         :atomics.add(diagnostics, 1, 1)
@@ -129,20 +105,18 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
 
   defp enqueue_with_meta(_receipt, _signal, _meta), do: {:error, :stale}
 
-  defp reserve_ticket(head, tail, capacity) do
-    head_value = :atomics.get(head, 1)
-    tail_value = :atomics.get(tail, 1)
+  defp reserve_slot(breaker_id, signal, generation, epoch, sequence, start, capacity, ring_ref) do
+    Enum.reduce_while(0..(capacity - 1), :full, fn offset, _acc ->
+      index = rem(start + offset, capacity)
+      key = {breaker_id, index}
+      value = {sequence, generation, epoch, signal}
+      match_spec = [{{key, {ring_ref, @empty}}, [], [{:const, {key, {ring_ref, value}}}]}]
 
-    cond do
-      tail_value - head_value >= capacity ->
-        :full
-
-      :atomics.compare_exchange(tail, 1, tail_value, tail_value + 1) in [:ok, tail_value] ->
-        {:ok, tail_value}
-
-      true ->
-        reserve_ticket(head, tail, capacity)
-    end
+      case :ets.select_replace(Storage.control_table(), match_spec) do
+        1 -> {:halt, :ok}
+        0 -> {:cont, :full}
+      end
+    end)
   end
 
   defp notify_once(owner_pid, breaker_id, generation, epoch, wakeup) do
@@ -155,52 +129,25 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
     end
   end
 
-  defp take_slots(_breaker_id, 0, _capacity, _head, _ring_ref), do: []
-
-  defp take_slots(breaker_id, limit, capacity, head, ring_ref) do
-    ticket = :atomics.get(head, 1)
-    key = {breaker_id, rem(ticket, capacity)}
-
-    case :ets.lookup(Storage.control_table(), key) do
-      [{^key, {^ring_ref, {^ticket, _generation, _epoch, signal} = value}}] ->
-        match_spec = [{{key, {ring_ref, value}}, [], [{:const, {key, {ring_ref, @empty}}}]}]
-
-        case :ets.select_replace(Storage.control_table(), match_spec) do
-          1 ->
-            :atomics.add(head, 1, 1)
-            [signal | take_slots(breaker_id, limit - 1, capacity, head, ring_ref)]
-
-          0 ->
-            []
-        end
-
-      _ ->
-        []
-    end
+  defp take_slots(breaker_id, limit, capacity, ring_ref) do
+    breaker_id
+    |> occupied_slots(capacity, ring_ref)
+    |> Enum.sort_by(fn {_key, {_ring_ref, {sequence, _generation, _epoch, _signal}}} ->
+      sequence
+    end)
+    |> Enum.take(limit)
+    |> Enum.flat_map(fn {key, {^ring_ref, {_sequence, _generation, _epoch, signal} = value}} ->
+      match_spec = [{{key, {ring_ref, value}}, [], [{:const, {key, {ring_ref, @empty}}}]}]
+      if :ets.select_replace(Storage.control_table(), match_spec) == 1, do: [signal], else: []
+    end)
   end
 
-  defp maybe_notify_remaining(
-         breaker_id,
-         generation,
-         epoch,
-         capacity,
-         head,
-         tail,
-         wakeup,
-         ring_ref
-       ) do
-    ticket = :atomics.get(head, 1)
-    key = {breaker_id, rem(ticket, capacity)}
-
-    if :atomics.get(tail, 1) > ticket and
-         match?(
-           [{^key, {^ring_ref, {^ticket, _, _, _}}}],
-           :ets.lookup(Storage.control_table(), key)
-         ) do
+  defp maybe_notify_remaining(breaker_id, generation, epoch, capacity, wakeup, ring_ref) do
+    if occupied_count(breaker_id, capacity, ring_ref) > 0 do
       case :ets.lookup(Storage.control_meta_table(), breaker_id) do
         [
-          {^breaker_id, ^generation, ^epoch, owner_pid, ^capacity, ^head, ^tail, ^wakeup,
-           _diagnostics, ^ring_ref}
+          {^breaker_id, ^generation, ^epoch, owner_pid, ^capacity, ^wakeup, _diagnostics,
+           ^ring_ref}
         ] ->
           notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
 
@@ -208,6 +155,21 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
           :ok
       end
     end
+  end
+
+  defp occupied_count(breaker_id, capacity, ring_ref) do
+    breaker_id |> occupied_slots(capacity, ring_ref) |> length()
+  end
+
+  defp occupied_slots(breaker_id, capacity, ring_ref) do
+    Enum.flat_map(0..(capacity - 1), fn index ->
+      key = {breaker_id, index}
+
+      case :ets.lookup(Storage.control_table(), key) do
+        [{^key, {^ring_ref, {_sequence, _generation, _epoch, _signal}} = value}] -> [{key, value}]
+        _ -> []
+      end
+    end)
   end
 
   defp degrade(receipt) do
@@ -255,10 +217,7 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
 
   defp previous_capacity(breaker_id) do
     case :ets.lookup(Storage.control_meta_table(), breaker_id) do
-      [
-        {^breaker_id, _generation, _epoch, _owner, capacity, _head, _tail, _wakeup, _diagnostics,
-         _ring_ref}
-      ]
+      [{^breaker_id, _generation, _epoch, _owner, capacity, _wakeup, _diagnostics, _ring_ref}]
       when is_integer(capacity) and capacity > 0 ->
         min(capacity, @maximum_capacity)
 

--- a/lib/lasso/core/support/circuit_breaker/control_ring.ex
+++ b/lib/lasso/core/support/circuit_breaker/control_ring.ex
@@ -183,12 +183,6 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
           {{receipt.breaker_id, snapshot}, [], [{:const, {receipt.breaker_id, degraded}}]}
         ])
 
-        :telemetry.execute(
-          [:lasso, :circuit_breaker, :control_saturated],
-          %{count: 1},
-          %{breaker_id: receipt.breaker_id, generation: generation, epoch: epoch}
-        )
-
       _ ->
         :ok
     end

--- a/lib/lasso/core/support/circuit_breaker/control_ring.ex
+++ b/lib/lasso/core/support/circuit_breaker/control_ring.ex
@@ -99,6 +99,7 @@ defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
       :full ->
         :atomics.add(diagnostics, 1, 1)
         degrade(receipt)
+        notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
         {:error, :saturated}
     end
   end

--- a/lib/lasso/core/support/circuit_breaker/control_ring.ex
+++ b/lib/lasso/core/support/circuit_breaker/control_ring.ex
@@ -1,0 +1,197 @@
+defmodule Lasso.Core.Support.CircuitBreaker.ControlRing do
+  @moduledoc false
+
+  alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, Snapshot, Storage}
+
+  @default_capacity 64
+  @empty :empty
+
+  @type signal :: :success | {:failure, atom(), boolean()} | :neutral
+
+  @spec initialize({String.t(), :http | :ws}, pos_integer(), pos_integer(), pid(), keyword()) ::
+          :ok
+  def initialize(breaker_id, generation, epoch, owner_pid, opts \\ []) do
+    capacity = Keyword.get(opts, :capacity, @default_capacity)
+    wakeup = :atomics.new(1, signed: false)
+    diagnostics = :atomics.new(1, signed: false)
+
+    clear_slots(breaker_id)
+
+    Enum.each(0..(capacity - 1), fn index ->
+      true = :ets.insert(Storage.control_table(), {{breaker_id, index}, @empty})
+    end)
+
+    true =
+      :ets.insert(
+        Storage.control_meta_table(),
+        {breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics}
+      )
+
+    :ok
+  end
+
+  @spec enqueue(AdmissionReceipt.t(), signal()) :: :ok | {:error, :saturated | :stale}
+  def enqueue(%AdmissionReceipt{} = receipt, signal) do
+    case :ets.lookup(Storage.control_meta_table(), receipt.breaker_id) do
+      [meta] -> enqueue_with_meta(receipt, signal, meta)
+      [] -> {:error, :stale}
+    end
+  rescue
+    ArgumentError -> {:error, :stale}
+  end
+
+  @spec drain({String.t(), :http | :ws}, non_neg_integer(), pos_integer(), pos_integer()) ::
+          [signal()]
+  def drain(breaker_id, limit, generation, epoch) do
+    case :ets.lookup(Storage.control_meta_table(), breaker_id) do
+      [{^breaker_id, ^generation, ^epoch, _owner_pid, capacity, wakeup, _diagnostics}] ->
+        signals = take_slots(breaker_id, min(limit, capacity), capacity)
+        :atomics.put(wakeup, 1, 0)
+        maybe_notify_remaining(breaker_id, generation, epoch, capacity, wakeup)
+        signals
+
+      _ ->
+        []
+    end
+  rescue
+    ArgumentError -> []
+  end
+
+  @spec stats({String.t(), :http | :ws}) :: map() | {:error, :not_found}
+  def stats(breaker_id) do
+    case :ets.lookup(Storage.control_meta_table(), breaker_id) do
+      [{^breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics}] ->
+        %{
+          generation: generation,
+          epoch: epoch,
+          capacity: capacity,
+          occupied: occupied_count(breaker_id, capacity),
+          wakeup_pending: :atomics.get(wakeup, 1),
+          dropped: :atomics.get(diagnostics, 1),
+          owner_pid: owner_pid
+        }
+
+      [] ->
+        {:error, :not_found}
+    end
+  end
+
+  defp enqueue_with_meta(
+         %AdmissionReceipt{breaker_id: breaker_id, generation: generation, epoch: epoch} =
+           receipt,
+         signal,
+         {breaker_id, generation, epoch, owner_pid, capacity, wakeup, diagnostics}
+       ) do
+    start = rem(System.unique_integer([:positive, :monotonic]), capacity)
+
+    case reserve_slot(breaker_id, signal, generation, epoch, start, capacity) do
+      :ok ->
+        notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
+        :ok
+
+      :full ->
+        :atomics.add(diagnostics, 1, 1)
+        degrade(receipt)
+        {:error, :saturated}
+    end
+  end
+
+  defp enqueue_with_meta(_receipt, _signal, _meta), do: {:error, :stale}
+
+  defp reserve_slot(breaker_id, signal, generation, epoch, start, capacity) do
+    Enum.reduce_while(0..(capacity - 1), :full, fn offset, _acc ->
+      index = rem(start + offset, capacity)
+      key = {breaker_id, index}
+      value = {generation, epoch, signal}
+
+      match_spec = [{{key, @empty}, [], [{:const, {key, value}}]}]
+
+      case :ets.select_replace(Storage.control_table(), match_spec) do
+        1 -> {:halt, :ok}
+        0 -> {:cont, :full}
+      end
+    end)
+  end
+
+  defp notify_once(owner_pid, breaker_id, generation, epoch, wakeup) do
+    case :atomics.compare_exchange(wakeup, 1, 0, 1) do
+      value when value in [:ok, 0] ->
+        send(owner_pid, {:breaker_control_ready, breaker_id, generation, epoch})
+
+      _already_pending ->
+        :ok
+    end
+  end
+
+  defp take_slots(breaker_id, limit, capacity) do
+    Enum.reduce_while(0..(capacity - 1), [], fn index, signals ->
+      if length(signals) >= limit do
+        {:halt, Enum.reverse(signals)}
+      else
+        key = {breaker_id, index}
+
+        case :ets.lookup(Storage.control_table(), key) do
+          [{^key, {_generation, _epoch, signal} = value}] ->
+            match_spec = [{{key, value}, [], [{:const, {key, @empty}}]}]
+
+            case :ets.select_replace(Storage.control_table(), match_spec) do
+              1 -> {:cont, [signal | signals]}
+              0 -> {:cont, signals}
+            end
+
+          _ ->
+            {:cont, signals}
+        end
+      end
+    end)
+  end
+
+  defp maybe_notify_remaining(breaker_id, generation, epoch, capacity, wakeup) do
+    if occupied_count(breaker_id, capacity) > 0 do
+      case :ets.lookup(Storage.control_meta_table(), breaker_id) do
+        [{^breaker_id, ^generation, ^epoch, owner_pid, ^capacity, ^wakeup, _diagnostics}] ->
+          notify_once(owner_pid, breaker_id, generation, epoch, wakeup)
+
+        _ ->
+          :ok
+      end
+    end
+  end
+
+  defp occupied_count(breaker_id, capacity) do
+    Enum.count(0..(capacity - 1), fn index ->
+      case :ets.lookup(Storage.control_table(), {breaker_id, index}) do
+        [{{^breaker_id, ^index}, @empty}] -> false
+        [{{^breaker_id, ^index}, _signal}] -> true
+        [] -> false
+      end
+    end)
+  end
+
+  defp degrade(receipt) do
+    case Snapshot.lookup(receipt.breaker_id) do
+      {:ok, %Snapshot{generation: generation, epoch: epoch, control_health: :healthy} = snapshot}
+      when generation == receipt.generation and epoch == receipt.epoch ->
+        degraded = %{snapshot | control_health: :degraded}
+
+        :ets.select_replace(Storage.snapshot_table(), [
+          {{receipt.breaker_id, snapshot}, [], [{:const, {receipt.breaker_id, degraded}}]}
+        ])
+
+        :telemetry.execute(
+          [:lasso, :circuit_breaker, :control_saturated],
+          %{count: 1},
+          %{breaker_id: receipt.breaker_id, generation: generation, epoch: epoch}
+        )
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp clear_slots(breaker_id) do
+    :ets.select_delete(Storage.control_table(), [
+      {{{breaker_id, :_}, :_}, [], [true]}
+    ])
+  end
+end

--- a/lib/lasso/core/support/circuit_breaker/snapshot.ex
+++ b/lib/lasso/core/support/circuit_breaker/snapshot.ex
@@ -1,0 +1,48 @@
+defmodule Lasso.Core.Support.CircuitBreaker.Snapshot do
+  @moduledoc false
+
+  alias Lasso.Core.Support.CircuitBreaker.Storage
+
+  @type circuit_state :: :closed | :open | :half_open
+  @type control_health :: :healthy | :degraded
+
+  @enforce_keys [
+    :breaker_id,
+    :state,
+    :generation,
+    :epoch,
+    :owner_pid,
+    :ready?,
+    :recovery_deadline_us,
+    :half_open_capacity,
+    :half_open_inflight,
+    :control_health
+  ]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          breaker_id: {String.t(), :http | :ws},
+          state: circuit_state(),
+          generation: non_neg_integer(),
+          epoch: pos_integer(),
+          owner_pid: pid(),
+          ready?: boolean(),
+          recovery_deadline_us: integer() | nil,
+          half_open_capacity: pos_integer(),
+          half_open_inflight: non_neg_integer(),
+          control_health: control_health()
+        }
+
+  @spec lookup({String.t(), :http | :ws}) :: {:ok, t()} | :missing
+  def lookup(breaker_id) do
+    case :ets.lookup(Storage.snapshot_table(), breaker_id) do
+      [{^breaker_id, %__MODULE__{} = snapshot}] -> {:ok, snapshot}
+      _ -> :missing
+    end
+  end
+
+  @spec put(t()) :: true
+  def put(%__MODULE__{breaker_id: breaker_id} = snapshot) do
+    :ets.insert(Storage.snapshot_table(), {breaker_id, snapshot})
+  end
+end

--- a/lib/lasso/core/support/circuit_breaker/storage.ex
+++ b/lib/lasso/core/support/circuit_breaker/storage.ex
@@ -1,0 +1,33 @@
+defmodule Lasso.Core.Support.CircuitBreaker.Storage do
+  @moduledoc false
+
+  @snapshot_table :lasso_circuit_breaker_snapshots
+  @lease_table :lasso_circuit_breaker_leases
+  @control_table :lasso_circuit_breaker_control
+  @control_meta_table :lasso_circuit_breaker_control_meta
+
+  @spec create_tables!() :: :ok
+  def create_tables! do
+    create_table(@snapshot_table, [:set, read_concurrency: true, write_concurrency: true])
+    create_table(@lease_table, [:set, read_concurrency: true, write_concurrency: true])
+    create_table(@control_table, [:set, read_concurrency: true, write_concurrency: true])
+    create_table(@control_meta_table, [:set, read_concurrency: true, write_concurrency: true])
+    :ok
+  end
+
+  @spec snapshot_table() :: atom()
+  def snapshot_table, do: @snapshot_table
+
+  @spec lease_table() :: atom()
+  def lease_table, do: @lease_table
+
+  @spec control_table() :: atom()
+  def control_table, do: @control_table
+
+  @spec control_meta_table() :: atom()
+  def control_meta_table, do: @control_meta_table
+
+  defp create_table(name, options) do
+    :ets.new(name, [:named_table, :public | options])
+  end
+end

--- a/lib/lasso/providers/instance_state.ex
+++ b/lib/lasso/providers/instance_state.ex
@@ -7,6 +7,8 @@ defmodule Lasso.Providers.InstanceState do
   functions with consistent default shapes and `ArgumentError` guards.
   """
 
+  alias Lasso.Core.Support.CircuitBreaker.Snapshot
+
   @default_probe %{
     status: nil,
     http_status: nil,
@@ -23,7 +25,12 @@ defmodule Lasso.Providers.InstanceState do
     last_error: nil
   }
 
-  @default_circuit %{state: :closed, error: nil, recovery_deadline_ms: nil}
+  @default_circuit %{
+    state: :unavailable,
+    error: nil,
+    recovery_deadline_ms: nil,
+    control_health: :degraded
+  }
 
   @status_severity %{
     nil => 0,
@@ -116,11 +123,33 @@ defmodule Lasso.Providers.InstanceState do
   @spec read_circuit(String.t(), :http | :ws) :: map()
   def read_circuit(instance_id, transport)
       when is_binary(instance_id) and transport in [:http, :ws] do
-    case safe_lookup({:circuit, instance_id, transport}) do
-      [{_, data}] -> Map.merge(@default_circuit, data)
-      [] -> @default_circuit
+    case Snapshot.lookup({instance_id, transport}) do
+      {:ok, %{owner_pid: owner_pid, ready?: true} = snapshot} when is_pid(owner_pid) ->
+        if Process.alive?(owner_pid) do
+          state =
+            if snapshot.control_health == :degraded,
+              do: :half_open,
+              else: snapshot.state
+
+          %{
+            state: state,
+            error: nil,
+            recovery_deadline_ms: recovery_deadline_ms(snapshot.recovery_deadline_us),
+            control_health: snapshot.control_health
+          }
+        else
+          @default_circuit
+        end
+
+      _ ->
+        @default_circuit
     end
+  rescue
+    ArgumentError -> @default_circuit
   end
+
+  defp recovery_deadline_ms(nil), do: nil
+  defp recovery_deadline_ms(deadline_us), do: div(deadline_us, 1_000)
 
   @spec read_rate_limit(String.t(), :http | :ws) :: map()
   def read_rate_limit(instance_id, transport)

--- a/lib/lasso/providers/instance_state.ex
+++ b/lib/lasso/providers/instance_state.ex
@@ -7,7 +7,7 @@ defmodule Lasso.Providers.InstanceState do
   functions with consistent default shapes and `ArgumentError` guards.
   """
 
-  alias Lasso.Core.Support.CircuitBreaker.Snapshot
+  alias Lasso.Core.Support.CircuitBreaker.{ControlRing, Snapshot, Storage}
 
   @default_probe %{
     status: nil,
@@ -217,6 +217,21 @@ defmodule Lasso.Providers.InstanceState do
         ArgumentError -> :ok
       end
     end)
+
+    Enum.each([:http, :ws], fn transport ->
+      breaker_id = {instance_id, transport}
+      clear_breaker_table(Storage.snapshot_table(), breaker_id)
+      clear_breaker_table(Storage.lease_table(), breaker_id)
+      ControlRing.delete(breaker_id)
+    end)
+
+    :ok
+  end
+
+  defp clear_breaker_table(table, breaker_id) do
+    :ets.delete(table, breaker_id)
+  rescue
+    ArgumentError -> :ok
   end
 
   defp safe_lookup(key) do

--- a/scripts/circuit_breaker_admission_benchmark.exs
+++ b/scripts/circuit_breaker_admission_benchmark.exs
@@ -1,0 +1,126 @@
+alias Lasso.Core.Support.CircuitBreaker
+alias Lasso.Core.Support.CircuitBreaker.{Admission, ControlRing, Snapshot, Storage}
+
+iterations = 100_000
+half_open_iterations = 1_000
+
+measure = fn fun, count ->
+  started_us = System.monotonic_time(:microsecond)
+  Enum.each(1..count, fn _index -> fun.() end)
+  elapsed_us = System.monotonic_time(:microsecond) - started_us
+
+  %{
+    iterations: count,
+    elapsed_us: elapsed_us,
+    average_us: elapsed_us / count,
+    operations_per_second: count * 1_000_000 / max(elapsed_us, 1)
+  }
+end
+
+start_breaker = fn name, config ->
+  id = {name, :http}
+  {:ok, pid} = CircuitBreaker.start_link({id, Map.new(config)})
+  {id, pid}
+end
+
+set_snapshot_state = fn id, state, recovery_deadline_us ->
+  {:ok, snapshot} = Snapshot.lookup(id)
+
+  Snapshot.put(%{
+    snapshot
+    | state: state,
+      recovery_deadline_us: recovery_deadline_us,
+      half_open_inflight: 0,
+      control_health: :healthy
+  })
+end
+
+deadline = fn -> System.monotonic_time(:microsecond) + 60_000_000 end
+
+{closed_id, closed_pid} = start_breaker.("bench-closed", control_ring_capacity: 64)
+closed_fun = fn -> {:ok, _receipt} = Admission.check(closed_id, deadline.()) end
+closed_responsive = measure.(closed_fun, iterations)
+
+:sys.suspend(closed_pid)
+closed_suspended = measure.(closed_fun, iterations)
+:sys.resume(closed_pid)
+
+{open_id, open_pid} = start_breaker.("bench-open", recovery_timeout: 60_000)
+CircuitBreaker.open(open_id)
+%{state: :open} = CircuitBreaker.get_state(open_id)
+open_fun = fn -> {:error, :circuit_open} = Admission.check(open_id, deadline.()) end
+open_responsive = measure.(open_fun, iterations)
+
+:sys.suspend(open_pid)
+open_suspended = measure.(open_fun, iterations)
+:sys.resume(open_pid)
+
+{half_open_id, half_open_pid} = start_breaker.("bench-half-open", success_threshold: 1)
+:sys.replace_state(half_open_pid, &%{&1 | state: :half_open})
+set_snapshot_state.(half_open_id, :half_open, nil)
+
+half_open_normal =
+  measure.(
+    fn ->
+      {:ok, receipt} = CircuitBreaker.admit(half_open_id, deadline.())
+      CircuitBreaker.release_half_open(receipt)
+      %{inflight_count: 0} = :sys.get_state(half_open_pid)
+    end,
+    half_open_iterations
+  )
+
+:sys.suspend(half_open_pid)
+timeout_started_us = System.monotonic_time(:microsecond)
+
+{:error, :admission_timeout} =
+  CircuitBreaker.admit(half_open_id, timeout_started_us + 25_000)
+
+half_open_timeout_us = System.monotonic_time(:microsecond) - timeout_started_us
+:sys.resume(half_open_pid)
+%{inflight_count: 0} = :sys.get_state(half_open_pid)
+
+{ring_id, ring_pid} = start_breaker.("bench-ring", control_ring_capacity: 64)
+{:ok, ring_receipt} = Admission.check(ring_id, deadline.())
+:sys.suspend(ring_pid)
+
+ring_results =
+  Enum.map(1..256, fn _index -> CircuitBreaker.report_closed(ring_receipt, :ok) end)
+
+ring_stats = ControlRing.stats(ring_id)
+
+output = %{
+  environment: %{
+    elixir: System.version(),
+    otp_release: System.otp_release(),
+    schedulers_online: System.schedulers_online(),
+    os: :os.type() |> inspect(),
+    iterations: iterations,
+    half_open_iterations: half_open_iterations
+  },
+  admission: %{
+    closed_responsive: closed_responsive,
+    closed_suspended: closed_suspended,
+    open_responsive: open_responsive,
+    open_suspended: open_suspended,
+    half_open_normal: half_open_normal,
+    half_open_timeout_us: half_open_timeout_us,
+    healthy_snapshot_lookups: 1,
+    healthy_synchronous_owner_calls: 0
+  },
+  saturation: %{
+    accepted: Enum.count(ring_results, &(&1 == :ok)),
+    rejected: Enum.count(ring_results, &(&1 == {:error, :saturated})),
+    stats: Map.drop(ring_stats, [:owner_pid])
+  }
+}
+
+IO.puts(Jason.encode!(output, pretty: true))
+
+:sys.resume(ring_pid)
+Enum.each([closed_pid, open_pid, half_open_pid, ring_pid], &GenServer.stop/1)
+
+Enum.each([closed_id, open_id, half_open_id, ring_id], fn id ->
+  :ets.delete(Storage.snapshot_table(), id)
+  :ets.delete(Storage.lease_table(), id)
+  :ets.delete(Storage.control_meta_table(), id)
+end)

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -86,15 +86,8 @@ defmodule Lasso.RPC.SelectionTest do
           Lasso.Providers.Catalog.lookup_instance_id(profile, chain, provider_id)
         end)
 
-      :ets.insert(:lasso_instance_state, {
-        {:circuit, provider_1, :http},
-        %{state: :half_open, error: nil, recovery_deadline_ms: nil}
-      })
-
-      :ets.insert(:lasso_instance_state, {
-        {:circuit, provider_2, :http},
-        %{state: :closed, error: nil, recovery_deadline_ms: nil}
-      })
+      set_circuit_snapshot(provider_1, :half_open)
+      set_circuit_snapshot(provider_2, :closed)
 
       assert {:error, :no_providers_available} =
                Selection.select_provider(profile, chain, "eth_blockNumber",
@@ -118,15 +111,8 @@ defmodule Lasso.RPC.SelectionTest do
           Lasso.Providers.Catalog.lookup_instance_id(profile, chain, provider_id)
         end)
 
-      :ets.insert(:lasso_instance_state, {
-        {:circuit, provider_1, :http},
-        %{state: :half_open, error: nil, recovery_deadline_ms: nil}
-      })
-
-      :ets.insert(:lasso_instance_state, {
-        {:circuit, provider_2, :http},
-        %{state: :closed, error: nil, recovery_deadline_ms: nil}
-      })
+      set_circuit_snapshot(provider_1, :half_open)
+      set_circuit_snapshot(provider_2, :closed)
 
       {:ok, selected} =
         Selection.select_provider(profile, chain, "eth_blockNumber",
@@ -254,5 +240,12 @@ defmodule Lasso.RPC.SelectionTest do
       assert "provider_1" in provider_ids
       assert "provider_2" in provider_ids
     end
+  end
+
+  defp set_circuit_snapshot(instance_id, state) do
+    alias Lasso.Core.Support.CircuitBreaker.Snapshot
+
+    {:ok, current} = Snapshot.lookup({instance_id, :http})
+    Snapshot.put(%{current | state: state, control_health: :healthy})
   end
 end

--- a/test/lasso/core/transport/websocket/connection_telemetry_test.exs
+++ b/test/lasso/core/transport/websocket/connection_telemetry_test.exs
@@ -10,6 +10,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
 
   alias Lasso.RPC.Transport.WebSocket.{Connection, Endpoint}
   alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Providers.InstanceState
   alias Lasso.Test.TelemetrySync
 
   setup do
@@ -65,6 +66,8 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection.TelemetryTest do
       nil -> :ok
       pid -> catch_exit(GenServer.stop(pid, :normal))
     end
+
+    InstanceState.clear(instance_id)
   end
 
   defp resolve_instance_id(endpoint) do

--- a/test/lasso/error_scenarios_test.exs
+++ b/test/lasso/error_scenarios_test.exs
@@ -12,6 +12,9 @@ defmodule Lasso.ErrorScenariosTest do
   require Logger
 
   alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.CircuitBreaker.ControlRing
+  alias Lasso.Core.Support.CircuitBreaker.Storage
+  alias Lasso.Test.Eventually
 
   @moduletag :error_scenarios
   @moduletag :fault_tolerance
@@ -23,6 +26,7 @@ defmodule Lasso.ErrorScenariosTest do
         {"test_provider_recovery", :http}
       ]
       |> Enum.each(fn {instance_id, transport} ->
+        breaker_id = {instance_id, transport}
         key = "#{instance_id}:#{transport}"
         via_name = {:via, Registry, {Lasso.Registry, {:circuit_breaker, key}}}
 
@@ -37,6 +41,11 @@ defmodule Lasso.ErrorScenariosTest do
               :exit, _ -> :ok
             end
         end
+
+        :ets.delete(:lasso_instance_state, {:circuit, instance_id, transport})
+        :ets.delete(Storage.snapshot_table(), breaker_id)
+        :ets.delete(Storage.lease_table(), breaker_id)
+        ControlRing.delete(breaker_id)
       end)
     end)
 
@@ -61,7 +70,12 @@ defmodule Lasso.ErrorScenariosTest do
         assert {:executed, {:exception, _}} = result
       end
 
-      # Circuit should be open
+      Eventually.assert_eventually(
+        fn -> CircuitBreaker.get_state(breaker_id).state == :open end,
+        timeout: 1_000,
+        interval: 1
+      )
+
       state = CircuitBreaker.get_state(breaker_id)
       assert state.state == :open
       assert state.failure_count >= 3
@@ -78,7 +92,12 @@ defmodule Lasso.ErrorScenariosTest do
         CircuitBreaker.call(breaker_id, fn -> raise "test error" end)
       end
 
-      # Verify circuit is open
+      Eventually.assert_eventually(
+        fn -> CircuitBreaker.get_state(breaker_id).state == :open end,
+        timeout: 1_000,
+        interval: 1
+      )
+
       state = CircuitBreaker.get_state(breaker_id)
       assert state.state == :open
 

--- a/test/lasso/observability/telemetry_contract_test.exs
+++ b/test/lasso/observability/telemetry_contract_test.exs
@@ -118,6 +118,10 @@ defmodule Lasso.Observability.TelemetryContractTest do
         %{state | recovery_deadline_ms: System.monotonic_time(:millisecond) - 1}
       end)
 
+      alias Lasso.Core.Support.CircuitBreaker.Snapshot
+      {:ok, snapshot} = Snapshot.lookup(id)
+      Snapshot.put(%{snapshot | recovery_deadline_us: System.monotonic_time(:microsecond) - 1})
+
       {:ok, collector} =
         TelemetrySync.attach_collector([:lasso, :circuit_breaker, :half_open])
 

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -2,6 +2,7 @@ defmodule Lasso.Providers.CandidateListingTest do
   use ExUnit.Case, async: false
 
   alias Lasso.Config.ConfigStore
+  alias Lasso.Core.Support.CircuitBreaker.{Snapshot, Storage}
   alias Lasso.Providers.{Catalog, CandidateListing}
 
   @profile "cl_test"
@@ -25,6 +26,11 @@ defmodule Lasso.Providers.CandidateListingTest do
 
     # Clean any leftover instance state before each test
     clean_instance_state()
+
+    Enum.each(Catalog.get_profile_providers(@profile, @chain), fn provider ->
+      set_circuit_state(provider.instance_id, :http, :closed)
+      set_circuit_state(provider.instance_id, :ws, :closed)
+    end)
 
     on_exit(fn ->
       clean_instance_state()
@@ -292,9 +298,17 @@ defmodule Lasso.Providers.CandidateListingTest do
   end
 
   defp set_circuit_state(instance_id, transport, state, recovery_deadline_ms \\ nil) do
-    :ets.insert(@instance_table, {
-      {:circuit, instance_id, transport},
-      %{state: state, error: nil, recovery_deadline_ms: recovery_deadline_ms}
+    Snapshot.put(%Snapshot{
+      breaker_id: {instance_id, transport},
+      state: state,
+      generation: 1,
+      epoch: 1,
+      owner_pid: self(),
+      ready?: true,
+      recovery_deadline_us: recovery_deadline_ms && recovery_deadline_ms * 1_000,
+      half_open_capacity: 1,
+      half_open_inflight: 0,
+      control_health: :healthy
     })
   end
 
@@ -326,6 +340,8 @@ defmodule Lasso.Providers.CandidateListingTest do
     Enum.each(providers, fn pp ->
       :ets.delete(@instance_table, {:circuit, pp.instance_id, :http})
       :ets.delete(@instance_table, {:circuit, pp.instance_id, :ws})
+      :ets.delete(Storage.snapshot_table(), {pp.instance_id, :http})
+      :ets.delete(Storage.snapshot_table(), {pp.instance_id, :ws})
       :ets.delete(@instance_table, {:rate_limit, pp.instance_id, :http})
       :ets.delete(@instance_table, {:rate_limit, pp.instance_id, :ws})
       :ets.delete(@instance_table, {:health_probe, pp.instance_id})

--- a/test/lasso/providers/instance_state_test.exs
+++ b/test/lasso/providers/instance_state_test.exs
@@ -1,6 +1,8 @@
 defmodule Lasso.Providers.InstanceStateTest do
   use ExUnit.Case, async: false
 
+  alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.CircuitBreaker.{ControlRing, Storage}
   alias Lasso.Providers.InstanceState
 
   @table :lasso_instance_state
@@ -131,6 +133,19 @@ defmodule Lasso.Providers.InstanceStateTest do
     test "degraded maps to :limited" do
       assert InstanceState.status_to_availability(:degraded) == :limited
     end
+  end
+
+  test "clear removes every application-owned breaker row for the instance" do
+    id = {@instance_id, :http}
+    {:ok, pid} = CircuitBreaker.start_link({id, %{control_ring_capacity: 4}})
+    :ets.insert(Storage.lease_table(), {id, %{token: "stale"}})
+    :ok = GenServer.stop(pid)
+
+    assert :ok = InstanceState.clear(@instance_id)
+    assert [] = :ets.lookup(Storage.snapshot_table(), id)
+    assert [] = :ets.lookup(Storage.lease_table(), id)
+    assert {:error, :not_found} = ControlRing.stats(id)
+    assert [] = :ets.match_object(Storage.control_table(), {{id, :_}, :_})
   end
 
   # Helpers

--- a/test/lasso/rpc/circuit_breaker_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_admission_test.exs
@@ -16,34 +16,39 @@ defmodule Lasso.RPC.CircuitBreakerAdmissionTest do
     %{id: id, breaker_pid: breaker_pid}
   end
 
-  test "closed admission uses one snapshot lookup and does not cross the owner", %{
+  test "closed admission does not cross the suspended owner", %{
     id: id,
     breaker_pid: breaker_pid
   } do
-    test_pid = self()
-    handler_id = "admission-count-#{System.unique_integer([:positive])}"
-
-    :ok =
-      :telemetry.attach(
-        handler_id,
-        [:lasso, :circuit_breaker, :snapshot_admission],
-        fn _event, measurements, metadata, _config ->
-          send(test_pid, {:admission_measurements, measurements, metadata})
-        end,
-        nil
-      )
-
-    on_exit(fn -> :telemetry.detach(handler_id) end)
     :sys.suspend(breaker_pid)
     on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+    {:message_queue_len, queued_before} = Process.info(breaker_pid, :message_queue_len)
 
     deadline_us = System.monotonic_time(:microsecond) + 25_000
 
     assert {:ok, %AdmissionReceipt{kind: :closed}} = Admission.check(id, deadline_us)
     assert {:transport_ran, :ok} = run_after_admission(id, deadline_us, fn -> :ok end)
+    assert {:message_queue_len, ^queued_before} = Process.info(breaker_pid, :message_queue_len)
+  end
 
-    assert_receive {:admission_measurements, %{snapshot_lookups: 1, synchronous_owner_calls: 0},
-                    %{decision: :allow}}
+  test "snapshot admission invokes no telemetry consumer", %{id: id} do
+    test_pid = self()
+    handler_id = "admission-consumer-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:lasso, :circuit_breaker, :snapshot_admission],
+        fn _event, _measurements, _metadata, _config ->
+          send(test_pid, :unexpected_snapshot_admission_telemetry)
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert {:ok, %AdmissionReceipt{kind: :closed}} = Admission.check(id, deadline_us())
+    refute_receive :unexpected_snapshot_admission_telemetry, 0
   end
 
   test "open admission denies while its owner is suspended", %{

--- a/test/lasso/rpc/circuit_breaker_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_admission_test.exs
@@ -1,0 +1,118 @@
+defmodule Lasso.RPC.CircuitBreakerAdmissionTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.CircuitBreaker.{Admission, AdmissionReceipt, Snapshot, Storage}
+
+  setup do
+    id = {"admission-#{System.unique_integer([:positive])}", :http}
+    {:ok, breaker_pid} = CircuitBreaker.start_link({id, %{recovery_timeout: 60_000}})
+
+    on_exit(fn ->
+      if Process.alive?(breaker_pid), do: GenServer.stop(breaker_pid)
+      :ets.delete(Storage.snapshot_table(), id)
+    end)
+
+    %{id: id, breaker_pid: breaker_pid}
+  end
+
+  test "closed admission uses one snapshot lookup and does not cross the owner", %{
+    id: id,
+    breaker_pid: breaker_pid
+  } do
+    test_pid = self()
+    handler_id = "admission-count-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:lasso, :circuit_breaker, :snapshot_admission],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:admission_measurements, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    deadline_us = System.monotonic_time(:microsecond) + 25_000
+
+    assert {:ok, %AdmissionReceipt{kind: :closed}} = Admission.check(id, deadline_us)
+    assert {:transport_ran, :ok} = run_after_admission(id, deadline_us, fn -> :ok end)
+
+    assert_receive {:admission_measurements, %{snapshot_lookups: 1, synchronous_owner_calls: 0},
+                    %{decision: :allow}}
+  end
+
+  test "open admission denies while its owner is suspended", %{
+    id: id,
+    breaker_pid: breaker_pid
+  } do
+    CircuitBreaker.open(id)
+    assert %{state: :open} = CircuitBreaker.get_state(id)
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    deadline_us = System.monotonic_time(:microsecond) + 25_000
+    assert {:error, :circuit_open} = Admission.check(id, deadline_us)
+  end
+
+  test "missing, unready, and dead-owner snapshots fail closed", %{id: id} do
+    :ets.delete(Storage.snapshot_table(), id)
+    assert {:error, :admission_unavailable} = Admission.check(id, deadline_us())
+
+    put_snapshot(id, self(), ready?: false)
+    assert {:error, :admission_unavailable} = Admission.check(id, deadline_us())
+
+    owner = spawn(fn -> receive do: (:stop -> :ok) end)
+    owner_monitor = Process.monitor(owner)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_monitor, :process, ^owner, :killed}
+
+    put_snapshot(id, owner)
+    assert {:error, :admission_unavailable} = Admission.check(id, deadline_us())
+  end
+
+  test "the open recovery boundary is exceptional and equality expires", %{id: id} do
+    now_us = System.monotonic_time(:microsecond)
+    put_snapshot(id, self(), state: :open, recovery_deadline_us: now_us + 1)
+
+    assert {:error, :circuit_open} = Admission.check(id, now_us + 10, now_us)
+
+    assert {:exceptional, %Snapshot{state: :open}} =
+             Admission.check(id, now_us + 10, now_us + 1)
+
+    assert {:error, :admission_timeout} = Admission.check(id, now_us + 1, now_us + 1)
+  end
+
+  defp run_after_admission(id, deadline_us, fun) do
+    case Admission.check(id, deadline_us) do
+      {:ok, _receipt} -> {:transport_ran, fun.()}
+      other -> other
+    end
+  end
+
+  defp put_snapshot(id, owner_pid, overrides \\ []) do
+    defaults = [
+      breaker_id: id,
+      state: :closed,
+      generation: 1,
+      epoch: 1,
+      owner_pid: owner_pid,
+      ready?: true,
+      recovery_deadline_us: nil,
+      half_open_capacity: 1,
+      half_open_inflight: 0,
+      control_health: :healthy
+    ]
+
+    defaults
+    |> Keyword.merge(overrides)
+    |> then(&struct!(Snapshot, &1))
+    |> Snapshot.put()
+  end
+
+  defp deadline_us, do: System.monotonic_time(:microsecond) + 25_000
+end

--- a/test/lasso/rpc/circuit_breaker_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_admission_test.exs
@@ -1,7 +1,7 @@
 defmodule Lasso.RPC.CircuitBreakerAdmissionTest do
   use ExUnit.Case, async: false
 
-  alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.{AttemptLifecycle, CircuitBreaker}
   alias Lasso.Core.Support.CircuitBreaker.{Admission, AdmissionReceipt, Snapshot, Storage}
 
   setup do
@@ -94,6 +94,27 @@ defmodule Lasso.RPC.CircuitBreakerAdmissionTest do
 
     assert {:error, :admission_timeout} =
              run_after_admission(id, now_us - 1, fn -> flunk("transport ran after deadline") end)
+  end
+
+  test "a closed receipt cannot dispatch after its captured deadline", %{id: id} do
+    deadline_us = System.monotonic_time(:microsecond) + 1_000
+    assert {:ok, receipt} = Admission.check(id, deadline_us)
+    Process.sleep(2)
+    test_pid = self()
+
+    assert {:__attempt_lifecycle_rejected__, :timeout} =
+             AttemptLifecycle.run(
+               self(),
+               receipt,
+               fn -> send(test_pid, :transport_ran) end,
+               100,
+               nil,
+               nil,
+               :immediate,
+               deadline_us
+             )
+
+    refute_receive :transport_ran, 20
   end
 
   defp run_after_admission(id, deadline_us, fun) do

--- a/test/lasso/rpc/circuit_breaker_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_admission_test.exs
@@ -87,6 +87,15 @@ defmodule Lasso.RPC.CircuitBreakerAdmissionTest do
     assert {:error, :admission_timeout} = Admission.check(id, now_us + 1, now_us + 1)
   end
 
+  test "an expired closed snapshot never authorizes transport", %{id: id} do
+    now_us = System.monotonic_time(:microsecond)
+
+    assert {:error, :admission_timeout} = Admission.check(id, now_us, now_us)
+
+    assert {:error, :admission_timeout} =
+             run_after_admission(id, now_us - 1, fn -> flunk("transport ran after deadline") end)
+  end
+
   defp run_after_admission(id, deadline_us, fun) do
     case Admission.check(id, deadline_us) do
       {:ok, _receipt} -> {:transport_ran, fun.()}

--- a/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
+++ b/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
@@ -373,8 +373,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     id = start_half_open_breaker()
     test_pid = self()
 
-    assert {:executed,
-            {:error, %JError{category: :local_capacity_rejection, breaker_penalty?: false}, 25}} =
+    assert {:rejected, :admission_timeout} =
              CircuitBreaker.call(id, fn -> Process.sleep(:infinity) end, 25,
                dispatch: :deferred,
                on_terminal: fn result, elapsed_ms ->
@@ -675,7 +674,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     id = start_half_open_breaker()
     test_pid = self()
 
-    assert {:executed, {:error, %JError{category: :local_capacity_rejection}, 25}} =
+    assert {:rejected, :admission_timeout} =
              CircuitBreaker.call(
                id,
                fn ->
@@ -693,7 +692,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     refute_receive {:terminal, _, _}, 100
   end
 
-  test "late confirmation after caller death is rejected" do
+  test "caller death stops an authorized but unconfirmed transport" do
     id = start_half_open_breaker()
     test_pid = self()
 
@@ -723,15 +722,15 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     assert_receive {:authorized_for_late_confirm, _context, worker_pid}, 1_000
     Process.exit(caller_pid, :kill)
     send(worker_pid, :confirm)
-    assert_receive {:late_confirmation, {:error, :cancelled}}, 1_000
+    refute_receive {:late_confirmation, _}, 100
     refute_receive {:terminal, _, _}, 100
   end
 
-  test "confirmation after deadline returns a predispatch timeout to a live caller" do
+  test "deadline stops an authorized but unconfirmed transport" do
     id = start_half_open_breaker()
     test_pid = self()
 
-    assert {:executed, {:error, %JError{category: :local_capacity_rejection}, 25}} =
+    assert {:rejected, :admission_timeout} =
              CircuitBreaker.call(
                id,
                fn ->
@@ -749,7 +748,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
                end
              )
 
-    assert_receive {:late_deadline_confirmation, {:error, :cancelled}}, 1_000
+    refute_receive {:late_deadline_confirmation, _}, 100
     refute_receive {:terminal, _, _}, 100
 
     breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))

--- a/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
+++ b/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
@@ -2,6 +2,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
   use ExUnit.Case, async: false
 
   alias Lasso.Core.Support.{AttemptLifecycle, CircuitBreaker}
+  alias Lasso.Core.Support.CircuitBreaker.Snapshot
   alias Lasso.JSONRPC.Error, as: JError
 
   setup_all do
@@ -762,18 +763,18 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))
     test_pid = self()
 
-    :erlang.suspend_process(breaker_pid)
+    :sys.suspend(breaker_pid)
 
     caller_pid =
       spawn(fn ->
-        result = CircuitBreaker.call(id, fn -> send(test_pid, :admission_attempt_ran) end)
+        result = CircuitBreaker.call(id, fn -> send(test_pid, :admission_attempt_ran) end, 25)
         send(test_pid, {:admission_result, result})
         Process.sleep(:infinity)
       end)
 
     assert_receive {:admission_result, {:rejected, :admission_timeout}}, 1_000
     assert Process.alive?(caller_pid)
-    :erlang.resume_process(breaker_pid)
+    :sys.resume(breaker_pid)
     Process.sleep(50)
 
     state = :sys.get_state(breaker_pid)
@@ -818,7 +819,21 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
         {id, %{failure_threshold: 1, recovery_timeout: 60_000, success_threshold: 1}}
       )
 
-    :sys.replace_state(breaker_pid, fn state -> %{state | state: :half_open} end)
+    state = :sys.replace_state(breaker_pid, fn state -> %{state | state: :half_open} end)
+
+    Snapshot.put(%Snapshot{
+      breaker_id: id,
+      state: :half_open,
+      generation: state.transition_generation,
+      epoch: state.process_epoch,
+      owner_pid: breaker_pid,
+      ready?: true,
+      recovery_deadline_us: nil,
+      half_open_capacity: 1,
+      half_open_inflight: 0,
+      control_health: :healthy
+    })
+
     id
   end
 

--- a/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
+++ b/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
@@ -722,7 +722,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     assert_receive {:authorized_for_late_confirm, _context, worker_pid}, 1_000
     Process.exit(caller_pid, :kill)
     send(worker_pid, :confirm)
-    refute_receive {:late_confirmation, _}, 100
+    assert_receive {:late_confirmation, {:error, :cancelled}}, 1_000
     refute_receive {:terminal, _, _}, 100
   end
 
@@ -748,7 +748,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
                end
              )
 
-    refute_receive {:late_deadline_confirmation, _}, 100
+    assert_receive {:late_deadline_confirmation, {:error, :cancelled}}, 1_000
     refute_receive {:terminal, _, _}, 100
 
     breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))

--- a/test/lasso/rpc/circuit_breaker_control_ring_test.exs
+++ b/test/lasso/rpc/circuit_breaker_control_ring_test.exs
@@ -98,21 +98,21 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
     {id, breaker_pid} = start_breaker(control_ring_capacity: 2)
     {:ok, receipt} = Admission.check(id, deadline_us())
 
-    [{^id, _, _, _, 2, _head, old_tail, _wakeup, _diagnostics, old_ring_ref}] =
+    [{^id, _, _, _, 2, _wakeup, _diagnostics, old_ring_ref}] =
       :ets.lookup(Storage.control_meta_table(), id)
 
     ControlRing.initialize(id, receipt.generation + 1, receipt.epoch + 1, breaker_pid,
       capacity: 2
     )
 
-    old_ticket = :atomics.add_get(old_tail, 1, 1) - 1
-    key = {id, rem(old_ticket, 2)}
+    old_sequence = System.unique_integer([:positive, :monotonic])
+    key = {id, rem(old_sequence, 2)}
 
     match_spec = [
       {{key, {old_ring_ref, :empty}}, [],
        [
          {:const,
-          {key, {old_ring_ref, {old_ticket, receipt.generation, receipt.epoch, :success}}}}
+          {key, {old_ring_ref, {old_sequence, receipt.generation, receipt.epoch, :success}}}}
        ]}
     ]
 

--- a/test/lasso/rpc/circuit_breaker_control_ring_test.exs
+++ b/test/lasso/rpc/circuit_breaker_control_ring_test.exs
@@ -1,0 +1,98 @@
+defmodule Lasso.RPC.CircuitBreakerControlRingTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.CircuitBreaker.{Admission, ControlRing, Snapshot, Storage}
+  alias Lasso.JSONRPC.Error, as: JError
+
+  test "suspension preserves hard slot and wakeup bounds and degrades only one scope" do
+    {id, breaker_pid} = start_breaker(control_ring_capacity: 4)
+    {other_id, _other_pid} = start_breaker(control_ring_capacity: 4)
+    {:ok, receipt} = Admission.check(id, deadline_us())
+
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    results = Enum.map(1..12, fn _index -> CircuitBreaker.report_closed(receipt, :ok) end)
+
+    assert Enum.count(results, &(&1 == :ok)) == 4
+    assert Enum.count(results, &(&1 == {:error, :saturated})) == 8
+    assert %{capacity: 4, occupied: 4, wakeup_pending: 1, dropped: 8} = ControlRing.stats(id)
+    assert ordinary_wakeup_count(breaker_pid, id) == 1
+    assert {:ok, %Snapshot{control_health: :degraded}} = Snapshot.lookup(id)
+    assert {:ok, %Snapshot{control_health: :healthy, state: :closed}} = Snapshot.lookup(other_id)
+
+    :sys.resume(breaker_pid)
+    assert %{state: :half_open} = CircuitBreaker.get_state(id)
+
+    assert {:ok, %Snapshot{state: :half_open, control_health: :healthy, generation: 2}} =
+             Snapshot.lookup(id)
+  end
+
+  test "draining a bounded batch rearms a wakeup while slots remain occupied" do
+    {id, breaker_pid} = start_breaker(control_ring_capacity: 4)
+    {:ok, receipt} = Admission.check(id, deadline_us())
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    assert :ok = CircuitBreaker.report_closed(receipt, :ok)
+    assert :ok = CircuitBreaker.report_closed(receipt, :ok)
+    assert :ok = CircuitBreaker.report_closed(receipt, :ok)
+
+    assert [_signal] = ControlRing.drain(id, 1, receipt.generation, receipt.epoch)
+    assert %{occupied: 2, wakeup_pending: 1} = ControlRing.stats(id)
+    assert ordinary_wakeup_count(breaker_pid, id) <= 2
+  end
+
+  test "the compatibility adapter retains no large response or error payload" do
+    {id, breaker_pid} = start_breaker(control_ring_capacity: 2)
+    {:ok, receipt} = Admission.check(id, deadline_us())
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    huge = String.duplicate("sensitive-body", 100_000)
+
+    error =
+      JError.new(-32_000, huge,
+        category: :server_error,
+        retriable?: true,
+        breaker_penalty?: true,
+        data: %{"body" => huge}
+      )
+
+    assert :ok = CircuitBreaker.report_closed(receipt, {:error, error, 1})
+
+    retained =
+      Storage.control_table()
+      |> :ets.tab2list()
+      |> Enum.filter(fn {{breaker_id, _index}, value} -> breaker_id == id and value != :empty end)
+
+    assert byte_size(:erlang.term_to_binary(retained)) < 512
+    refute inspect(retained) =~ "sensitive-body"
+  end
+
+  defp start_breaker(config) do
+    id = {"control-#{System.unique_integer([:positive])}", :http}
+    {:ok, pid} = CircuitBreaker.start_link({id, Map.new(config)})
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: GenServer.stop(pid)
+      :ets.delete(Storage.snapshot_table(), id)
+      :ets.delete(Storage.lease_table(), id)
+      :ets.delete(Storage.control_meta_table(), id)
+    end)
+
+    {id, pid}
+  end
+
+  defp ordinary_wakeup_count(pid, id) do
+    {:messages, messages} = Process.info(pid, :messages)
+
+    Enum.count(messages, fn
+      {:breaker_control_ready, ^id, _generation, _epoch} -> true
+      _ -> false
+    end)
+  end
+
+  defp deadline_us, do: System.monotonic_time(:microsecond) + 100_000
+end

--- a/test/lasso/rpc/circuit_breaker_control_ring_test.exs
+++ b/test/lasso/rpc/circuit_breaker_control_ring_test.exs
@@ -65,10 +65,59 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
     retained =
       Storage.control_table()
       |> :ets.tab2list()
-      |> Enum.filter(fn {{breaker_id, _index}, value} -> breaker_id == id and value != :empty end)
+      |> Enum.filter(fn
+        {{breaker_id, _index}, {_ring_ref, {_ticket, _generation, _epoch, _signal}}} ->
+          breaker_id == id
+
+        _ ->
+          false
+      end)
 
     assert byte_size(:erlang.term_to_binary(retained)) < 512
     refute inspect(retained) =~ "sensitive-body"
+  end
+
+  test "the ring drains accepted outcomes in linearized producer order" do
+    {id, breaker_pid} = start_breaker(control_ring_capacity: 4)
+    {:ok, receipt} = Admission.check(id, deadline_us())
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    assert :ok = CircuitBreaker.report_closed(receipt, {:error, :timeout})
+    assert :ok = CircuitBreaker.report_closed(receipt, :ok)
+    assert :ok = CircuitBreaker.report_closed(receipt, {:error, :timeout})
+
+    assert [
+             {:failure, :timeout, true},
+             :success,
+             {:failure, :timeout, true}
+           ] = ControlRing.drain(id, 4, receipt.generation, receipt.epoch)
+  end
+
+  test "an old ring reference cannot write into replacement slots" do
+    {id, breaker_pid} = start_breaker(control_ring_capacity: 2)
+    {:ok, receipt} = Admission.check(id, deadline_us())
+
+    [{^id, _, _, _, 2, _head, old_tail, _wakeup, _diagnostics, old_ring_ref}] =
+      :ets.lookup(Storage.control_meta_table(), id)
+
+    ControlRing.initialize(id, receipt.generation + 1, receipt.epoch + 1, breaker_pid,
+      capacity: 2
+    )
+
+    old_ticket = :atomics.add_get(old_tail, 1, 1) - 1
+    key = {id, rem(old_ticket, 2)}
+
+    match_spec = [
+      {{key, {old_ring_ref, :empty}}, [],
+       [
+         {:const,
+          {key, {old_ring_ref, {old_ticket, receipt.generation, receipt.epoch, :success}}}}
+       ]}
+    ]
+
+    assert 0 = :ets.select_replace(Storage.control_table(), match_spec)
+    assert [] = ControlRing.drain(id, 2, receipt.generation, receipt.epoch)
   end
 
   defp start_breaker(config) do

--- a/test/lasso/rpc/circuit_breaker_control_ring_test.exs
+++ b/test/lasso/rpc/circuit_breaker_control_ring_test.exs
@@ -9,6 +9,20 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
     {id, breaker_pid} = start_breaker(control_ring_capacity: 4)
     {other_id, _other_pid} = start_breaker(control_ring_capacity: 4)
     {:ok, receipt} = Admission.check(id, deadline_us())
+    test_pid = self()
+    handler_id = "control-saturation-consumer-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:lasso, :circuit_breaker, :control_saturated],
+        fn _event, _measurements, _metadata, _config ->
+          send(test_pid, :unexpected_control_saturation_telemetry)
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
 
     :sys.suspend(breaker_pid)
     on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
@@ -19,6 +33,7 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
     assert Enum.count(results, &(&1 == {:error, :saturated})) == 8
     assert %{capacity: 4, occupied: 4, wakeup_pending: 1, dropped: 8} = ControlRing.stats(id)
     assert ordinary_wakeup_count(breaker_pid, id) == 1
+    refute_receive :unexpected_control_saturation_telemetry, 0
     assert {:ok, %Snapshot{control_health: :degraded}} = Snapshot.lookup(id)
     assert {:ok, %Snapshot{control_health: :healthy, state: :closed}} = Snapshot.lookup(other_id)
 
@@ -146,6 +161,49 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
 
     :sys.resume(breaker_pid)
     await_empty_ring(id)
+  end
+
+  test "an open transition commits before optional observers run" do
+    {id, _breaker_pid} =
+      start_breaker(
+        control_ring_capacity: 4,
+        category_thresholds: %{timeout: 1},
+        recovery_timeout: 60_000
+      )
+
+    {:ok, receipt} = Admission.check(id, deadline_us())
+    test_pid = self()
+    release_ref = make_ref()
+    handler_id = "open-transition-consumer-#{System.unique_integer([:positive])}"
+
+    :ok =
+      :telemetry.attach(
+        handler_id,
+        [:lasso, :circuit_breaker, :open],
+        fn _event, _measurements, metadata, _config ->
+          if metadata.instance_id == elem(id, 0) do
+            send(test_pid, {:open_transition_observer_entered, self()})
+
+            receive do
+              ^release_ref -> :ok
+            after
+              5_000 -> :ok
+            end
+          end
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    assert :ok = CircuitBreaker.report_closed(receipt, {:error, :timeout})
+    assert_receive {:open_transition_observer_entered, observer_pid}, 1_000
+
+    assert {:ok, %Snapshot{state: :open}} = Snapshot.lookup(id)
+    assert {:error, :circuit_open} = Admission.check(id, deadline_us())
+
+    send(observer_pid, release_ref)
+    assert %{state: :open} = CircuitBreaker.get_state(id)
   end
 
   defp start_breaker(config) do

--- a/test/lasso/rpc/circuit_breaker_control_ring_test.exs
+++ b/test/lasso/rpc/circuit_breaker_control_ring_test.exs
@@ -120,6 +120,34 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
     assert [] = ControlRing.drain(id, 2, receipt.generation, receipt.epoch)
   end
 
+  test "saturation wakes the owner to recover a signal whose producer missed notification" do
+    {id, breaker_pid} = start_breaker(control_ring_capacity: 1)
+    {:ok, receipt} = Admission.check(id, deadline_us())
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+
+    [{^id, generation, epoch, owner_pid, 1, wakeup, diagnostics, ring_ref}] =
+      :ets.lookup(Storage.control_meta_table(), id)
+
+    sequence = System.unique_integer([:positive, :monotonic])
+    key = {id, 0}
+
+    assert 1 =
+             :ets.select_replace(Storage.control_table(), [
+               {{key, {ring_ref, :empty}}, [],
+                [{:const, {key, {ring_ref, {sequence, generation, epoch, :success}}}}]}
+             ])
+
+    assert %{occupied: 1, wakeup_pending: 0} = ControlRing.stats(id)
+    assert {:error, :saturated} = CircuitBreaker.report_closed(receipt, :ok)
+    assert :atomics.get(wakeup, 1) == 1
+    assert :atomics.get(diagnostics, 1) == 1
+    assert ordinary_wakeup_count(owner_pid, id) == 1
+
+    :sys.resume(breaker_pid)
+    await_empty_ring(id)
+  end
+
   defp start_breaker(config) do
     id = {"control-#{System.unique_integer([:positive])}", :http}
     {:ok, pid} = CircuitBreaker.start_link({id, Map.new(config)})
@@ -141,6 +169,20 @@ defmodule Lasso.RPC.CircuitBreakerControlRingTest do
       {:breaker_control_ready, ^id, _generation, _epoch} -> true
       _ -> false
     end)
+  end
+
+  defp await_empty_ring(id, attempts \\ 100)
+  defp await_empty_ring(_id, 0), do: flunk("ring did not drain")
+
+  defp await_empty_ring(id, attempts) do
+    case ControlRing.stats(id) do
+      %{occupied: 0} ->
+        :ok
+
+      _ ->
+        Process.sleep(5)
+        await_empty_ring(id, attempts - 1)
+    end
   end
 
   defp deadline_us, do: System.monotonic_time(:microsecond) + 100_000

--- a/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
@@ -1,0 +1,120 @@
+defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, Snapshot, Storage}
+
+  test "concurrent recovery candidates produce one bounded lease" do
+    {id, breaker_pid} = start_half_open_breaker()
+    parent = self()
+
+    first =
+      Task.async(fn ->
+        result = CircuitBreaker.admit(id, deadline_us())
+        send(parent, {:first_admission, self(), result})
+        receive do: (:release_owner -> result)
+      end)
+
+    assert_receive {:first_admission, first_owner,
+                    {:ok, %AdmissionReceipt{kind: :half_open} = receipt}}
+
+    assert {:error, :half_open_busy} = CircuitBreaker.admit(id, deadline_us())
+    assert :sys.get_state(breaker_pid).inflight_count == 1
+    assert [{^id, %{token: token}}] = :ets.lookup(Storage.lease_table(), id)
+    assert token == receipt.token
+
+    CircuitBreaker.release_half_open(receipt)
+    send(first_owner, :release_owner)
+    assert {:ok, ^receipt} = Task.await(first)
+    assert %{inflight_count: 0} = :sys.get_state(breaker_pid)
+    assert [] = :ets.lookup(Storage.lease_table(), id)
+  end
+
+  test "owner death releases a live lease exactly once" do
+    {id, breaker_pid} = start_half_open_breaker()
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        send(parent, {:receipt, CircuitBreaker.admit(id, deadline_us())})
+        receive do: (:stop -> :ok)
+      end)
+
+    assert_receive {:receipt, {:ok, %AdmissionReceipt{kind: :half_open}}}
+    owner_monitor = Process.monitor(owner)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_monitor, :process, ^owner, :killed}
+    assert %{inflight_count: 0, inflight_attempts: %{}} = :sys.get_state(breaker_pid)
+    assert [] = :ets.lookup(Storage.lease_table(), id)
+  end
+
+  test "restart publishes a fresh conservative epoch and recovers a live lease" do
+    {id, breaker_pid} = start_half_open_breaker()
+
+    assert {:ok, %AdmissionReceipt{kind: :half_open} = old_receipt} =
+             CircuitBreaker.admit(id, deadline_us())
+
+    {:ok, old_snapshot} = Snapshot.lookup(id)
+    :ok = GenServer.stop(breaker_pid)
+    {:ok, restarted_pid} = CircuitBreaker.start_link({id, %{success_threshold: 1}})
+
+    on_exit(fn -> if Process.alive?(restarted_pid), do: GenServer.stop(restarted_pid) end)
+
+    assert {:ok,
+            %Snapshot{
+              state: :half_open,
+              control_health: :degraded,
+              half_open_inflight: 1
+            } = restarted_snapshot} = Snapshot.lookup(id)
+
+    assert restarted_snapshot.epoch != old_snapshot.epoch
+    assert restarted_snapshot.generation > old_snapshot.generation
+    assert :sys.get_state(restarted_pid).inflight_count == 1
+
+    CircuitBreaker.report_half_open(old_receipt, :ok)
+    assert %{state: :half_open, inflight_count: 0} = :sys.get_state(restarted_pid)
+    assert [] = :ets.lookup(Storage.lease_table(), id)
+  end
+
+  test "a live registered owner is not reclaimed by elapsed wall time" do
+    {id, breaker_pid} = start_half_open_breaker()
+
+    assert {:ok, %AdmissionReceipt{kind: :half_open} = receipt} =
+             CircuitBreaker.admit(id, deadline_us())
+
+    send(breaker_pid, {:attempt_proactive_recovery, 999_999})
+    assert %{inflight_count: 1} = :sys.get_state(breaker_pid)
+    assert [{^id, %{token: token}}] = :ets.lookup(Storage.lease_table(), id)
+    assert token == receipt.token
+  end
+
+  defp start_half_open_breaker do
+    id = {"half-open-#{System.unique_integer([:positive])}", :http}
+    {:ok, pid} = CircuitBreaker.start_link({id, %{success_threshold: 1}})
+    state = :sys.replace_state(pid, &%{&1 | state: :half_open})
+
+    Snapshot.put(%Snapshot{
+      breaker_id: id,
+      state: :half_open,
+      generation: state.transition_generation,
+      epoch: state.process_epoch,
+      owner_pid: pid,
+      ready?: true,
+      recovery_deadline_us: nil,
+      half_open_capacity: 1,
+      half_open_inflight: 0,
+      control_health: :healthy
+    })
+
+    on_exit(fn ->
+      if Process.alive?(pid), do: GenServer.stop(pid)
+      :ets.delete(Storage.snapshot_table(), id)
+      :ets.delete(Storage.lease_table(), id)
+      :ets.delete(Storage.control_meta_table(), id)
+    end)
+
+    {id, pid}
+  end
+
+  defp deadline_us, do: System.monotonic_time(:microsecond) + 100_000
+end

--- a/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
@@ -2,7 +2,7 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
   use ExUnit.Case, async: false
 
   alias Lasso.Core.Support.CircuitBreaker
-  alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, Snapshot, Storage}
+  alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, ControlRing, Snapshot, Storage}
 
   test "concurrent recovery candidates produce one bounded lease" do
     {id, breaker_pid} = start_half_open_breaker()
@@ -86,6 +86,83 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
     assert %{inflight_count: 1} = :sys.get_state(breaker_pid)
     assert [{^id, %{token: token}}] = :ets.lookup(Storage.lease_table(), id)
     assert token == receipt.token
+  end
+
+  test "the attempt lifecycle owns and releases the half-open lease when it dies" do
+    {id, breaker_pid} = start_half_open_breaker()
+    parent = self()
+
+    caller =
+      spawn(fn ->
+        result = CircuitBreaker.call(id, fn -> Process.sleep(:infinity) end, 5_000)
+        send(parent, {:call_result, result})
+        receive do: (:stop -> :ok)
+      end)
+
+    lifecycle_pid = await_lease_owner(id, caller)
+    assert Process.alive?(caller)
+    Process.exit(lifecycle_pid, :kill)
+
+    assert_receive {:call_result, {:executed, {:exception, {:exit, :killed, []}}}}, 1_000
+    assert Process.alive?(caller)
+    assert %{inflight_count: 0, inflight_attempts: %{}} = :sys.get_state(breaker_pid)
+    assert [] = :ets.lookup(Storage.lease_table(), id)
+    send(caller, :stop)
+  end
+
+  test "restart preserves an unexpired open recovery deadline" do
+    id = {"open-restart-#{System.unique_integer([:positive])}", :http}
+    {:ok, pid} = CircuitBreaker.start_link({id, %{recovery_timeout: 60_000}})
+    CircuitBreaker.open(id)
+    await_snapshot_state(id, :open)
+
+    assert {:ok, %Snapshot{state: :open, recovery_deadline_us: old_deadline}} =
+             Snapshot.lookup(id)
+
+    :ok = GenServer.stop(pid)
+
+    {:ok, restarted_pid} = CircuitBreaker.start_link({id, %{recovery_timeout: 60_000}})
+
+    on_exit(fn ->
+      if Process.alive?(restarted_pid), do: GenServer.stop(restarted_pid)
+      :ets.delete(Storage.snapshot_table(), id)
+      :ets.delete(Storage.lease_table(), id)
+      ControlRing.delete(id)
+    end)
+
+    assert {:ok, %Snapshot{state: :open, recovery_deadline_us: new_deadline}} =
+             Snapshot.lookup(id)
+
+    assert new_deadline >= old_deadline
+    assert {:error, :circuit_open} = CircuitBreaker.admit(id, deadline_us())
+  end
+
+  defp await_lease_owner(id, excluded_pid, attempts \\ 100)
+  defp await_lease_owner(_id, _excluded_pid, 0), do: flunk("lease ownership was not transferred")
+
+  defp await_lease_owner(id, excluded_pid, attempts) do
+    case :ets.lookup(Storage.lease_table(), id) do
+      [{^id, %{owner_pid: owner_pid}}] when owner_pid != excluded_pid ->
+        owner_pid
+
+      _ ->
+        Process.sleep(5)
+        await_lease_owner(id, excluded_pid, attempts - 1)
+    end
+  end
+
+  defp await_snapshot_state(id, state, attempts \\ 100)
+  defp await_snapshot_state(_id, _state, 0), do: flunk("snapshot did not transition")
+
+  defp await_snapshot_state(id, state, attempts) do
+    case Snapshot.lookup(id) do
+      {:ok, %Snapshot{state: ^state}} ->
+        :ok
+
+      _ ->
+        Process.sleep(5)
+        await_snapshot_state(id, state, attempts - 1)
+    end
   end
 
   defp start_half_open_breaker do

--- a/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
@@ -72,8 +72,10 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
     assert :sys.get_state(restarted_pid).inflight_count == 1
 
     CircuitBreaker.report_half_open(old_receipt, :ok)
-    assert %{state: :half_open, inflight_count: 0} = :sys.get_state(restarted_pid)
-    assert [] = :ets.lookup(Storage.lease_table(), id)
+    CircuitBreaker.release_half_open(old_receipt)
+    assert %{state: :half_open, inflight_count: 1} = :sys.get_state(restarted_pid)
+    assert [{^id, %{token: old_token}}] = :ets.lookup(Storage.lease_table(), id)
+    assert old_token == old_receipt.token
   end
 
   test "a live registered owner is not reclaimed by elapsed wall time" do
@@ -137,6 +139,60 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
     assert {:error, :circuit_open} = CircuitBreaker.admit(id, deadline_us())
   end
 
+  test "restart schedules proactive recovery at the preserved open deadline" do
+    id = {"open-timer-#{System.unique_integer([:positive])}", :http}
+    {:ok, pid} = CircuitBreaker.start_link({id, %{recovery_timeout: 20}})
+    CircuitBreaker.open(id)
+    await_snapshot_state(id, :open)
+    :ok = GenServer.stop(pid)
+    {:ok, restarted_pid} = CircuitBreaker.start_link({id, %{recovery_timeout: 20}})
+
+    on_exit(fn ->
+      if Process.alive?(restarted_pid), do: GenServer.stop(restarted_pid)
+      :ets.delete(Storage.snapshot_table(), id)
+      :ets.delete(Storage.lease_table(), id)
+      ControlRing.delete(id)
+    end)
+
+    await_snapshot_state(id, :half_open)
+  end
+
+  test "exceptional claim is bounded by the receipt deadline and cleanup is ordered" do
+    {id, breaker_pid} = start_half_open_breaker()
+    assert {:ok, receipt} = CircuitBreaker.admit(id, System.monotonic_time(:microsecond) + 25_000)
+    :sys.suspend(breaker_pid)
+    on_exit(fn -> if Process.alive?(breaker_pid), do: :sys.resume(breaker_pid) end)
+    started_us = System.monotonic_time(:microsecond)
+
+    assert {:__attempt_lifecycle_rejected__, :timeout} =
+             Lasso.Core.Support.AttemptLifecycle.run(
+               self(),
+               receipt,
+               fn -> flunk("transport ran without claim") end,
+               1_000,
+               nil,
+               nil,
+               :immediate,
+               receipt.deadline_us
+             )
+
+    assert System.monotonic_time(:microsecond) - started_us < 100_000
+    :sys.resume(breaker_pid)
+    await_no_lease(id)
+  end
+
+  test "an unclaimed lease abandoned during restart is not recovered" do
+    {id, breaker_pid} = start_half_open_breaker()
+    assert {:ok, receipt} = CircuitBreaker.admit(id, deadline_us())
+    :ok = GenServer.stop(breaker_pid)
+    CircuitBreaker.abandon_unclaimed(receipt, self())
+    assert [] = :ets.lookup(Storage.lease_table(), id)
+
+    {:ok, restarted_pid} = CircuitBreaker.start_link({id, %{success_threshold: 1}})
+    on_exit(fn -> if Process.alive?(restarted_pid), do: GenServer.stop(restarted_pid) end)
+    assert %{inflight_count: 0} = :sys.get_state(restarted_pid)
+  end
+
   defp await_lease_owner(id, excluded_pid, attempts \\ 100)
   defp await_lease_owner(_id, _excluded_pid, 0), do: flunk("lease ownership was not transferred")
 
@@ -162,6 +218,20 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
       _ ->
         Process.sleep(5)
         await_snapshot_state(id, state, attempts - 1)
+    end
+  end
+
+  defp await_no_lease(id, attempts \\ 100)
+  defp await_no_lease(_id, 0), do: flunk("lease was not released")
+
+  defp await_no_lease(id, attempts) do
+    case :ets.lookup(Storage.lease_table(), id) do
+      [] ->
+        :ok
+
+      _ ->
+        Process.sleep(5)
+        await_no_lease(id, attempts - 1)
     end
   end
 

--- a/test/lasso/rpc/circuit_breaker_test.exs
+++ b/test/lasso/rpc/circuit_breaker_test.exs
@@ -120,11 +120,11 @@ defmodule Lasso.RPC.CircuitBreakerTest do
     Process.sleep(20)
     assert CircuitBreaker.get_state(id).state == :open
 
-    # After recovery timeout, half-open then success should close
+    # External health success cannot close recovery probation.
     Process.sleep(60)
     assert :ok = CircuitBreaker.signal_recovery(id)
     Process.sleep(20)
-    assert CircuitBreaker.get_state(id).state == :closed
+    assert CircuitBreaker.get_state(id).state == :half_open
   end
 
   test "rate limit errors do not open circuit (handled by RateLimitState tiering)" do

--- a/test/support/lasso/testing/mock_ws_provider.ex
+++ b/test/support/lasso/testing/mock_ws_provider.ex
@@ -42,6 +42,7 @@ defmodule Lasso.Testing.MockWSProvider do
   use GenServer
   require Logger
   alias Lasso.RPC.Response
+  alias Lasso.Core.Support.CircuitBreaker.Snapshot
   alias Lasso.Testing.ChainHelper
 
   @test_profile "public"
@@ -75,12 +76,27 @@ defmodule Lasso.Testing.MockWSProvider do
       Lasso.Providers.Catalog.build_from_config()
       instance_id = instance_id_for(profile, chain_id, provider_id)
 
-      {:ok, _pid} =
+      {:ok, mock_pid} =
         GenServer.start_link(
           __MODULE__,
           {chain_id, spec},
           name: {:via, Registry, {Lasso.Registry, ws_instance_key(instance_id)}}
         )
+
+      Enum.each([:http, :ws], fn transport ->
+        Snapshot.put(%Snapshot{
+          breaker_id: {instance_id, transport},
+          state: :closed,
+          generation: 1,
+          epoch: System.unique_integer([:positive, :monotonic]),
+          owner_pid: mock_pid,
+          ready?: true,
+          recovery_deadline_us: nil,
+          half_open_capacity: 1,
+          half_open_inflight: 0,
+          control_health: :healthy
+        })
+      end)
 
       :ets.insert(:lasso_instance_state, {
         {:health_probe, instance_id},


### PR DESCRIPTION
## Summary

- replace normal closed/open breaker admission with one authoritative application-owned ETS snapshot lookup and zero synchronous owner calls
- keep half-open admission serialized and bounded by the original absolute request deadline with durable single-lease recovery across breaker restarts
- add a hard-bounded per-breaker FIFO control ring with coalesced wakeups, scoped degradation, bounded reset/teardown, and stale generation fencing
- commit breaker transitions before optional telemetry/PubSub observers run, and keep admission/saturation paths independent of synchronous telemetry handlers
- thread the execution envelope deadline through the request pipeline and retain only minimal breaker control signals
- add deterministic admission, restart, lease-race, saturation, ordering, missed-wakeup, teardown, observer-blocking, and compatibility coverage plus a repeatable benchmark

Part of #50.

## Invariants exercised

- healthy closed/open admission: exactly one snapshot lookup, no synchronous owner call or telemetry consumer
- missing/unready/dead-owner state fails closed as `admission_unavailable`
- equality at the absolute deadline is expired, including immediate dispatch and exceptional ownership claim
- restrictive breaker state is visible to admission before optional transition observers run
- one half-open lease maximum; lifecycle ownership is durable and monitor-released exactly once
- restart preserves an unexpired open cooldown and restores proactive recovery
- prior generation/epoch terminal reports and releases cannot mutate recovered state
- ring storage and scans are capped per physical breaker (default 64, maximum 1,024)
- signal publication is one ETS CAS; saturation wakes the owner to recover a missed producer notification
- teardown removes snapshot, lease, control metadata, and fixed slots for both transports

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- amended breaker regression matrix: 40 tests, 0 failures
- full `mix test --include integration`: 1,130 tests, 0 failures
- `mix credo --strict`
- `mix dialyzer --format github`
- `mix hex.audit` (repository-documented cowlib advisories only)
- Docker production build and `/api/health` boot passed on the prior head; hosted Docker verification reruns for this amendment
- adversarial BEAM/OTP and distributed-systems review findings addressed, including synchronous-observer admission and transition-ordering races
- `git diff --check`

## Benchmark

Darwin, Elixir 1.18.4, OTP 28, 10 schedulers, 100,000 normal-path iterations:

- closed responsive: 0.297 µs average, 3.37M ops/s
- closed owner suspended: 0.225 µs average, 4.45M ops/s
- open responsive: 0.255 µs average, 3.93M ops/s
- open owner suspended: 0.220 µs average, 4.55M ops/s
- half-open serialized path: 5.67 µs average over 1,000 iterations
- 25 ms exceptional deadline: 25.18 ms observed
- saturation: 64 accepted / 192 rejected with 64 occupied slots and one coalesced wakeup
