### PR TITLE
Add bounded projection lanes

### DIFF
--- a/lib/lasso/core/projection_dispatcher.ex
+++ b/lib/lasso/core/projection_dispatcher.ex
@@ -1,0 +1,178 @@
+defmodule Lasso.Core.ProjectionDispatcher do
+  @moduledoc """
+  Registry and lifecycle owner for isolated optional projection lanes.
+
+  Enqueue, cancellation, and recovery use the named ETS registry directly and
+  never synchronously call this process. Each configured sink class owns
+  separate slots, workers, limits, counters, and failure behavior.
+  """
+
+  use GenServer
+
+  alias Lasso.Core.ProjectionLane
+
+  @sink_classes [
+    :learned_feedback,
+    :diagnostics,
+    :analytics,
+    :ui,
+    :pubsub,
+    :telemetry,
+    :durable_audit
+  ]
+
+  defstruct [:name, :registry, lanes: %{}]
+
+  @type sink_class ::
+          :learned_feedback
+          | :diagnostics
+          | :analytics
+          | :ui
+          | :pubsub
+          | :telemetry
+          | :durable_audit
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :name)
+
+    unless is_atom(name), do: raise(ArgumentError, "projection dispatcher name must be an atom")
+
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Enqueues an encoded payload without crossing a process boundary."
+  @spec enqueue(atom(), sink_class(), ProjectionLane.scope(), binary()) ::
+          ProjectionLane.enqueue_result()
+  def enqueue(dispatcher, sink_class, scope, payload) when is_atom(dispatcher) do
+    case lookup_lane(dispatcher, sink_class) do
+      {:ok, metadata} -> ProjectionLane.enqueue(metadata, scope, payload)
+      {:error, reason} -> {:drop, reason, :untracked}
+    end
+  end
+
+  @doc "Encodes and enqueues a tagged canonical execution fact."
+  @spec enqueue_fact(atom(), sink_class(), ProjectionLane.scope(), struct()) ::
+          ProjectionLane.enqueue_result()
+  def enqueue_fact(dispatcher, sink_class, scope, fact) when is_atom(dispatcher) do
+    case lookup_lane(dispatcher, sink_class) do
+      {:ok, metadata} -> ProjectionLane.enqueue_fact(metadata, scope, fact)
+      {:error, reason} -> {:drop, reason, :untracked}
+    end
+  end
+
+  @spec cancel(atom(), sink_class(), ProjectionLane.Token.t()) ::
+          :cancelled | :delivering | :not_found | :unavailable
+  def cancel(dispatcher, sink_class, token) when is_atom(dispatcher) do
+    case lookup_lane(dispatcher, sink_class) do
+      {:ok, metadata} -> ProjectionLane.cancel(metadata, token)
+      _ -> :unavailable
+    end
+  end
+
+  @spec recover(atom(), sink_class(), ProjectionLane.Degradation.t()) ::
+          :recovered | :stale | :unavailable
+  def recover(dispatcher, sink_class, degradation) when is_atom(dispatcher) do
+    case lookup_lane(dispatcher, sink_class) do
+      {:ok, metadata} -> ProjectionLane.recover(metadata, degradation)
+      _ -> :unavailable
+    end
+  end
+
+  @doc false
+  @spec lane(GenServer.server(), sink_class()) :: {:ok, pid()} | {:error, :unknown_sink_class}
+  def lane(dispatcher, sink_class), do: GenServer.call(dispatcher, {:lane, sink_class})
+
+  @doc false
+  @spec stats(GenServer.server(), sink_class()) :: map() | {:error, :unknown_sink_class}
+  def stats(dispatcher, sink_class) do
+    with {:ok, lane} <- lane(dispatcher, sink_class) do
+      ProjectionLane.stats(lane)
+    end
+  end
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    name = Keyword.fetch!(opts, :name)
+    lane_configs = Keyword.fetch!(opts, :lanes)
+    validate_lane_configs!(lane_configs)
+
+    registry =
+      :ets.new(name, [:named_table, :protected, :set, read_concurrency: true])
+
+    :ets.insert(registry, {:registry_state, :initializing})
+
+    lanes =
+      Map.new(lane_configs, fn {sink_class, lane_opts} ->
+        {:ok, lane} = ProjectionLane.start_link(lane_opts)
+        metadata = ProjectionLane.metadata(lane)
+        :ets.insert(registry, {sink_class, lane, metadata})
+        {sink_class, {lane, lane_opts}}
+      end)
+
+    :ets.insert(registry, {:registry_state, :ready})
+    {:ok, %__MODULE__{name: name, registry: registry, lanes: lanes}}
+  end
+
+  @impl true
+  def handle_call({:lane, sink_class}, _from, state) do
+    reply =
+      case Map.fetch(state.lanes, sink_class) do
+        {:ok, {lane, _opts}} -> {:ok, lane}
+        :error -> {:error, :unknown_sink_class}
+      end
+
+    {:reply, reply, state}
+  end
+
+  @impl true
+  def handle_info({:EXIT, pid, _reason}, state) do
+    case Enum.find(state.lanes, fn {_class, {lane, _opts}} -> lane == pid end) do
+      {sink_class, {^pid, lane_opts}} ->
+        {:ok, replacement} = ProjectionLane.start_link(lane_opts)
+        metadata = ProjectionLane.metadata(replacement)
+        :ets.insert(state.registry, {sink_class, replacement, metadata})
+        {:noreply, put_in(state.lanes[sink_class], {replacement, lane_opts})}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    Enum.each(state.lanes, fn {_class, {lane, _opts}} ->
+      if Process.alive?(lane), do: GenServer.stop(lane, :shutdown, 1_000)
+    end)
+
+    :ok
+  end
+
+  defp lookup_lane(dispatcher, sink_class) do
+    case :ets.lookup(dispatcher, sink_class) do
+      [{^sink_class, lane, metadata}] ->
+        if Process.alive?(lane), do: {:ok, metadata}, else: {:error, :unavailable}
+
+      [] ->
+        case :ets.lookup(dispatcher, :registry_state) do
+          [{:registry_state, :ready}] -> {:error, :unknown_sink_class}
+          _ -> {:error, :unavailable}
+        end
+    end
+  rescue
+    ArgumentError -> {:error, :unavailable}
+  end
+
+  defp validate_lane_configs!(lane_configs) when is_list(lane_configs) do
+    classes = Keyword.keys(lane_configs)
+
+    if classes != Enum.uniq(classes),
+      do: raise(ArgumentError, "projection sink classes must be unique")
+
+    unless Enum.all?(classes, &(&1 in @sink_classes)),
+      do: raise(ArgumentError, "unknown or critical projection sink class")
+
+    :ok
+  end
+end

--- a/lib/lasso/core/projection_lane.ex
+++ b/lib/lasso/core/projection_lane.ex
@@ -1,0 +1,880 @@
+defmodule Lasso.Core.ProjectionLane do
+  @moduledoc """
+  Hard-bounded asynchronous delivery for one optional projection class.
+
+  Each fixed worker owns one ETS table containing a fixed number of logical
+  slots. Scope hashing assigns `{profile, chain}` traffic to a fixed bucket;
+  colliding scopes conservatively share that bucket's quota. Worker mailboxes
+  contain only coalesced bucket wakes, never request or response payloads.
+
+  Breaker leases and other critical accounting do not belong in this module.
+  """
+
+  use GenServer
+
+  alias Lasso.RPC.{BoundedIdentifier, ExecutionFact.Codec}
+
+  defmodule Metadata do
+    @moduledoc false
+    @enforce_keys [
+      :control,
+      :incarnation,
+      :capacity,
+      :byte_capacity,
+      :scope_capacity,
+      :scope_byte_capacity,
+      :shards,
+      :buckets_per_shard,
+      :max_payload_bytes,
+      :max_age_ms,
+      :audit_interval_ms,
+      :coalesce,
+      :now,
+      :test_hook,
+      :global_counters
+    ]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule Token do
+    @moduledoc "Opaque, incarnation- and generation-safe cancellation token."
+    @enforce_keys [:incarnation, :shard, :shard_generation, :bucket, :slot, :sequence]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{}
+  end
+
+  defmodule Degradation do
+    @moduledoc "Opaque reference to one independently versioned bucket degradation."
+    @enforce_keys [:incarnation, :shard, :shard_generation, :bucket, :epoch]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{}
+  end
+
+  @type scope :: {binary(), binary() | pos_integer()}
+  @type enqueue_result ::
+          {:ok, Token.t()}
+          | {:coalesced, Token.t(), Degradation.t()}
+          | {:drop, atom(), Degradation.t() | :untracked}
+
+  @counter_reasons [
+    :bucket_contended,
+    :cancelled,
+    :coalesced,
+    :expired,
+    :invalid_payload,
+    :invalid_scope,
+    :recovered,
+    :sink_failure,
+    :unavailable,
+    :worker_restart
+  ]
+  @counter_indexes @counter_reasons |> Enum.with_index(1) |> Map.new()
+  @counter_count length(@counter_reasons)
+  @max_counter 9_223_372_036_854_775_807
+  @max_epoch div(@max_counter - 1, 2)
+  @max_chain_id @max_counter
+
+  defstruct [:metadata, :sink, workers: %{}]
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  @doc "Enqueues one previously encoded fact or bounded diagnostic batch."
+  @spec enqueue(Metadata.t(), scope(), binary()) :: enqueue_result()
+  def enqueue(%Metadata{} = metadata, scope, payload) do
+    with {:ok, normalized_scope} <- normalize_scope(scope),
+         :ok <- validate_payload(metadata, payload),
+         {:ok, runtime} <- runtime_for_scope(metadata, normalized_scope) do
+      publish(metadata, runtime, normalized_scope, payload)
+    else
+      {:error, :invalid_scope} -> untracked_drop(metadata, :invalid_scope)
+      {:error, :invalid_payload} -> untracked_drop(metadata, :invalid_payload)
+      {:error, :unavailable} -> untracked_drop(metadata, :unavailable)
+    end
+  rescue
+    ArgumentError -> {:drop, :unavailable, :untracked}
+  end
+
+  @doc "Encodes a canonical tagged execution fact before bounded enqueue."
+  @spec enqueue_fact(Metadata.t(), scope(), struct()) :: enqueue_result()
+  def enqueue_fact(%Metadata{} = metadata, scope, fact) do
+    case Codec.encode(fact) do
+      {:ok, payload} -> enqueue(metadata, scope, payload)
+      {:error, _reason} -> untracked_drop(metadata, :invalid_payload)
+    end
+  end
+
+  @doc "Cancels an item if and only if its exact token is still queued."
+  @spec cancel(Metadata.t(), Token.t()) :: :cancelled | :delivering | :not_found | :unavailable
+  def cancel(
+        %Metadata{incarnation: incarnation} = metadata,
+        %Token{incarnation: incarnation} = token
+      ) do
+    case runtime_for_token(metadata, token) do
+      {:ok, runtime} -> cancel_queued(metadata, runtime, token)
+      {:error, :stale} -> :not_found
+      {:error, :unavailable} -> :unavailable
+    end
+  rescue
+    ArgumentError -> :unavailable
+  end
+
+  def cancel(%Metadata{}, %Token{}), do: :not_found
+
+  @doc "Recovers only the exact independently versioned degradation supplied."
+  @spec recover(Metadata.t(), Degradation.t()) :: :recovered | :stale | :unavailable
+  def recover(
+        %Metadata{incarnation: incarnation} = metadata,
+        %Degradation{incarnation: incarnation} = degradation
+      ) do
+    case runtime_for_degradation(metadata, degradation) do
+      {:ok, runtime} -> recover_degradation(metadata, runtime, degradation)
+      {:error, :stale} -> :stale
+      {:error, :unavailable} -> :unavailable
+    end
+  rescue
+    ArgumentError -> :unavailable
+  end
+
+  def recover(%Metadata{}, %Degradation{}), do: :stale
+
+  defp cancel_queued(metadata, runtime, token) do
+    case lookup_slot(runtime.table, token.slot) do
+      {:ok, row} when elem(row, 1) == :queued and elem(row, 2) == token ->
+        if delete_exact(runtime.table, row) do
+          record(metadata, runtime, token.bucket, :cancelled)
+          :cancelled
+        else
+          cancel(metadata, token)
+        end
+
+      {:ok, row} when elem(row, 1) == :delivering and elem(row, 2) == token ->
+        :delivering
+
+      _other ->
+        :not_found
+    end
+  end
+
+  defp recover_degradation(metadata, runtime, degradation) do
+    index = degradation.bucket + 1
+    expected = degradation.epoch * 2 + 1
+
+    case :atomics.compare_exchange(runtime.degradations, index, expected, expected - 1) do
+      :ok ->
+        record(metadata, runtime, degradation.bucket, :recovered)
+        :recovered
+
+      _current ->
+        :stale
+    end
+  end
+
+  @doc false
+  @spec metadata(GenServer.server()) :: Metadata.t()
+  def metadata(lane), do: GenServer.call(lane, :metadata)
+
+  @doc false
+  @spec workers(GenServer.server()) :: %{non_neg_integer() => {pid(), pos_integer()}}
+  def workers(lane), do: GenServer.call(lane, :workers)
+
+  @doc false
+  @spec stats(GenServer.server()) :: map()
+  def stats(lane), do: GenServer.call(lane, :stats)
+
+  @doc false
+  @spec audit(GenServer.server()) :: :ok
+  def audit(lane), do: GenServer.call(lane, :audit)
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+
+    capacity = positive!(opts, :capacity)
+    byte_capacity = positive!(opts, :byte_capacity)
+    scope_capacity = positive!(opts, :scope_capacity)
+    scope_byte_capacity = positive!(opts, :scope_byte_capacity)
+    shards = positive!(opts, :shards)
+    max_age_ms = positive!(opts, :max_age_ms)
+    audit_interval_ms = positive!(opts, :audit_interval_ms)
+    coalesce = Keyword.get(opts, :coalesce, :none)
+    sink = Keyword.fetch!(opts, :sink)
+
+    true = is_function(sink, 2)
+    true = coalesce in [:none, :latest]
+    true = coalesce != :latest or scope_capacity == 1
+    true = rem(capacity, shards * scope_capacity) == 0
+
+    buckets_per_shard = div(capacity, shards * scope_capacity)
+
+    max_payload_bytes =
+      Enum.min([
+        Codec.max_bytes(),
+        div(byte_capacity, capacity),
+        div(scope_byte_capacity, scope_capacity)
+      ])
+
+    true = buckets_per_shard > 0
+    true = max_payload_bytes > 0
+
+    incarnation = make_ref()
+    control = :ets.new(:projection_lane_control, table_options())
+    global_counters = :atomics.new(@counter_count, signed: true)
+
+    metadata = %Metadata{
+      control: control,
+      incarnation: incarnation,
+      capacity: capacity,
+      byte_capacity: byte_capacity,
+      scope_capacity: scope_capacity,
+      scope_byte_capacity: scope_byte_capacity,
+      shards: shards,
+      buckets_per_shard: buckets_per_shard,
+      max_payload_bytes: max_payload_bytes,
+      max_age_ms: max_age_ms,
+      audit_interval_ms: audit_interval_ms,
+      coalesce: coalesce,
+      now: Keyword.get(opts, :now, fn -> System.monotonic_time(:millisecond) end),
+      test_hook: Keyword.get(opts, :test_hook, fn _event -> :ok end),
+      global_counters: global_counters
+    }
+
+    workers =
+      Map.new(0..(shards - 1), fn shard ->
+        runtime = start_worker(metadata, sink, shard, 1)
+        publish_runtime(metadata, runtime)
+        {shard, runtime}
+      end)
+
+    {:ok, %__MODULE__{metadata: metadata, sink: sink, workers: workers}}
+  end
+
+  @impl true
+  def handle_call(:metadata, _from, state), do: {:reply, state.metadata, state}
+
+  def handle_call(:workers, _from, state) do
+    workers =
+      Map.new(state.workers, fn {shard, runtime} -> {shard, {runtime.pid, runtime.generation}} end)
+
+    {:reply, workers, state}
+  end
+
+  def handle_call(:stats, _from, state), do: {:reply, build_stats(state), state}
+
+  def handle_call(:audit, _from, state) do
+    Enum.each(state.workers, fn {_shard, runtime} -> send(runtime.pid, :audit_now) end)
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info({:EXIT, pid, _reason}, state) do
+    case Enum.find(state.workers, fn {_shard, runtime} -> runtime.pid == pid end) do
+      {shard, old_runtime} ->
+        runtime = start_worker(state.metadata, state.sink, shard, old_runtime.generation + 1)
+        publish_runtime(state.metadata, runtime)
+        increment_counter(state.metadata.global_counters, counter_index(:worker_restart))
+        state.metadata.test_hook.({:worker_restarted, shard, runtime.pid, runtime.generation})
+        {:noreply, put_in(state.workers[shard], runtime)}
+
+      nil ->
+        {:noreply, state}
+    end
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    Enum.each(state.workers, fn {_shard, runtime} ->
+      if Process.alive?(runtime.pid), do: Process.exit(runtime.pid, :shutdown)
+    end)
+
+    :ok
+  end
+
+  defp publish(metadata, runtime, scope, payload) do
+    sequence = System.unique_integer([:positive, :monotonic])
+    first_offset = rem(sequence, metadata.scope_capacity)
+    token = token(metadata, runtime, first_offset, sequence)
+    row = row(:queued, token, scope, metadata.now.(), payload)
+
+    case metadata.coalesce do
+      :latest -> publish_latest(metadata, runtime, row)
+      :none -> publish_new(metadata, runtime, row, first_offset)
+    end
+  end
+
+  defp publish_new(metadata, runtime, row, first_offset) do
+    case insert_with_fixed_probe(metadata, runtime, row, first_offset) do
+      {:ok, token, slot_operations} ->
+        metadata.test_hook.({:published, token})
+        metadata.test_hook.({:enqueue_ops, token, 1 + slot_operations})
+        schedule_bucket(metadata, runtime, token.bucket)
+        {:ok, token}
+
+      :full ->
+        degradation = degrade(metadata, runtime, runtime.bucket, :bucket_contended)
+        {:drop, :bucket_contended, degradation}
+    end
+  end
+
+  defp publish_latest(metadata, runtime, row) do
+    token = elem(row, 2)
+    replacement = latest_match(token.slot, elem(row, 3), row)
+
+    case :ets.select_replace(runtime.table, replacement) do
+      1 ->
+        degradation = degrade(metadata, runtime, token.bucket, :coalesced)
+        metadata.test_hook.({:published, token})
+        metadata.test_hook.({:enqueue_ops, token, 2})
+        schedule_bucket(metadata, runtime, token.bucket)
+        {:coalesced, token, degradation}
+
+      0 ->
+        if :ets.insert_new(runtime.table, row) do
+          metadata.test_hook.({:published, token})
+          metadata.test_hook.({:enqueue_ops, token, 3})
+          schedule_bucket(metadata, runtime, token.bucket)
+          {:ok, token}
+        else
+          degradation = degrade(metadata, runtime, token.bucket, :bucket_contended)
+          {:drop, :bucket_contended, degradation}
+        end
+    end
+  end
+
+  defp insert_with_fixed_probe(metadata, runtime, row, first_offset) do
+    token = elem(row, 2)
+
+    if :ets.insert_new(runtime.table, row) do
+      {:ok, token, 1}
+    else
+      maybe_insert_second(metadata, runtime, row, first_offset)
+    end
+  end
+
+  defp maybe_insert_second(%Metadata{scope_capacity: 1}, _runtime, _row, _first_offset), do: :full
+
+  defp maybe_insert_second(metadata, runtime, row, first_offset) do
+    second_offset = rem(first_offset + 1, metadata.scope_capacity)
+    token = elem(row, 2)
+    second_token = %{token | slot: slot(token.bucket, second_offset, metadata.scope_capacity)}
+    second_row = put_elem(row, 2, second_token) |> put_elem(0, second_token.slot)
+
+    if :ets.insert_new(runtime.table, second_row),
+      do: {:ok, second_token, 2},
+      else: :full
+  end
+
+  defp runtime_for_scope(metadata, scope) do
+    bucket_count = metadata.shards * metadata.buckets_per_shard
+    global_bucket = :erlang.phash2(scope, bucket_count)
+    shard = div(global_bucket, metadata.buckets_per_shard)
+    bucket = rem(global_bucket, metadata.buckets_per_shard)
+
+    case lookup_runtime(metadata, shard) do
+      {:ok, runtime} -> {:ok, Map.put(runtime, :bucket, bucket)}
+      error -> error
+    end
+  end
+
+  defp runtime_for_token(metadata, token) do
+    case lookup_runtime(metadata, token.shard) do
+      {:ok, %{generation: generation} = runtime} when generation == token.shard_generation ->
+        {:ok, Map.put(runtime, :bucket, token.bucket)}
+
+      {:ok, _runtime} ->
+        {:error, :stale}
+
+      error ->
+        error
+    end
+  end
+
+  defp runtime_for_degradation(metadata, degradation) do
+    case lookup_runtime(metadata, degradation.shard) do
+      {:ok, %{generation: generation} = runtime}
+      when generation == degradation.shard_generation ->
+        {:ok, Map.put(runtime, :bucket, degradation.bucket)}
+
+      {:ok, _runtime} ->
+        {:error, :stale}
+
+      error ->
+        error
+    end
+  end
+
+  defp lookup_runtime(metadata, shard) do
+    case :ets.lookup(metadata.control, {:shard, shard}) do
+      [{{:shard, ^shard}, generation, pid, table, wakes, counters, degradations}] ->
+        {:ok,
+         %{
+           shard: shard,
+           generation: generation,
+           pid: pid,
+           table: table,
+           wakes: wakes,
+           counters: counters,
+           degradations: degradations
+         }}
+
+      [] ->
+        {:error, :unavailable}
+    end
+  rescue
+    ArgumentError -> {:error, :unavailable}
+  end
+
+  defp start_worker(metadata, sink, shard, generation) do
+    parent = self()
+    wakes = :atomics.new(metadata.buckets_per_shard, signed: true)
+    counters = :atomics.new(metadata.buckets_per_shard * @counter_count, signed: true)
+    degradations = :atomics.new(metadata.buckets_per_shard, signed: true)
+
+    worker_config = %{
+      parent: parent,
+      incarnation: metadata.incarnation,
+      shard: shard,
+      generation: generation,
+      wakes: wakes,
+      counters: counters,
+      degradations: degradations,
+      scope_capacity: metadata.scope_capacity,
+      buckets_per_shard: metadata.buckets_per_shard,
+      max_age_ms: metadata.max_age_ms,
+      audit_interval_ms: metadata.audit_interval_ms,
+      now: metadata.now,
+      sink: sink,
+      hook: metadata.test_hook,
+      global_counters: metadata.global_counters
+    }
+
+    pid = spawn_link(fn -> initialize_worker(worker_config) end)
+
+    receive do
+      {:projection_worker_ready, ^pid, table} ->
+        %{
+          shard: shard,
+          generation: generation,
+          pid: pid,
+          table: table,
+          wakes: wakes,
+          counters: counters,
+          degradations: degradations
+        }
+
+      {:EXIT, ^pid, reason} ->
+        exit({:projection_worker_start_failed, shard, reason})
+    end
+  end
+
+  defp initialize_worker(config) do
+    table = :ets.new(:projection_worker_slots, table_options())
+    send(config.parent, {:projection_worker_ready, self(), table})
+    schedule_audit(config.audit_interval_ms)
+    worker_loop(Map.merge(config, %{table: table, last_scopes: %{}}))
+  end
+
+  defp worker_loop(state) do
+    receive do
+      {:drain_bucket, incarnation, generation, bucket}
+      when incarnation == state.incarnation and generation == state.generation ->
+        state
+        |> drain_one(bucket)
+        |> worker_loop()
+
+      :audit ->
+        state.hook.({:audit, state.shard, state.generation})
+        schedule_all_worker(state)
+        schedule_audit(state.audit_interval_ms)
+        worker_loop(state)
+
+      :audit_now ->
+        schedule_all_worker(state)
+        worker_loop(state)
+
+      {:barrier, from, reference} ->
+        send(from, {:barrier, reference})
+        worker_loop(state)
+
+      _message ->
+        worker_loop(state)
+    end
+  end
+
+  defp drain_one(state, bucket) do
+    case next_queued(state, bucket) do
+      nil ->
+        state.hook.({:before_empty_settle, bucket})
+        reschedule_or_settle(state, bucket)
+        state
+
+      row ->
+        token = elem(row, 2)
+        scope = elem(row, 3)
+        state.hook.({:before_claim, token})
+
+        if claim(state.table, row) do
+          state.hook.({:claimed, token})
+          result = deliver(state, row)
+          delete_delivering(state.table, put_elem(row, 1, :delivering))
+          state.hook.({:completed, token, result})
+        end
+
+        reschedule_or_settle(state, bucket)
+        %{state | last_scopes: Map.put(state.last_scopes, bucket, scope)}
+    end
+  end
+
+  defp deliver(state, row) do
+    token = elem(row, 2)
+    scope = elem(row, 3)
+    enqueued_at = elem(row, 4)
+    payload = elem(row, 6)
+
+    if state.now.() - enqueued_at >= state.max_age_ms do
+      record_worker(state, token.bucket, :expired)
+      :expired
+    else
+      try do
+        state.sink.(scope, payload)
+        :ok
+      rescue
+        _exception ->
+          degrade_worker(state, token.bucket, :sink_failure)
+          :sink_failure
+      catch
+        _kind, _reason ->
+          degrade_worker(state, token.bucket, :sink_failure)
+          :sink_failure
+      end
+    end
+  end
+
+  defp next_queued(state, bucket) do
+    rows =
+      for offset <- 0..(state.scope_capacity - 1),
+          {:ok, row} <- [lookup_slot(state.table, slot(bucket, offset, state.scope_capacity))],
+          elem(row, 1) == :queued,
+          do: row
+
+    choose_fair(rows, Map.get(state.last_scopes, bucket))
+  end
+
+  defp choose_fair([], _last_scope), do: nil
+
+  defp choose_fair(rows, last_scope) do
+    scopes = rows |> Enum.map(&elem(&1, 3)) |> Enum.uniq() |> Enum.sort()
+
+    next_scope =
+      Enum.find(scopes, fn scope -> is_nil(last_scope) or scope > last_scope end) || hd(scopes)
+
+    rows
+    |> Enum.filter(&(elem(&1, 3) == next_scope))
+    |> Enum.min_by(fn row -> elem(row, 2).sequence end)
+  end
+
+  defp reschedule_or_settle(state, bucket) do
+    if bucket_has_queued?(state.table, bucket, state.scope_capacity) do
+      send(self(), {:drain_bucket, state.incarnation, state.generation, bucket})
+    else
+      settle_wake(state, bucket)
+
+      if bucket_has_queued?(state.table, bucket, state.scope_capacity),
+        do: schedule_bucket_worker(state, bucket)
+    end
+  end
+
+  defp settle_wake(state, bucket), do: :atomics.put(state.wakes, bucket + 1, 0)
+
+  defp schedule_all_worker(state) do
+    Enum.each(0..(state.buckets_per_shard - 1), fn bucket ->
+      if bucket_has_queued?(state.table, bucket, state.scope_capacity),
+        do: repair_bucket_wake(state, bucket)
+    end)
+  end
+
+  defp schedule_bucket(metadata, runtime, bucket) do
+    if :atomics.compare_exchange(runtime.wakes, bucket + 1, 0, 1) == :ok do
+      metadata.test_hook.({:wake_claimed, runtime.shard, runtime.generation, bucket})
+      send(runtime.pid, {:drain_bucket, metadata.incarnation, runtime.generation, bucket})
+    end
+
+    :ok
+  end
+
+  defp schedule_bucket_worker(state, bucket) do
+    if :atomics.compare_exchange(state.wakes, bucket + 1, 0, 1) == :ok do
+      send(self(), {:drain_bucket, state.incarnation, state.generation, bucket})
+    end
+  end
+
+  defp repair_bucket_wake(state, bucket) do
+    :atomics.put(state.wakes, bucket + 1, 1)
+    send(self(), {:drain_bucket, state.incarnation, state.generation, bucket})
+  end
+
+  defp schedule_audit(interval), do: Process.send_after(self(), :audit, interval)
+
+  defp bucket_has_queued?(table, bucket, scope_capacity) do
+    Enum.any?(0..(scope_capacity - 1), fn offset ->
+      case lookup_slot(table, slot(bucket, offset, scope_capacity)) do
+        {:ok, row} -> elem(row, 1) == :queued
+        :error -> false
+      end
+    end)
+  end
+
+  defp claim(table, row), do: replace_exact(table, row, put_elem(row, 1, :delivering))
+  defp delete_delivering(table, row), do: delete_exact(table, row)
+
+  defp replace_exact(table, old, new) do
+    :ets.select_replace(table, [{old, [], [{:const, new}]}]) == 1
+  end
+
+  defp delete_exact(table, row), do: :ets.select_delete(table, [{row, [], [true]}]) == 1
+
+  defp latest_match(slot, scope, row) do
+    [
+      {
+        {slot, :queued, :"$1", scope, :"$2", :"$3", :"$4"},
+        [],
+        [{:const, row}]
+      }
+    ]
+  end
+
+  defp lookup_slot(table, slot) do
+    case :ets.lookup(table, slot) do
+      [row] -> {:ok, row}
+      [] -> :error
+    end
+  end
+
+  defp row(state, token, scope, enqueued_at, payload),
+    do: {token.slot, state, token, scope, enqueued_at, byte_size(payload), payload}
+
+  defp token(metadata, runtime, offset, sequence) do
+    %Token{
+      incarnation: metadata.incarnation,
+      shard: runtime.shard,
+      shard_generation: runtime.generation,
+      bucket: runtime.bucket,
+      slot: slot(runtime.bucket, offset, metadata.scope_capacity),
+      sequence: sequence
+    }
+  end
+
+  defp slot(bucket, offset, scope_capacity), do: bucket * scope_capacity + offset
+
+  defp publish_runtime(metadata, runtime) do
+    :ets.insert(
+      metadata.control,
+      {{:shard, runtime.shard}, runtime.generation, runtime.pid, runtime.table, runtime.wakes,
+       runtime.counters, runtime.degradations}
+    )
+  end
+
+  defp degrade(metadata, runtime, bucket, reason) do
+    record(metadata, runtime, bucket, reason)
+    epoch = next_degradation(runtime.degradations, bucket + 1)
+
+    %Degradation{
+      incarnation: metadata.incarnation,
+      shard: runtime.shard,
+      shard_generation: runtime.generation,
+      bucket: bucket,
+      epoch: epoch
+    }
+  end
+
+  defp degrade_worker(state, bucket, reason) do
+    record_worker(state, bucket, reason)
+    epoch = next_degradation(state.degradations, bucket + 1)
+
+    degradation = %Degradation{
+      incarnation: state.incarnation,
+      shard: state.shard,
+      shard_generation: state.generation,
+      bucket: bucket,
+      epoch: epoch
+    }
+
+    state.hook.({:degraded, degradation, reason})
+    degradation
+  end
+
+  defp next_degradation(atomics, index) do
+    current = :atomics.get(atomics, index)
+    epoch = div(current, 2)
+    next_epoch = if epoch >= @max_epoch, do: 1, else: epoch + 1
+    next = next_epoch * 2 + 1
+
+    case :atomics.compare_exchange(atomics, index, current, next) do
+      :ok -> next_epoch
+      _other -> next_degradation(atomics, index)
+    end
+  end
+
+  defp record(metadata, runtime, bucket, reason) do
+    increment_counter(metadata.global_counters, counter_index(reason))
+    increment_counter(runtime.counters, bucket_counter_index(bucket, reason))
+  end
+
+  defp record_worker(state, bucket, reason) do
+    increment_counter(state.global_counters, counter_index(reason))
+    increment_counter(state.counters, bucket_counter_index(bucket, reason))
+  end
+
+  defp untracked_drop(metadata, reason) do
+    increment_counter(metadata.global_counters, counter_index(reason))
+    {:drop, reason, :untracked}
+  rescue
+    ArgumentError -> {:drop, reason, :untracked}
+  end
+
+  defp increment_counter(atomics, index) do
+    current = :atomics.get(atomics, index)
+
+    cond do
+      current >= @max_counter ->
+        @max_counter
+
+      :atomics.compare_exchange(atomics, index, current, current + 1) == :ok ->
+        current + 1
+
+      true ->
+        increment_counter(atomics, index)
+    end
+  end
+
+  defp counter_index(reason), do: Map.fetch!(@counter_indexes, reason)
+
+  defp bucket_counter_index(bucket, reason),
+    do: bucket * @counter_count + counter_index(reason)
+
+  defp build_stats(state) do
+    shard_stats =
+      Map.new(state.workers, fn {shard, runtime} -> {shard, worker_stats(state, runtime)} end)
+
+    %{
+      capacity: state.metadata.capacity,
+      byte_capacity: state.metadata.byte_capacity,
+      scope_capacity: state.metadata.scope_capacity,
+      scope_byte_capacity: state.metadata.scope_byte_capacity,
+      max_payload_bytes: state.metadata.max_payload_bytes,
+      retained_items:
+        Enum.sum(Enum.map(shard_stats, fn {_shard, stats} -> stats.retained_items end)),
+      queued_items: Enum.sum(Enum.map(shard_stats, fn {_shard, stats} -> stats.queued_items end)),
+      bytes: Enum.sum(Enum.map(shard_stats, fn {_shard, stats} -> stats.bytes end)),
+      active_scopes:
+        shard_stats
+        |> Enum.flat_map(fn {_shard, stats} -> stats.active_scopes end)
+        |> MapSet.new(),
+      counters: read_counters(state.metadata.global_counters),
+      shards: shard_stats
+    }
+  end
+
+  defp worker_stats(state, runtime) do
+    rows = fixed_rows(runtime.table, state.metadata)
+
+    bucket_stats =
+      Map.new(0..(state.metadata.buckets_per_shard - 1), fn bucket ->
+        bucket_rows = Enum.filter(rows, fn row -> elem(row, 2).bucket == bucket end)
+        packed = :atomics.get(runtime.degradations, bucket + 1)
+
+        {bucket,
+         %{
+           retained_items: length(bucket_rows),
+           bytes: Enum.sum(Enum.map(bucket_rows, &elem(&1, 5))),
+           status: if(rem(packed, 2) == 1, do: :degraded, else: :healthy),
+           degradation_epoch: div(packed, 2),
+           counters: read_bucket_counters(runtime.counters, bucket)
+         }}
+      end)
+
+    %{
+      generation: runtime.generation,
+      worker: runtime.pid,
+      table: runtime.table,
+      retained_items: length(rows),
+      queued_items: Enum.count(rows, &(elem(&1, 1) == :queued)),
+      bytes: Enum.sum(Enum.map(rows, &elem(&1, 5))),
+      active_scopes: Enum.map(rows, &elem(&1, 3)),
+      buckets: bucket_stats,
+      message_queue_len: message_queue_len(runtime.pid)
+    }
+  rescue
+    ArgumentError ->
+      %{
+        generation: runtime.generation,
+        worker: runtime.pid,
+        table: runtime.table,
+        retained_items: 0,
+        queued_items: 0,
+        bytes: 0,
+        active_scopes: [],
+        buckets: %{},
+        message_queue_len: message_queue_len(runtime.pid)
+      }
+  end
+
+  defp fixed_rows(table, metadata) do
+    for slot <- 0..(div(metadata.capacity, metadata.shards) - 1),
+        {:ok, row} <- [lookup_slot(table, slot)],
+        do: row
+  end
+
+  defp read_counters(atomics) do
+    Map.new(@counter_reasons, fn reason ->
+      {reason, :atomics.get(atomics, counter_index(reason))}
+    end)
+  end
+
+  defp read_bucket_counters(atomics, bucket) do
+    Map.new(@counter_reasons, fn reason ->
+      {reason, :atomics.get(atomics, bucket_counter_index(bucket, reason))}
+    end)
+  end
+
+  defp message_queue_len(pid) do
+    case Process.info(pid, :message_queue_len) do
+      {:message_queue_len, length} -> length
+      nil -> 0
+    end
+  end
+
+  defp normalize_scope({profile, chain}) when is_binary(profile) do
+    with {:ok, chain} <- normalize_chain(chain) do
+      {:ok, {BoundedIdentifier.encode(profile), chain}}
+    end
+  end
+
+  defp normalize_scope(_scope), do: {:error, :invalid_scope}
+
+  defp normalize_chain(chain) when is_binary(chain), do: {:ok, BoundedIdentifier.encode(chain)}
+
+  defp normalize_chain(chain) when is_integer(chain) and chain > 0 and chain <= @max_chain_id,
+    do: {:ok, Integer.to_string(chain)}
+
+  defp normalize_chain(_chain), do: {:error, :invalid_scope}
+
+  defp validate_payload(metadata, payload)
+       when is_binary(payload) and byte_size(payload) <= metadata.max_payload_bytes,
+       do: :ok
+
+  defp validate_payload(_metadata, _payload), do: {:error, :invalid_payload}
+
+  defp positive!(opts, key) do
+    value = Keyword.fetch!(opts, key)
+    true = is_integer(value) and value > 0
+    value
+  end
+
+  defp table_options,
+    do: [:set, :public, read_concurrency: true, write_concurrency: true]
+end

--- a/test/lasso/core/projection_dispatcher_test.exs
+++ b/test/lasso/core/projection_dispatcher_test.exs
@@ -1,0 +1,209 @@
+defmodule Lasso.Core.ProjectionDispatcherTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.{ProjectionDispatcher, ProjectionLane}
+
+  @scope {"profile", 1}
+
+  test "enqueue is nonblocking through named ETS and distinguishes unavailable from unknown class" do
+    unavailable = unique_name(:unavailable)
+
+    assert {:drop, :unavailable, :untracked} =
+             ProjectionDispatcher.enqueue(unavailable, :diagnostics, @scope, "fact")
+
+    parent = self()
+    name = unique_name(:dispatcher)
+
+    dispatcher =
+      start_dispatcher(name,
+        diagnostics: lane_opts(fn _scope, payload -> send(parent, {:diagnostic, payload}) end)
+      )
+
+    assert {:drop, :unknown_sink_class, :untracked} =
+             ProjectionDispatcher.enqueue(name, :analytics, @scope, "fact")
+
+    :erlang.suspend_process(dispatcher)
+    assert {:ok, _token} = ProjectionDispatcher.enqueue(name, :diagnostics, @scope, "fact")
+    assert_receive {:diagnostic, "fact"}
+    assert {:message_queue_len, 0} = Process.info(dispatcher, :message_queue_len)
+    :erlang.resume_process(dispatcher)
+  end
+
+  test "normal enqueue stays within the four-operation ETS budget" do
+    parent = self()
+    name = unique_name(:operation_budget)
+
+    _dispatcher =
+      start_dispatcher(name,
+        diagnostics:
+          lane_opts(fn _scope, _payload -> :ok end,
+            test_hook: fn event -> send(parent, event) end
+          )
+      )
+
+    assert {:ok, token} = ProjectionDispatcher.enqueue(name, :diagnostics, @scope, "fact")
+    assert_receive {:enqueue_ops, ^token, lane_operations}
+
+    # The lane reports its control lookup plus fixed slot probes. The named
+    # dispatcher registry lookup is the one remaining ETS operation.
+    assert lane_operations + 1 <= 4
+  end
+
+  test "hung sinks and saturation stay isolated between fixed sink classes" do
+    parent = self()
+    name = unique_name(:isolation)
+
+    _dispatcher =
+      start_dispatcher(name,
+        analytics:
+          lane_opts(fn _scope, payload ->
+            send(parent, {:analytics_started, self(), payload})
+            receive do: (:release -> :ok)
+          end),
+        learned_feedback:
+          lane_opts(fn _scope, payload -> send(parent, {:learned, payload}) end,
+            coalesce: :latest,
+            scope_capacity: 1
+          )
+      )
+
+    assert {:ok, _token} = ProjectionDispatcher.enqueue(name, :analytics, @scope, "slow")
+    assert_receive {:analytics_started, analytics_worker, "slow"}
+
+    assert {:ok, _token} =
+             ProjectionDispatcher.enqueue(name, :learned_feedback, @scope, "fast")
+
+    assert_receive {:learned, "fast"}
+    send(analytics_worker, :release)
+  end
+
+  test "lane restart swaps its incarnation without suppressing another class" do
+    parent = self()
+    name = unique_name(:restart)
+
+    _dispatcher =
+      start_dispatcher(name,
+        diagnostics: lane_opts(fn _scope, payload -> send(parent, {:diagnostic, payload}) end),
+        analytics: lane_opts(fn _scope, payload -> send(parent, {:analytics, payload}) end)
+      )
+
+    {:ok, old_lane} = ProjectionDispatcher.lane(name, :diagnostics)
+    old_incarnation = ProjectionLane.metadata(old_lane).incarnation
+    monitor = Process.monitor(old_lane)
+    Process.exit(old_lane, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^old_lane, :killed}
+
+    new_lane = await_replacement(name, :diagnostics, old_lane)
+    refute ProjectionLane.metadata(new_lane).incarnation == old_incarnation
+
+    assert {:ok, _token} = ProjectionDispatcher.enqueue(name, :analytics, @scope, "independent")
+    assert_receive {:analytics, "independent"}
+    assert {:ok, _token} = ProjectionDispatcher.enqueue(name, :diagnostics, @scope, "recovered")
+    assert_receive {:diagnostic, "recovered"}
+  end
+
+  test "dispatcher death removes the registry and supervision rebuilds every lane" do
+    parent = self()
+    name = unique_name(:dispatcher_restart)
+
+    dispatcher =
+      start_dispatcher(name,
+        diagnostics: lane_opts(fn _scope, payload -> send(parent, {:delivered, payload}) end)
+      )
+
+    {:ok, old_lane} = ProjectionDispatcher.lane(name, :diagnostics)
+    {old_worker, _generation} = ProjectionLane.workers(old_lane)[0]
+    dispatcher_monitor = Process.monitor(dispatcher)
+    lane_monitor = Process.monitor(old_lane)
+    worker_monitor = Process.monitor(old_worker)
+    Process.exit(dispatcher, :kill)
+
+    assert_receive {:DOWN, ^dispatcher_monitor, :process, ^dispatcher, :killed}
+    assert_receive {:DOWN, ^lane_monitor, :process, ^old_lane, _reason}
+    assert_receive {:DOWN, ^worker_monitor, :process, ^old_worker, _reason}
+
+    replacement = await_dispatcher(name, dispatcher)
+    assert Process.alive?(replacement)
+    assert {:ok, _new_lane} = ProjectionDispatcher.lane(name, :diagnostics)
+    assert {:ok, _token} = ProjectionDispatcher.enqueue(name, :diagnostics, @scope, "after")
+    assert_receive {:delivered, "after"}
+  end
+
+  test "critical lease accounting is not a configurable projection class" do
+    name = unique_name(:invalid)
+    previous = Process.flag(:trap_exit, true)
+
+    assert {:error, {%ArgumentError{}, _stacktrace}} =
+             ProjectionDispatcher.start_link(
+               name: name,
+               lanes: [critical_lease_accounting: lane_opts(fn _scope, _payload -> :ok end)]
+             )
+
+    Process.flag(:trap_exit, previous)
+  end
+
+  defp start_dispatcher(name, lanes) do
+    start_supervised!({ProjectionDispatcher, name: name, lanes: lanes})
+  end
+
+  defp lane_opts(sink, overrides \\ []) do
+    Keyword.merge(
+      [
+        capacity: 4,
+        byte_capacity: 16_384,
+        scope_capacity: 2,
+        scope_byte_capacity: 8_192,
+        shards: 1,
+        max_age_ms: 1_000,
+        audit_interval_ms: 60_000,
+        sink: sink
+      ],
+      overrides
+    )
+  end
+
+  defp unique_name(suffix),
+    do: Module.concat(__MODULE__, "#{suffix}_#{System.unique_integer([:positive])}")
+
+  defp await_replacement(name, sink_class, old_lane) do
+    await_replacement(name, sink_class, old_lane, deadline_ms())
+  end
+
+  defp await_replacement(name, sink_class, old_lane, deadline) do
+    case ProjectionDispatcher.lane(name, sink_class) do
+      {:ok, lane} when lane != old_lane ->
+        lane
+
+      _ ->
+        wait_until(deadline, "projection lane was not replaced")
+        await_replacement(name, sink_class, old_lane, deadline)
+    end
+  end
+
+  defp await_dispatcher(name, old_dispatcher) do
+    await_dispatcher(name, old_dispatcher, deadline_ms())
+  end
+
+  defp await_dispatcher(name, old_dispatcher, deadline) do
+    case Process.whereis(name) do
+      dispatcher when is_pid(dispatcher) and dispatcher != old_dispatcher ->
+        dispatcher
+
+      _ ->
+        wait_until(deadline, "dispatcher was not restarted")
+        await_dispatcher(name, old_dispatcher, deadline)
+    end
+  end
+
+  defp deadline_ms, do: System.monotonic_time(:millisecond) + 1_000
+
+  defp wait_until(deadline, message) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+    if remaining <= 0, do: flunk(message)
+
+    receive do
+    after
+      min(remaining, 5) -> :ok
+    end
+  end
+end

--- a/test/lasso/core/projection_lane_test.exs
+++ b/test/lasso/core/projection_lane_test.exs
@@ -1,0 +1,633 @@
+defmodule Lasso.Core.ProjectionLaneTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.ProjectionLane
+  alias Lasso.RPC.{AdmissionTerminal, ExecutionFact.Codec}
+
+  @scope_a {"profile-a", 1}
+
+  test "retains only encoded binary facts within the structural four-KiB bound" do
+    parent = self()
+    {lane, metadata} = start_lane(sink: fn scope, payload -> send(parent, {scope, payload}) end)
+    worker = worker(lane)
+    suspend(worker)
+
+    fact =
+      AdmissionTerminal.new(
+        request_id: "request-1",
+        profile: "profile-a",
+        chain_id: 1,
+        routing_intent: "default",
+        workload_key: "read",
+        reason: :local_capacity,
+        candidate_admission_count: 1,
+        dispatch_count: 0,
+        elapsed_us: 2
+      )
+
+    assert {:ok, fact_token} = ProjectionLane.enqueue_fact(metadata, @scope_a, fact)
+
+    assert {:ok, maximum_token} =
+             ProjectionLane.enqueue(metadata, {"profile-b", 1}, :binary.copy("x", 4_096))
+
+    assert metadata.max_payload_bytes == Codec.max_bytes()
+
+    stats = ProjectionLane.stats(lane)
+    assert stats.retained_items == 2
+    assert stats.bytes <= stats.byte_capacity
+
+    for {_shard, shard_stats} <- stats.shards,
+        {_key, _state, _token, _scope, _at, size, payload} <- :ets.tab2list(shard_stats.table) do
+      assert is_binary(payload)
+      assert byte_size(payload) == size
+      assert size <= Codec.max_bytes()
+    end
+
+    assert {:drop, :invalid_payload, :untracked} =
+             ProjectionLane.enqueue(metadata, @scope_a, %{request_body: "not encoded"})
+
+    assert {:drop, :invalid_payload, :untracked} =
+             ProjectionLane.enqueue(metadata, @scope_a, :binary.copy("x", 4_097))
+
+    assert :cancelled = ProjectionLane.cancel(metadata, fact_token)
+    assert :cancelled = ProjectionLane.cancel(metadata, maximum_token)
+    resume(worker)
+  end
+
+  test "a cancelled row is never reinserted by a stale worker claim" do
+    parent = self()
+
+    hook = fn
+      {:before_claim, token} ->
+        send(parent, {:before_claim, self(), token})
+        receive do: ({:release_claim, ^token} -> :ok)
+
+      event ->
+        send(parent, event)
+    end
+
+    {lane, metadata} =
+      start_lane(
+        capacity: 1,
+        scope_capacity: 1,
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end,
+        test_hook: hook
+      )
+
+    worker = worker(lane)
+    assert {:ok, first} = ProjectionLane.enqueue(metadata, @scope_a, "first")
+    assert_receive {:before_claim, ^worker, ^first}
+    assert :cancelled = ProjectionLane.cancel(metadata, first)
+
+    assert {:ok, second} = ProjectionLane.enqueue(metadata, @scope_a, "second")
+    send(worker, {:release_claim, first})
+    assert_receive {:before_claim, ^worker, ^second}
+    assert ProjectionLane.stats(lane).retained_items == 1
+    refute_received {:delivered, "first"}
+
+    send(worker, {:release_claim, second})
+    assert_receive {:delivered, "second"}
+    assert_receive {:completed, ^second, :ok}
+    barrier(worker)
+    assert ProjectionLane.stats(lane).retained_items == 0
+  end
+
+  test "cancellation reports the exact queued or delivering state" do
+    parent = self()
+
+    {lane, metadata} =
+      start_lane(
+        sink: fn _scope, payload ->
+          send(parent, {:sink_entered, self(), payload})
+          receive do: (:release_sink -> :ok)
+        end
+      )
+
+    worker = worker(lane)
+    suspend(worker)
+    assert {:ok, queued} = ProjectionLane.enqueue(metadata, @scope_a, "queued")
+    assert :cancelled = ProjectionLane.cancel(metadata, queued)
+    resume(worker)
+    barrier(worker)
+    refute_received {:sink_entered, _, "queued"}
+
+    assert {:ok, delivering} = ProjectionLane.enqueue(metadata, @scope_a, "delivering")
+    assert_receive {:sink_entered, ^worker, "delivering"}
+    assert :delivering = ProjectionLane.cancel(metadata, delivering)
+    send(worker, :release_sink)
+    barrier(worker)
+    assert :not_found = ProjectionLane.cancel(metadata, delivering)
+  end
+
+  test "producer death after atomic publication cannot lose its wake forever" do
+    parent = self()
+
+    hook = fn
+      {:published, token} ->
+        send(parent, {:published, self(), token})
+        receive do: (:never -> :ok)
+
+      event ->
+        send(parent, event)
+    end
+
+    {lane, metadata} =
+      start_lane(
+        test_hook: hook,
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end
+      )
+
+    producer = spawn(fn -> ProjectionLane.enqueue(metadata, @scope_a, "published") end)
+    assert_receive {:published, ^producer, token}
+    Process.exit(producer, :kill)
+    assert ProjectionLane.stats(lane).queued_items == 1
+
+    assert :ok = ProjectionLane.audit(lane)
+    assert_receive {:delivered, "published"}
+    assert_receive {:completed, ^token, :ok}
+  end
+
+  test "automatic audit repairs producer death after wake ownership but before send" do
+    parent = self()
+
+    hook = fn
+      {:wake_claimed, shard, generation, bucket} ->
+        send(parent, {:wake_claimed, self(), shard, generation, bucket})
+        receive do: (:never -> :ok)
+
+      {:audit, shard, generation} ->
+        send(parent, {:automatic_audit, shard, generation})
+
+      event ->
+        send(parent, event)
+    end
+
+    {_lane, metadata} =
+      start_lane(
+        capacity: 1,
+        scope_capacity: 1,
+        audit_interval_ms: 1,
+        test_hook: hook,
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end
+      )
+
+    producer = spawn(fn -> ProjectionLane.enqueue(metadata, @scope_a, "repair") end)
+    assert_receive {:wake_claimed, ^producer, 0, 1, 0}
+    Process.exit(producer, :kill)
+
+    assert_receive {:automatic_audit, 0, 1}
+    assert_receive {:delivered, "repair"}
+    assert_receive {:completed, _token, :ok}
+  end
+
+  test "an enqueue between an empty scan and wake settlement is not lost" do
+    parent = self()
+
+    hook = fn
+      {:before_empty_settle, bucket} ->
+        send(parent, {:before_empty_settle, self(), bucket})
+        receive do: ({:settle, ^bucket} -> :ok)
+
+      event ->
+        send(parent, event)
+    end
+
+    {lane, metadata} =
+      start_lane(
+        capacity: 1,
+        scope_capacity: 1,
+        test_hook: hook,
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end
+      )
+
+    worker = worker(lane)
+    suspend(worker)
+    assert {:ok, cancelled} = ProjectionLane.enqueue(metadata, @scope_a, "cancelled")
+    assert :cancelled = ProjectionLane.cancel(metadata, cancelled)
+    resume(worker)
+    assert_receive {:before_empty_settle, ^worker, 0}
+
+    assert {:ok, replacement} = ProjectionLane.enqueue(metadata, @scope_a, "replacement")
+    send(worker, {:settle, 0})
+    assert_receive {:delivered, "replacement"}
+    assert_receive {:completed, ^replacement, :ok}
+    barrier(worker)
+    assert ProjectionLane.stats(lane).retained_items == 0
+  end
+
+  test "unique scope floods remain structurally bounded and every overflow is tracked" do
+    {lane, metadata} = start_lane(capacity: 8, scope_capacity: 2, shards: 2)
+    suspend_workers(lane)
+
+    results =
+      for index <- 1..2_000 do
+        ProjectionLane.enqueue(metadata, {"profile-#{index}", index}, "x")
+      end
+
+    accepted = for {:ok, token} <- results, do: token
+    drops = for {:drop, :bucket_contended, degradation} <- results, do: degradation
+
+    assert length(accepted) <= metadata.capacity
+    assert length(accepted) + length(drops) == length(results)
+    assert Enum.all?(drops, &match?(%ProjectionLane.Degradation{}, &1))
+
+    stats = ProjectionLane.stats(lane)
+    assert stats.retained_items <= metadata.capacity
+    assert MapSet.size(stats.active_scopes) <= metadata.capacity
+    assert stats.counters.bucket_contended == length(drops)
+
+    for {_shard, shard_stats} <- stats.shards do
+      assert :ets.info(shard_stats.table, :size) <= div(metadata.capacity, metadata.shards)
+      assert shard_stats.message_queue_len <= metadata.buckets_per_shard
+    end
+
+    Enum.each(accepted, fn token -> assert :cancelled = ProjectionLane.cancel(metadata, token) end)
+
+    assert ProjectionLane.stats(lane).retained_items == 0
+    resume_workers(lane)
+  end
+
+  test "concurrent publication and cancellation preserve fixed storage" do
+    {lane, metadata} = start_lane(capacity: 64, scope_capacity: 8, shards: 2)
+    suspend_workers(lane)
+
+    results =
+      1..256
+      |> Task.async_stream(
+        fn index -> ProjectionLane.enqueue(metadata, {"profile-#{index}", 1}, "x") end,
+        max_concurrency: 64,
+        ordered: false
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    tokens = for {:ok, token} <- results, do: token
+    assert length(tokens) <= metadata.capacity
+    assert ProjectionLane.stats(lane).retained_items == length(tokens)
+
+    tokens
+    |> Task.async_stream(&ProjectionLane.cancel(metadata, &1),
+      max_concurrency: 64,
+      ordered: false
+    )
+    |> Enum.each(fn {:ok, result} -> assert result == :cancelled end)
+
+    assert %{retained_items: 0, queued_items: 0, bytes: 0} = ProjectionLane.stats(lane)
+    resume_workers(lane)
+  end
+
+  test "item and retained-byte caps are structural rather than reconciled counters" do
+    {lane, metadata} =
+      start_lane(
+        capacity: 2,
+        byte_capacity: 6,
+        scope_capacity: 1,
+        scope_byte_capacity: 4
+      )
+
+    suspend_workers(lane)
+    [scope_a, scope_b] = scopes_in_distinct_buckets(metadata, 2)
+
+    assert metadata.max_payload_bytes == 3
+
+    assert {:drop, :invalid_payload, :untracked} =
+             ProjectionLane.enqueue(metadata, scope_a, "1234")
+
+    assert {:ok, first} = ProjectionLane.enqueue(metadata, scope_a, "123")
+    assert {:ok, second} = ProjectionLane.enqueue(metadata, scope_b, "456")
+
+    assert %{retained_items: 2, queued_items: 2, bytes: 6} = ProjectionLane.stats(lane)
+    assert :cancelled = ProjectionLane.cancel(metadata, first)
+    assert :cancelled = ProjectionLane.cancel(metadata, second)
+    assert %{retained_items: 0, bytes: 0} = ProjectionLane.stats(lane)
+    resume_workers(lane)
+  end
+
+  test "one bucket rotates fairly across colliding profile and chain scopes" do
+    parent = self()
+
+    {lane, metadata} =
+      start_lane(
+        capacity: 4,
+        scope_capacity: 4,
+        sink: fn _scope, payload -> send(parent, payload) end
+      )
+
+    worker = worker(lane)
+    suspend(worker)
+
+    for {scope, payload} <- [
+          {{"profile-a", 1}, "a1"},
+          {{"profile-b", 1}, "b1"},
+          {{"profile-a", 1}, "a2"},
+          {{"profile-b", 1}, "b2"}
+        ] do
+      assert {:ok, _token} = ProjectionLane.enqueue(metadata, scope, payload)
+    end
+
+    resume(worker)
+    assert_receive "a1"
+    assert_receive "b1"
+    assert_receive "a2"
+    assert_receive "b2"
+  end
+
+  test "latest-value coalescing has exact tokens and an independent degradation epoch" do
+    parent = self()
+
+    {lane, metadata} =
+      start_lane(
+        capacity: 1,
+        scope_capacity: 1,
+        coalesce: :latest,
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end
+      )
+
+    worker = worker(lane)
+    suspend(worker)
+    assert {:ok, first} = ProjectionLane.enqueue(metadata, @scope_a, "first")
+
+    assert {:coalesced, second, degradation_1} =
+             ProjectionLane.enqueue(metadata, @scope_a, "second")
+
+    assert {:coalesced, third, degradation_2} =
+             ProjectionLane.enqueue(metadata, @scope_a, "third")
+
+    refute first == second
+    refute second == third
+    assert :not_found = ProjectionLane.cancel(metadata, first)
+    assert :not_found = ProjectionLane.cancel(metadata, second)
+    assert :stale = ProjectionLane.recover(metadata, degradation_1)
+    assert :recovered = ProjectionLane.recover(metadata, degradation_2)
+
+    assert {:coalesced, fourth, degradation_3} =
+             ProjectionLane.enqueue(metadata, @scope_a, "fourth")
+
+    assert :stale = ProjectionLane.recover(metadata, degradation_2)
+    assert degradation_3.epoch > degradation_2.epoch
+    assert ProjectionLane.stats(lane).retained_items == 1
+
+    resume(worker)
+    assert_receive {:delivered, "fourth"}
+    barrier(worker)
+    assert :not_found = ProjectionLane.cancel(metadata, fourth)
+  end
+
+  test "a worker reads then loses a coalescing race without restoring stale data" do
+    parent = self()
+
+    hook = fn
+      {:before_claim, token} ->
+        send(parent, {:before_claim, self(), token})
+        receive do: ({:release_claim, ^token} -> :ok)
+
+      event ->
+        send(parent, event)
+    end
+
+    {lane, metadata} =
+      start_lane(
+        capacity: 1,
+        scope_capacity: 1,
+        coalesce: :latest,
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end,
+        test_hook: hook
+      )
+
+    worker = worker(lane)
+    assert {:ok, old} = ProjectionLane.enqueue(metadata, @scope_a, "old")
+    assert_receive {:before_claim, ^worker, ^old}
+
+    assert {:coalesced, latest, _degradation} =
+             ProjectionLane.enqueue(metadata, @scope_a, "latest")
+
+    send(worker, {:release_claim, old})
+    assert_receive {:before_claim, ^worker, ^latest}
+    send(worker, {:release_claim, latest})
+    assert_receive {:delivered, "latest"}
+    refute_received {:delivered, "old"}
+    barrier(worker)
+    assert ProjectionLane.stats(lane).retained_items == 0
+  end
+
+  test "queue age expires at the injected monotonic boundary" do
+    parent = self()
+    {:ok, clock} = Agent.start_link(fn -> 10 end)
+
+    {lane, metadata} =
+      start_lane(
+        now: fn -> Agent.get(clock, & &1) end,
+        max_age_ms: 5,
+        test_hook: fn event -> send(parent, event) end,
+        sink: fn _scope, payload -> send(parent, {:unexpected_delivery, payload}) end
+      )
+
+    worker = worker(lane)
+    suspend(worker)
+    assert {:ok, token} = ProjectionLane.enqueue(metadata, @scope_a, "expired")
+    Agent.update(clock, fn _ -> 15 end)
+    resume(worker)
+
+    assert_receive {:completed, ^token, :expired}
+    refute_received {:unexpected_delivery, _payload}
+    assert ProjectionLane.stats(lane).counters.expired == 1
+  end
+
+  test "raising and exiting sinks degrade observably without killing the worker" do
+    parent = self()
+
+    sink = fn _scope, payload ->
+      case payload do
+        "raise" -> raise "sink failed"
+        "exit" -> exit(:sink_failed)
+        "healthy" -> send(parent, :healthy_delivery)
+      end
+    end
+
+    {lane, metadata} =
+      start_lane(
+        sink: sink,
+        test_hook: fn event -> send(parent, event) end
+      )
+
+    worker = worker(lane)
+    assert {:ok, raised} = ProjectionLane.enqueue(metadata, @scope_a, "raise")
+    assert_receive {:degraded, raised_degradation, :sink_failure}
+    assert_receive {:completed, ^raised, :sink_failure}
+    assert Process.alive?(worker)
+    assert :recovered = ProjectionLane.recover(metadata, raised_degradation)
+
+    assert {:ok, exited} = ProjectionLane.enqueue(metadata, @scope_a, "exit")
+    assert_receive {:degraded, exited_degradation, :sink_failure}
+    assert_receive {:completed, ^exited, :sink_failure}
+    assert Process.alive?(worker)
+    assert exited_degradation.epoch > raised_degradation.epoch
+    assert ProjectionLane.stats(lane).counters.sink_failure == 2
+
+    assert {:ok, healthy} = ProjectionLane.enqueue(metadata, @scope_a, "healthy")
+    assert_receive :healthy_delivery
+    assert_receive {:completed, ^healthy, :ok}
+  end
+
+  test "worker death discards its optional queued and delivering facts and advances generation" do
+    parent = self()
+
+    {lane, metadata} =
+      start_lane(
+        sink: fn _scope, payload ->
+          send(parent, {:entered, self(), payload})
+          receive do: (:release -> :ok)
+        end,
+        test_hook: fn event -> send(parent, event) end
+      )
+
+    old_worker = worker(lane)
+    assert {:ok, token} = ProjectionLane.enqueue(metadata, @scope_a, "delivering")
+    assert_receive {:entered, ^old_worker, "delivering"}
+    Process.exit(old_worker, :kill)
+    assert_receive {:worker_restarted, 0, replacement, 2}
+    assert ProjectionLane.stats(lane).retained_items == 0
+    assert :not_found = ProjectionLane.cancel(metadata, token)
+
+    assert {:ok, replacement_token} = ProjectionLane.enqueue(metadata, @scope_a, "replacement")
+    assert_receive {:entered, ^replacement, "replacement"}
+    send(replacement, :release)
+    barrier(replacement)
+    assert :not_found = ProjectionLane.cancel(metadata, replacement_token)
+  end
+
+  test "worker death while queued cannot strand capacity in another owner" do
+    parent = self()
+
+    {lane, metadata} =
+      start_lane(
+        sink: fn _scope, payload -> send(parent, {:delivered, payload}) end,
+        test_hook: fn event -> send(parent, event) end
+      )
+
+    old_worker = worker(lane)
+    suspend(old_worker)
+    assert {:ok, old_token} = ProjectionLane.enqueue(metadata, @scope_a, "old")
+    assert ProjectionLane.stats(lane).queued_items == 1
+
+    Process.exit(old_worker, :kill)
+    assert_receive {:worker_restarted, 0, replacement, 2}
+    assert ProjectionLane.stats(lane).retained_items == 0
+    assert :not_found = ProjectionLane.cancel(metadata, old_token)
+    refute_received {:delivered, "old"}
+
+    assert {:ok, new_token} = ProjectionLane.enqueue(metadata, @scope_a, "new")
+    assert_receive {:delivered, "new"}
+    barrier(replacement)
+    assert :not_found = ProjectionLane.cancel(metadata, new_token)
+  end
+
+  test "a hung sink is isolated to its fixed shard" do
+    parent = self()
+
+    sink = fn _scope, payload ->
+      if payload == "slow" do
+        send(parent, {:slow, self()})
+        receive do: (:release -> :ok)
+      else
+        send(parent, {:fast, self(), payload})
+      end
+    end
+
+    {_lane, metadata} = start_lane(capacity: 4, scope_capacity: 1, shards: 2, sink: sink)
+    slow_scope = scope_in_shard(metadata, 0)
+    fast_scope = scope_in_shard(metadata, 1)
+
+    assert {:ok, _token} = ProjectionLane.enqueue(metadata, slow_scope, "slow")
+    assert_receive {:slow, slow_worker}
+    assert {:ok, _token} = ProjectionLane.enqueue(metadata, fast_scope, "fast")
+    assert_receive {:fast, fast_worker, "fast"}
+    refute slow_worker == fast_worker
+    send(slow_worker, :release)
+  end
+
+  test "normal lane shutdown terminates all fixed workers" do
+    {lane, _metadata} = start_lane(shards: 2)
+    workers = lane |> ProjectionLane.workers() |> Map.values() |> Enum.map(&elem(&1, 0))
+    monitors = Map.new(workers, &{Process.monitor(&1), &1})
+
+    GenServer.stop(lane, :normal)
+
+    for {reference, worker} <- monitors do
+      assert_receive {:DOWN, ^reference, :process, ^worker, _reason}
+    end
+  end
+
+  defp start_lane(overrides) do
+    defaults = [
+      capacity: 8,
+      byte_capacity: 32_768,
+      scope_capacity: 2,
+      scope_byte_capacity: 8_192,
+      shards: 1,
+      max_age_ms: 1_000,
+      audit_interval_ms: 60_000,
+      sink: fn _scope, _payload -> :ok end
+    ]
+
+    lane = start_supervised!({ProjectionLane, Keyword.merge(defaults, overrides)})
+    {lane, ProjectionLane.metadata(lane)}
+  end
+
+  defp worker(lane, shard \\ 0) do
+    {worker, _generation} = ProjectionLane.workers(lane)[shard]
+    worker
+  end
+
+  defp suspend_workers(lane),
+    do: Enum.each(ProjectionLane.workers(lane), fn {_shard, {pid, _}} -> suspend(pid) end)
+
+  defp resume_workers(lane),
+    do: Enum.each(ProjectionLane.workers(lane), fn {_shard, {pid, _}} -> resume(pid) end)
+
+  defp suspend(process) do
+    :erlang.suspend_process(process)
+    on_exit(fn -> if Process.alive?(process), do: :erlang.resume_process(process) end)
+  end
+
+  defp resume(process) do
+    if Process.alive?(process) and :erlang.is_process_alive(process),
+      do: :erlang.resume_process(process)
+  catch
+    :error, :badarg -> :ok
+  end
+
+  defp barrier(worker) do
+    reference = make_ref()
+    send(worker, {:barrier, self(), reference})
+    assert_receive {:barrier, ^reference}
+  end
+
+  defp scopes_in_distinct_buckets(metadata, count) do
+    1..10_000
+    |> Enum.reduce_while(%{}, fn index, scopes ->
+      scope = {"profile-#{index}", 1}
+      {_shard, bucket} = scope_location(metadata, scope)
+      scopes = Map.put_new(scopes, bucket, scope)
+
+      if map_size(scopes) == count,
+        do: {:halt, Map.values(scopes)},
+        else: {:cont, scopes}
+    end)
+  end
+
+  defp scope_in_shard(metadata, wanted_shard) do
+    Enum.find_value(1..10_000, fn index ->
+      scope = {"profile-#{index}", 1}
+      {shard, _bucket} = scope_location(metadata, scope)
+      if shard == wanted_shard, do: scope
+    end)
+  end
+
+  defp scope_location(metadata, {profile, chain}) do
+    normalized = {profile, Integer.to_string(chain)}
+    global_bucket = :erlang.phash2(normalized, metadata.shards * metadata.buckets_per_shard)
+
+    {div(global_bucket, metadata.buckets_per_shard),
+     rem(global_bucket, metadata.buckets_per_shard)}
+  end
+end


### PR DESCRIPTION
## Summary

- add isolated, application-ready projection lanes backed by fixed worker-owned ETS buckets and slots
- enforce hard item, byte, scope, and queue-age bounds without an unbounded coordinator mailbox
- provide generation-safe cancellation, delivery claims, degradation epochs, coalesced wakeups, fair scope rotation, and automatic lost-wakeup recovery
- keep critical breaker and lease accounting outside projection delivery while isolating learned feedback, diagnostics, analytics/UI, and durable-audit sink classes
- retain only encoded bounded fact binaries; the substrate is intentionally not wired into request execution in this PR

The normal enqueue path performs three ETS operations including dispatcher lookup, or four on the fixed collision probe. Saturation and worker failure remain bounded and observable.

## Verification

- 24 focused deterministic tests
- focused suite repeated 500 times
- `PORT=0 MIX_ENV=test mix test --include integration` — 1,154 tests, 0 failures
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix hex.audit` — only the repository's documented cowlib exceptions
- Docker production build and health boot
- two adversarial reviews; the amended commit resolved reservation/accounting, worker-death, ABA, scope-growth, hot-path operation-count, and lost-wakeup findings

Part of #50.
