### PR TITLE
Add strict upstream response validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Routes without `/profile/:profile` use the included `public` profile. Use a name
 ### Prerequisites
 
 - **Elixir**: 1.17+ (check with `elixir --version`)
-- **Erlang/OTP**: 26+ (check with `erl -version`)
+- **Erlang/OTP**: 27+ (check with `erl -version`)
 - **Node.js**: 18+ (for asset compilation)
 
 ### Local (recommended)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 
 - **Elixir**: 1.17+
-- **Erlang/OTP**: 26+
+- **Erlang/OTP**: 27+
 - **Node.js**: 18+ (asset compilation)
 
 ### Setup

--- a/lib/lasso/core/transport/upstream_response.ex
+++ b/lib/lasso/core/transport/upstream_response.ex
@@ -1,0 +1,664 @@
+defmodule Lasso.Core.Transport.UpstreamResponse do
+  @moduledoc false
+
+  alias Lasso.JSONRPC.Error, as: JError
+  alias Lasso.RPC.Response
+
+  @max_transport_id_bytes 128
+
+  defmodule Validated do
+    @moduledoc false
+
+    @enforce_keys [:kind, :id]
+    defstruct [:kind, :id, :error_code, :error_message, :error_data, :id_span]
+
+    @type t :: %__MODULE__{
+            kind: :result | :error,
+            id: integer() | binary() | nil,
+            error_code: integer() | nil,
+            error_message: binary() | nil,
+            error_data: term(),
+            id_span: {non_neg_integer(), non_neg_integer()} | nil
+          }
+  end
+
+  @type invalid_reason ::
+          :invalid_json
+          | :invalid_envelope
+          | :unsupported_version
+          | :id_mismatch
+          | :unexpected_notification
+          | :unexpected_batch
+
+  @type parsed ::
+          {:ok, Validated.t()}
+          | {:invalid, invalid_reason(), integer() | binary() | nil}
+          | {:legacy, :notification | :connection_error}
+
+  @spec parse_unary(binary()) :: parsed()
+  def parse_unary(raw_bytes) when is_binary(raw_bytes) do
+    case decode(raw_bytes, response_mode(raw_bytes)) do
+      {{:container, :object}, {:root, fields}, rest} ->
+        if only_json_whitespace?(rest) do
+          classify_fields(fields)
+        else
+          {:invalid, :invalid_json, candidate_id(fields)}
+        end
+
+      {{:container, :array}, _accumulator, rest} ->
+        if only_json_whitespace?(rest),
+          do: {:invalid, :unexpected_batch, nil},
+          else: {:invalid, :invalid_json, nil}
+
+      {_value, _accumulator, _rest} ->
+        {:invalid, :invalid_envelope, nil}
+
+      :invalid_json ->
+        {:invalid, :invalid_json, nil}
+    end
+  end
+
+  def parse_unary(_raw_bytes), do: {:invalid, :invalid_json, nil}
+
+  @spec parse_ws_frame(binary()) ::
+          {:transport, Validated.t()}
+          | {:transport_invalid, String.t(), invalid_reason()}
+          | :legacy
+          | {:unattributable, invalid_reason() | :ambiguous_id_location}
+  def parse_ws_frame(raw_bytes) when is_binary(raw_bytes) do
+    case parse_unary(raw_bytes) do
+      {:ok, %Validated{id: transport_id} = validated} ->
+        if transport_id?(transport_id) do
+          case locate_id(validated, raw_bytes) do
+            {:ok, located} -> {:transport, located}
+            {:error, reason} -> {:unattributable, reason}
+          end
+        else
+          :legacy
+        end
+
+      {:invalid, reason, transport_id} when is_binary(transport_id) ->
+        if transport_id?(transport_id),
+          do: {:transport_invalid, transport_id, reason},
+          else: {:unattributable, reason}
+
+      {:invalid, reason, _candidate_id} ->
+        {:unattributable, reason}
+
+      {:legacy, _kind} ->
+        :legacy
+    end
+  end
+
+  @spec finalize_unary(Validated.t(), binary(), term(), term()) ::
+          {:ok, Response.Success.t()} | {:error, JError.t()} | {:invalid, invalid_reason()}
+  def finalize_unary(
+        %Validated{id: upstream_id} = validated,
+        raw_bytes,
+        upstream_id,
+        client_id
+      )
+      when is_binary(raw_bytes) do
+    case restore_id(validated, raw_bytes, client_id) do
+      {:ok, restored_bytes} -> build_response(validated, client_id, restored_bytes)
+      {:error, _reason} -> {:invalid, :invalid_envelope}
+    end
+  end
+
+  def finalize_unary(%Validated{}, _raw_bytes, _upstream_id, _client_id),
+    do: {:invalid, :id_mismatch}
+
+  @spec validate_unary(binary(), term(), term()) ::
+          {:ok, Response.Success.t()} | {:error, JError.t()} | {:invalid, invalid_reason()}
+  def validate_unary(raw_bytes, upstream_id, client_id) when is_binary(raw_bytes) do
+    case parse_unary(raw_bytes) do
+      {:ok, validated} -> finalize_unary(validated, raw_bytes, upstream_id, client_id)
+      {:invalid, reason, _candidate_id} -> {:invalid, reason}
+      {:legacy, _kind} -> {:invalid, :unexpected_notification}
+    end
+  end
+
+  @doc false
+  @spec extract_transport_ids(binary()) :: {:ok, [String.t()]} | {:error, :unattributable}
+  def extract_transport_ids(raw_bytes) when is_binary(raw_bytes) do
+    case parse_unary(raw_bytes) do
+      {:ok, %Validated{id: transport_id}} when is_binary(transport_id) ->
+        if transport_id?(transport_id), do: {:ok, [transport_id]}, else: {:ok, []}
+
+      {:invalid, _reason, transport_id} when is_binary(transport_id) ->
+        if transport_id?(transport_id), do: {:ok, [transport_id]}, else: {:ok, []}
+
+      {:legacy, _kind} ->
+        {:ok, []}
+
+      _other ->
+        {:error, :unattributable}
+    end
+  end
+
+  @doc false
+  @spec correlation(binary()) ::
+          {:transport_id, String.t()} | :legacy | {:unattributable, atom()}
+  def correlation(raw_bytes) when is_binary(raw_bytes) do
+    case parse_ws_frame(raw_bytes) do
+      {:transport, %Validated{id: transport_id}} -> {:transport_id, transport_id}
+      {:transport_invalid, transport_id, _reason} -> {:transport_id, transport_id}
+      :legacy -> :legacy
+      {:unattributable, reason} -> {:unattributable, reason}
+    end
+  end
+
+  @spec transport_id?(term()) :: boolean()
+  def transport_id?(transport_id) when is_binary(transport_id) do
+    byte_size(transport_id) <= @max_transport_id_bytes and
+      String.starts_with?(transport_id, "lasso-")
+  end
+
+  def transport_id?(_transport_id), do: false
+
+  defp decoders(mode) do
+    %{
+      array_start: &array_start(&1, mode),
+      array_push: &array_push/2,
+      array_finish: &array_finish/2,
+      object_start: &object_start(&1, mode),
+      object_push: &object_push/3,
+      object_finish: &object_finish/2,
+      integer: &decode_integer/1,
+      float: float_decoder(mode),
+      string: &Function.identity/1,
+      null: nil
+    }
+  end
+
+  defp float_decoder(:discard), do: fn _token -> :float end
+  defp float_decoder(:retain_error), do: &:erlang.binary_to_float/1
+
+  defp decode(raw_bytes, mode) do
+    :json.decode(raw_bytes, {:root, nil}, decoders(mode))
+  rescue
+    _error -> :invalid_json
+  catch
+    _kind, _reason -> :invalid_json
+  end
+
+  defp initial_fields do
+    %{
+      jsonrpc: :missing,
+      jsonrpc_count: 0,
+      id: :missing,
+      id_count: 0,
+      result_count: 0,
+      error: :missing,
+      error_count: 0,
+      method_count: 0
+    }
+  end
+
+  defp initial_error_fields do
+    %{code: :missing, code_count: 0, message: :missing, message_count: 0}
+  end
+
+  defp object_start({:root, _fields}, _mode), do: {:object, 0, initial_fields()}
+
+  defp object_start(old_accumulator, :discard) do
+    depth = accumulator_depth(old_accumulator) + 1
+    fields = if depth == 1, do: initial_error_fields(), else: nil
+    {:object, depth, fields}
+  end
+
+  defp object_start(old_accumulator, :retain_error) do
+    depth = accumulator_depth(old_accumulator) + 1
+    fields = if depth == 1, do: initial_error_fields(), else: nil
+    {:retained_object, depth, [], fields}
+  end
+
+  defp object_push(key, value, {:object, 0, fields}) do
+    {:object, 0, capture_response_field(fields, key, value)}
+  end
+
+  defp object_push(key, value, {:object, 1, fields}) do
+    {:object, 1, capture_error_field(fields, key, value)}
+  end
+
+  defp object_push(key, value, {:retained_object, 1, pairs, fields}) do
+    {:retained_object, 1, [{key, value} | pairs], capture_error_field(fields, key, value)}
+  end
+
+  defp object_push(key, value, {:retained_object, depth, pairs, fields}) do
+    {:retained_object, depth, [{key, value} | pairs], fields}
+  end
+
+  defp object_push(_key, _value, accumulator), do: accumulator
+
+  defp object_finish({:object, 0, fields}, {:root, _old_fields}) do
+    {{:container, :object}, {:root, fields}}
+  end
+
+  defp object_finish({:object, 1, fields}, old_accumulator) do
+    {{:container, :object, fields}, old_accumulator}
+  end
+
+  defp object_finish({:object, _depth, _fields}, old_accumulator) do
+    {{:container, :object}, old_accumulator}
+  end
+
+  defp object_finish({:retained_object, 1, pairs, fields}, old_accumulator) do
+    value = pairs |> Enum.reverse() |> Map.new()
+    {{:container, :object, %{fields: fields, value: value}}, old_accumulator}
+  end
+
+  defp object_finish({:retained_object, _depth, pairs, _fields}, old_accumulator) do
+    {pairs |> Enum.reverse() |> Map.new(), old_accumulator}
+  end
+
+  defp array_start({:root, _fields}, _mode), do: {:array, 0, nil}
+
+  defp array_start(old_accumulator, :discard),
+    do: {:array, accumulator_depth(old_accumulator) + 1, nil}
+
+  defp array_start(old_accumulator, :retain_error),
+    do: {:retained_array, accumulator_depth(old_accumulator) + 1, []}
+
+  defp array_push(value, {:retained_array, depth, values}),
+    do: {:retained_array, depth, [value | values]}
+
+  defp array_push(_value, accumulator), do: accumulator
+
+  defp array_finish({:array, 0, _fields}, {:root, _old_fields}) do
+    {{:container, :array}, {:root, :top_level_array}}
+  end
+
+  defp array_finish({:array, _depth, _fields}, old_accumulator) do
+    {{:container, :array}, old_accumulator}
+  end
+
+  defp array_finish({:retained_array, _depth, values}, old_accumulator) do
+    {Enum.reverse(values), old_accumulator}
+  end
+
+  defp accumulator_depth({:object, depth, _fields}), do: depth
+  defp accumulator_depth({:array, depth, _fields}), do: depth
+  defp accumulator_depth({:retained_object, depth, _pairs, _fields}), do: depth
+  defp accumulator_depth({:retained_array, depth, _values}), do: depth
+
+  defp capture_response_field(fields, "jsonrpc", value) do
+    %{fields | jsonrpc: value, jsonrpc_count: fields.jsonrpc_count + 1}
+  end
+
+  defp capture_response_field(fields, "id", value) do
+    %{fields | id: normalize_id(value), id_count: fields.id_count + 1}
+  end
+
+  defp capture_response_field(fields, "result", _value) do
+    %{fields | result_count: fields.result_count + 1}
+  end
+
+  defp capture_response_field(fields, "error", value) do
+    %{fields | error: value, error_count: fields.error_count + 1}
+  end
+
+  defp capture_response_field(fields, "method", _value) do
+    %{fields | method_count: fields.method_count + 1}
+  end
+
+  defp capture_response_field(fields, _key, _value), do: fields
+
+  defp capture_error_field(fields, "code", value) do
+    %{fields | code: normalize_error_code(value), code_count: fields.code_count + 1}
+  end
+
+  defp capture_error_field(fields, "message", value) do
+    message = if is_binary(value), do: value, else: :invalid
+    %{fields | message: message, message_count: fields.message_count + 1}
+  end
+
+  defp capture_error_field(fields, _key, _value), do: fields
+
+  defp decode_integer(token), do: :erlang.binary_to_integer(token)
+
+  defp normalize_id(value) when is_binary(value), do: value
+  defp normalize_id(value) when is_integer(value), do: value
+  defp normalize_id(nil), do: nil
+  defp normalize_id(_value), do: :invalid
+
+  defp normalize_error_code(value) when is_integer(value), do: value
+  defp normalize_error_code(_value), do: :invalid
+
+  defp classify_fields(fields) do
+    candidate_id = candidate_id(fields)
+
+    cond do
+      fields.jsonrpc_count != 1 ->
+        {:invalid, :invalid_envelope, candidate_id}
+
+      fields.jsonrpc != "2.0" ->
+        {:invalid, :unsupported_version, candidate_id}
+
+      fields.id_count == 0 and legacy_frame?(fields) ->
+        {:legacy, legacy_kind(fields)}
+
+      fields.id_count != 1 ->
+        {:invalid, :invalid_envelope, nil}
+
+      fields.id == :invalid ->
+        {:invalid, :invalid_envelope, nil}
+
+      fields.method_count > 0 ->
+        {:invalid, :unexpected_notification, candidate_id}
+
+      fields.result_count == 1 and fields.error_count == 0 ->
+        {:ok, %Validated{kind: :result, id: fields.id}}
+
+      fields.result_count == 0 and fields.error_count == 1 ->
+        validate_error(fields.error, fields.id)
+
+      true ->
+        {:invalid, :invalid_envelope, candidate_id}
+    end
+  end
+
+  defp legacy_frame?(fields),
+    do: fields.method_count > 0 or fields.error_count == 1
+
+  defp legacy_kind(%{method_count: count}) when count > 0, do: :notification
+  defp legacy_kind(_fields), do: :connection_error
+
+  defp validate_error(
+         {:container, :object,
+          %{
+            fields: %{code: code, code_count: 1, message: message, message_count: 1},
+            value: value
+          }},
+         id
+       )
+       when is_integer(code) and is_binary(message) and is_map(value) do
+    {:ok,
+     %Validated{
+       kind: :error,
+       id: id,
+       error_code: code,
+       error_message: message,
+       error_data: Map.get(value, "data")
+     }}
+  end
+
+  defp validate_error(
+         {:container, :object, %{code: code, code_count: 1, message: message, message_count: 1}},
+         id
+       )
+       when is_integer(code) and is_binary(message) do
+    {:ok,
+     %Validated{
+       kind: :error,
+       id: id,
+       error_code: code,
+       error_message: message
+     }}
+  end
+
+  defp validate_error(_error, id), do: {:invalid, :invalid_envelope, id}
+
+  defp candidate_id(%{id_count: 1, id: id}) when id != :invalid, do: id
+  defp candidate_id(_fields), do: nil
+
+  defp locate_id(%Validated{id: id} = validated, raw_bytes) do
+    case Jason.encode(id) do
+      {:ok, encoded_id} -> locate_encoded_id(validated, raw_bytes, encoded_id)
+      {:error, _reason} -> {:error, :ambiguous_id_location}
+    end
+  end
+
+  defp locate_encoded_id(validated, raw_bytes, encoded_id) do
+    case :binary.matches(raw_bytes, encoded_id) do
+      [{start_pos, length}] = matches ->
+        locate_verified_id(validated, raw_bytes, matches, {start_pos, length})
+
+      _none_or_ambiguous ->
+        locate_top_level_id(validated, raw_bytes)
+    end
+  end
+
+  defp locate_verified_id(validated, raw_bytes, _matches, canonical_span) do
+    case top_level_id_span(raw_bytes) do
+      {:ok, ^canonical_span} -> {:ok, %{validated | id_span: canonical_span}}
+      {:ok, actual_span} -> {:ok, %{validated | id_span: actual_span}}
+      :error -> {:error, :ambiguous_id_location}
+    end
+  end
+
+  defp locate_top_level_id(validated, raw_bytes) do
+    case top_level_id_span(raw_bytes) do
+      {:ok, span} -> {:ok, %{validated | id_span: span}}
+      :error -> {:error, :ambiguous_id_location}
+    end
+  end
+
+  defp response_mode(raw_bytes) do
+    start = skip_whitespace(raw_bytes, 0)
+
+    if byte_at(raw_bytes, start) == ?{ do
+      scan_response_mode(raw_bytes, skip_whitespace(raw_bytes, start + 1))
+    else
+      :discard
+    end
+  end
+
+  defp scan_response_mode(raw_bytes, index) do
+    with ?" <- byte_at(raw_bytes, index),
+         {:ok, key_end} <- skip_string(raw_bytes, index),
+         {:ok, key} <- decode_key(raw_bytes, index, key_end) do
+      colon_index = skip_whitespace(raw_bytes, key_end)
+
+      if byte_at(raw_bytes, colon_index) == ?: do
+        value_start = skip_whitespace(raw_bytes, colon_index + 1)
+
+        case key do
+          "error" -> :retain_error
+          "result" -> :discard
+          _other -> continue_response_mode(raw_bytes, value_start)
+        end
+      else
+        :discard
+      end
+    else
+      _invalid -> :discard
+    end
+  end
+
+  defp continue_response_mode(raw_bytes, value_start) do
+    case skip_value(raw_bytes, value_start) do
+      {:ok, value_end} ->
+        next = skip_whitespace(raw_bytes, value_end)
+
+        case byte_at(raw_bytes, next) do
+          ?, -> scan_response_mode(raw_bytes, skip_whitespace(raw_bytes, next + 1))
+          _end_or_invalid -> :discard
+        end
+
+      :error ->
+        :discard
+    end
+  end
+
+  defp top_level_id_span(raw_bytes) do
+    start = skip_whitespace(raw_bytes, 0)
+
+    if byte_at(raw_bytes, start) == ?{ do
+      scan_top_level_members(raw_bytes, skip_whitespace(raw_bytes, start + 1))
+    else
+      :error
+    end
+  end
+
+  defp scan_top_level_members(raw_bytes, index) do
+    case byte_at(raw_bytes, index) do
+      ?} ->
+        :error
+
+      ?" ->
+        with {:ok, key_end} <- skip_string(raw_bytes, index),
+             {:ok, key} <- decode_key(raw_bytes, index, key_end),
+             colon_index = skip_whitespace(raw_bytes, key_end),
+             ?: <- byte_at(raw_bytes, colon_index),
+             value_start = skip_whitespace(raw_bytes, colon_index + 1),
+             {:ok, value_end} <- skip_value(raw_bytes, value_start) do
+          if key == "id" do
+            {:ok, {value_start, value_end - value_start}}
+          else
+            continue_top_level_members(raw_bytes, value_end)
+          end
+        else
+          _invalid -> :error
+        end
+
+      _other ->
+        :error
+    end
+  end
+
+  defp continue_top_level_members(raw_bytes, value_end) do
+    next = skip_whitespace(raw_bytes, value_end)
+
+    case byte_at(raw_bytes, next) do
+      ?, -> scan_top_level_members(raw_bytes, skip_whitespace(raw_bytes, next + 1))
+      ?} -> :error
+      _other -> :error
+    end
+  end
+
+  defp decode_key(raw_bytes, start, finish) do
+    token = binary_part(raw_bytes, start, finish - start)
+    {:ok, :json.decode(token)}
+  rescue
+    _error -> :error
+  end
+
+  defp skip_value(raw_bytes, index) do
+    case byte_at(raw_bytes, index) do
+      ?" ->
+        skip_string(raw_bytes, index)
+
+      ?{ ->
+        skip_container(raw_bytes, index + 1, [?}])
+
+      ?[ ->
+        skip_container(raw_bytes, index + 1, [?]])
+
+      byte when byte in [?-, ?0, ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?t, ?f, ?n] ->
+        skip_scalar(raw_bytes, index)
+
+      _other ->
+        :error
+    end
+  end
+
+  defp skip_container(raw_bytes, index, [expected | rest] = stack) do
+    case byte_at(raw_bytes, index) do
+      nil ->
+        :error
+
+      ?" ->
+        case skip_string(raw_bytes, index) do
+          {:ok, next} -> skip_container(raw_bytes, next, stack)
+          :error -> :error
+        end
+
+      ?{ ->
+        skip_container(raw_bytes, index + 1, [?} | stack])
+
+      ?[ ->
+        skip_container(raw_bytes, index + 1, [?] | stack])
+
+      ^expected when rest == [] ->
+        {:ok, index + 1}
+
+      ^expected ->
+        skip_container(raw_bytes, index + 1, rest)
+
+      _byte ->
+        skip_container(raw_bytes, index + 1, stack)
+    end
+  end
+
+  defp skip_string(raw_bytes, index), do: do_skip_string(raw_bytes, index + 1)
+
+  defp do_skip_string(raw_bytes, index) do
+    case byte_at(raw_bytes, index) do
+      nil -> :error
+      ?" -> {:ok, index + 1}
+      ?\\ -> skip_escape(raw_bytes, index)
+      _byte -> do_skip_string(raw_bytes, index + 1)
+    end
+  end
+
+  defp skip_escape(raw_bytes, index) do
+    next_index = if byte_at(raw_bytes, index + 1) == ?u, do: index + 6, else: index + 2
+
+    if next_index <= byte_size(raw_bytes),
+      do: do_skip_string(raw_bytes, next_index),
+      else: :error
+  end
+
+  defp skip_scalar(raw_bytes, index) do
+    case byte_at(raw_bytes, index) do
+      byte when byte in [nil, ?\s, ?\t, ?\r, ?\n, ?,, ?}, ?]] -> {:ok, index}
+      _byte -> skip_scalar(raw_bytes, index + 1)
+    end
+  end
+
+  defp skip_whitespace(raw_bytes, index) do
+    case byte_at(raw_bytes, index) do
+      byte when byte in [?\s, ?\t, ?\r, ?\n] -> skip_whitespace(raw_bytes, index + 1)
+      _byte -> index
+    end
+  end
+
+  defp byte_at(raw_bytes, index) when index < byte_size(raw_bytes),
+    do: :binary.at(raw_bytes, index)
+
+  defp byte_at(_raw_bytes, _index), do: nil
+
+  defp restore_id(%Validated{id: id}, raw_bytes, id), do: {:ok, raw_bytes}
+
+  defp restore_id(%Validated{id_span: {start_pos, length}}, raw_bytes, client_id) do
+    with {:ok, encoded_id} <- Jason.encode(client_id) do
+      prefix = binary_part(raw_bytes, 0, start_pos)
+      suffix_start = start_pos + length
+      suffix = binary_part(raw_bytes, suffix_start, byte_size(raw_bytes) - suffix_start)
+      {:ok, IO.iodata_to_binary([prefix, encoded_id, suffix])}
+    end
+  end
+
+  defp restore_id(%Validated{} = validated, raw_bytes, client_id) do
+    case locate_id(validated, raw_bytes) do
+      {:ok, located} -> restore_id(located, raw_bytes, client_id)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp build_response(%Validated{kind: :result}, client_id, restored_bytes) do
+    {:ok, %Response.Success{id: client_id, jsonrpc: "2.0", raw_bytes: restored_bytes}}
+  end
+
+  defp build_response(
+         %Validated{
+           kind: :error,
+           error_code: code,
+           error_message: message,
+           error_data: data
+         },
+         _client_id,
+         _restored_bytes
+       ) do
+    {:error, JError.new(code, message, data: data)}
+  end
+
+  defp only_json_whitespace?(<<>>), do: true
+
+  defp only_json_whitespace?(rest) when is_binary(rest) do
+    rest
+    |> :binary.bin_to_list()
+    |> Enum.all?(&(&1 in [32, 9, 10, 13]))
+  end
+end

--- a/test/lasso/core/transport/upstream_response_test.exs
+++ b/test/lasso/core/transport/upstream_response_test.exs
@@ -1,0 +1,336 @@
+defmodule Lasso.Core.Transport.UpstreamResponseTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Core.Transport.UpstreamResponse
+  alias Lasso.Core.Transport.UpstreamResponse.Validated
+  alias Lasso.JSONRPC.Error, as: JError
+  alias Lasso.RPC.Response
+
+  test "accepts one correlated response and restores the client id" do
+    raw = ~s({"jsonrpc":"2.0","id":"internal","result":"0x1"})
+
+    assert {:ok, %Response.Success{id: 7} = response} =
+             UpstreamResponse.validate_unary(raw, "internal", 7)
+
+    assert {:ok, %{"id" => 7, "result" => "0x1"}} = Jason.decode(response.raw_bytes)
+  end
+
+  test "rejects invalid unary envelopes with bounded reasons" do
+    vectors = [
+      {"not-json", :invalid_json},
+      {~s({"jsonrpc":"1.0","id":"internal","result":1}), :unsupported_version},
+      {~s({"jsonrpc":"2.0","id":"wrong","result":1}), :id_mismatch},
+      {~s({"jsonrpc":"2.0","method":"notice","params":[]}), :unexpected_notification},
+      {~s([{"jsonrpc":"2.0","id":"internal","result":1}]), :unexpected_batch},
+      {~s({"jsonrpc":"2.0","id":"internal","result":1} trailing), :invalid_json},
+      {~s({"jsonrpc":"2.0","id":"internal","result":1,"error":{}}), :invalid_envelope}
+    ]
+
+    for {raw, reason} <- vectors do
+      assert {:invalid, ^reason} = UpstreamResponse.validate_unary(raw, "internal", 1)
+    end
+  end
+
+  test "strictly validates the unary JSON-RPC grammar without retaining result values" do
+    valid_nested =
+      ~s({"jsonrpc":"2.0","result":{"id":"nested","items":[1,{"deep":true}]},"id":"internal"})
+
+    escaped_keys =
+      ~S({"json\u0072pc":"2.0","\u0069d":"internal","res\u0075lt":{"ok":true}})
+
+    vectors = [
+      {~s({"jsonrpc":"2.0","id":"internal","result":{"ok":true}}), {:ok, :result, "internal"}},
+      {valid_nested, {:ok, :result, "internal"}},
+      {escaped_keys, {:ok, :result, "internal"}},
+      {~s({"jsonrpc":"2.0","id":"internal","error":{"code":-32000,"message":"busy","data":{"secret":"discarded"}}}),
+       {:ok, :error, "internal"}},
+      {~s({"jsonrpc":"2.0","id":"internal","result":[1,]}), {:invalid, :invalid_json}},
+      {<<"{\"jsonrpc\":\"2.0\",\"id\":\"internal\",\"result\":\"", 0xFF, "\"}">>,
+       {:invalid, :invalid_json}},
+      {"{\"jsonrpc\":\"2.0\",\"id\":\"internal\",\"result\":\"" <>
+         "\\u" <> "D800\"}", {:invalid, :invalid_json}},
+      {~s({"jsonrpc":"2.0","result":{"id":"internal"}}), {:invalid, :invalid_envelope}},
+      {~s({"jsonrpc":"2.0","id":"internal","id":"internal","result":1}),
+       {:invalid, :invalid_envelope}},
+      {~s({"jsonrpc":"2.0","id":"internal","result":1,"error":{"code":-1,"message":"both"}}),
+       {:invalid, :invalid_envelope}},
+      {~s({"jsonrpc":"2.0","id":"internal","error":{"code":"bad","message":"no"}}),
+       {:invalid, :invalid_envelope}},
+      {~s({"jsonrpc":"2.0","id":"internal","result":1} trailing), {:invalid, :invalid_json}},
+      {~s([{"jsonrpc":"2.0","id":"internal","result":1}]), {:invalid, :unexpected_batch}},
+      {~s({"jsonrpc":"2.0","method":"notice","params":[]}), {:legacy, :notification}}
+    ]
+
+    Enum.each(vectors, fn
+      {raw, {:ok, kind, id}} ->
+        assert {:ok, %Validated{kind: ^kind, id: ^id}} = UpstreamResponse.parse_unary(raw)
+
+      {raw, {:invalid, reason}} ->
+        assert {:invalid, ^reason, _candidate_id} = UpstreamResponse.parse_unary(raw)
+
+      {raw, expected} ->
+        assert expected == UpstreamResponse.parse_unary(raw)
+    end)
+  end
+
+  test "preserves the full error message and data from the strict OTP pass" do
+    oversized_message = String.duplicate("x", 4_096)
+
+    error_data = %{
+      "request" => String.duplicate("secret", 10_000),
+      "retry_after" => 25,
+      "nested" => [%{"missing" => nil}, true, [1, 2, 3]]
+    }
+
+    raw =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => "internal",
+        "error" => %{
+          "code" => -32_000,
+          "message" => oversized_message,
+          "data" => error_data
+        }
+      })
+
+    assert {:ok,
+            %Validated{
+              kind: :error,
+              error_message: ^oversized_message,
+              error_data: ^error_data
+            }} =
+             UpstreamResponse.parse_unary(raw)
+
+    assert {:error, %JError{code: -32_000, message: ^oversized_message, data: ^error_data}} =
+             UpstreamResponse.validate_unary(raw, "internal", "client")
+  end
+
+  test "preserves JSON float and exponent values in nested error data" do
+    raw =
+      ~s({"jsonrpc":"2.0","id":7,"error":{"code":-32000,"message":"numeric data","data":{"decimal":1.25,"exponent":1e3,"negative_zero":-0.0,"nested":[-2.5E-4,{"value":6.02e23}]}}})
+
+    assert {:error, %JError{data: data}} = UpstreamResponse.validate_unary(raw, 7, 7)
+    assert data["decimal"] == 1.25
+    assert data["exponent"] == 1.0e3
+    assert data["nested"] == [-2.5e-4, %{"value" => 6.02e23}]
+    negative_zero = data["negative_zero"]
+    assert <<1::1, _magnitude::63>> = <<negative_zero::float>>
+  end
+
+  @tag timeout: 10_000
+  test "100 KiB errors avoid the legacy second parse with bounded parser overhead" do
+    error_data = "0x" <> String.duplicate("d", 100 * 1_024)
+
+    raw =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => 7,
+        "error" => %{
+          "code" => -32_000,
+          "message" => "execution reverted",
+          "data" => error_data
+        }
+      })
+
+    true = Code.ensure_loaded?(Response)
+    legacy_decode_mfa = {Response, :from_bytes, 1}
+    :erlang.trace_pattern(legacy_decode_mfa, true, [])
+    :erlang.trace(self(), true, [:call])
+
+    on_exit(fn ->
+      :erlang.trace_pattern(legacy_decode_mfa, false, [])
+    end)
+
+    assert {:error, %JError{data: ^error_data}} =
+             UpstreamResponse.validate_unary(raw, 7, 7)
+
+    :erlang.trace(self(), false, [:call])
+    :erlang.trace_pattern(legacy_decode_mfa, false, [])
+    refute_receive {:trace, _pid, :call, {Response, :from_bytes, [_raw]}}, 0
+
+    parent = self()
+
+    {worker, monitor} =
+      spawn_monitor(fn ->
+        :erlang.garbage_collect()
+        {:total_heap_size, before_words} = Process.info(self(), :total_heap_size)
+        {:reductions, before_reductions} = Process.info(self(), :reductions)
+        started_at_us = System.monotonic_time(:microsecond)
+        result = UpstreamResponse.validate_unary(raw, 7, 7)
+        elapsed_us = System.monotonic_time(:microsecond) - started_at_us
+        {:reductions, after_reductions} = Process.info(self(), :reductions)
+        :erlang.garbage_collect()
+        {:total_heap_size, after_words} = Process.info(self(), :total_heap_size)
+
+        send(
+          parent,
+          {:large_error_validation, result, after_words - before_words,
+           after_reductions - before_reductions, elapsed_us}
+        )
+      end)
+
+    assert_receive {:large_error_validation, {:error, %JError{data: ^error_data}}, heap_growth,
+                    reductions, elapsed_us},
+                   5_000
+
+    assert heap_growth < 50_000
+    assert reductions < 50_000
+    assert elapsed_us < 500_000
+    assert_receive {:DOWN, ^monitor, :process, ^worker, :normal}
+  end
+
+  test "locates only the top-level id span for escaped and repeated spellings" do
+    transport_id = "lasso-internal"
+
+    escaped =
+      ~S({"jsonrpc":"2.0","\u0069d":"lasso-\u0069nternal","result":{"copy":"lasso-internal"}})
+
+    assert {:transport, %Validated{id: ^transport_id} = validated} =
+             UpstreamResponse.parse_ws_frame(escaped)
+
+    assert {:ok, %Response.Success{raw_bytes: restored}} =
+             UpstreamResponse.finalize_unary(validated, escaped, transport_id, "client")
+
+    assert {:ok, %{"id" => "client", "result" => %{"copy" => ^transport_id}}} =
+             Jason.decode(restored)
+
+    repeated =
+      ~s({"result":{"first":"#{transport_id}","nested":{"id":"#{transport_id}"}},"id":"#{transport_id}","jsonrpc":"2.0"})
+
+    assert {:transport, %Validated{id: ^transport_id} = repeated_validation} =
+             UpstreamResponse.parse_ws_frame(repeated)
+
+    assert {:ok, %Response.Success{raw_bytes: repeated_restored}} =
+             UpstreamResponse.finalize_unary(
+               repeated_validation,
+               repeated,
+               transport_id,
+               "client"
+             )
+
+    assert {:ok,
+            %{
+              "id" => "client",
+              "result" => %{
+                "first" => ^transport_id,
+                "nested" => %{"id" => ^transport_id}
+              }
+            }} = Jason.decode(repeated_restored)
+  end
+
+  test "accepts long string and arbitrary-size integer JSON-RPC ids" do
+    long_id = String.duplicate("client-id-", 64)
+    large_integer_id = String.to_integer(String.duplicate("9", 128))
+
+    for id <- [long_id, large_integer_id] do
+      raw = Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => %{"ok" => true}})
+
+      assert {:ok, %Response.Success{id: ^id, raw_bytes: ^raw}} =
+               UpstreamResponse.validate_unary(raw, id, id)
+    end
+
+    refute UpstreamResponse.transport_id?("lasso-" <> String.duplicate("x", 129))
+  end
+
+  test "extracts only bounded internal transport ids for correlation" do
+    first = "lasso-conn_a-first"
+    second = "lasso-conn_a-second"
+
+    assert {:ok, [^first]} =
+             UpstreamResponse.extract_transport_ids(
+               ~s({"jsonrpc":"2.0","id":"#{first}","result":1})
+             )
+
+    assert {:ok, [^first]} =
+             UpstreamResponse.extract_transport_ids(
+               ~s({"jsonrpc":"2.0","id":"#{first}","result":1} trailing)
+             )
+
+    batch =
+      Jason.encode!([
+        %{"jsonrpc" => "2.0", "id" => first, "result" => 1},
+        %{"jsonrpc" => "2.0", "id" => second, "result" => 2}
+      ])
+
+    assert {:error, :unattributable} = UpstreamResponse.extract_transport_ids(batch)
+    assert {:ok, []} = UpstreamResponse.extract_transport_ids(~s({"id":"client-id","result":1}))
+    assert {:error, :unattributable} = UpstreamResponse.extract_transport_ids("not-json")
+  end
+
+  test "correlates only one unambiguous top-level transport id" do
+    transport_id = "lasso-conn_a-only"
+
+    assert {:error, :unattributable} =
+             UpstreamResponse.extract_transport_ids(
+               ~s({"id":"#{transport_id}","id":"#{transport_id}","result":1})
+             )
+
+    assert {:ok, []} =
+             UpstreamResponse.extract_transport_ids(
+               ~s({"jsonrpc":"2.0","id":"client","result":{"id":"#{transport_id}"}})
+             )
+
+    assert {:error, :unattributable} =
+             UpstreamResponse.extract_transport_ids(
+               ~s({"jsonrpc":"2.0","meta":{"id":"#{transport_id}"},"result":1)
+             )
+  end
+
+  @tag timeout: 10_000
+  test "large success has bounded retained memory and a generous parser latency ceiling" do
+    result = "[" <> String.duplicate("0,", 524_288) <> "0]"
+    raw = ~s({"jsonrpc":"2.0","id":"internal","result":#{result}})
+    parent = self()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        :erlang.garbage_collect()
+        {:total_heap_size, before_words} = :erlang.process_info(self(), :total_heap_size)
+        {:reductions, before_reductions} = :erlang.process_info(self(), :reductions)
+        started_at = System.monotonic_time(:microsecond)
+        validation = UpstreamResponse.validate_unary(raw, "internal", "client")
+        elapsed_us = System.monotonic_time(:microsecond) - started_at
+        {:reductions, after_reductions} = :erlang.process_info(self(), :reductions)
+        :erlang.garbage_collect()
+        {:total_heap_size, after_words} = :erlang.process_info(self(), :total_heap_size)
+
+        send(
+          parent,
+          {:large_validation, validation, after_words - before_words,
+           after_reductions - before_reductions, elapsed_us}
+        )
+      end)
+
+    assert_receive {:large_validation,
+                    {:ok, %Response.Success{id: "client", raw_bytes: restored}}, heap_growth,
+                    reductions, elapsed_us},
+                   5_000
+
+    assert restored ==
+             ~s({"jsonrpc":"2.0","id":"client","result":#{result}})
+
+    assert heap_growth < 100_000
+    assert reductions < byte_size(raw) * 50
+    assert elapsed_us < 2_000_000
+
+    assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}
+  end
+
+  test "same-id HTTP validation returns the exact upstream binary" do
+    result = "[" <> String.duplicate("0,", 100_000) <> "0]"
+    raw = ~s({"jsonrpc":"2.0","id":77,"result":#{result}})
+
+    assert {:ok, %Response.Success{id: 77, raw_bytes: restored}} =
+             UpstreamResponse.validate_unary(raw, 77, 77)
+
+    assert restored === raw
+    assert :erts_debug.same(restored, raw)
+
+    assert {:error, %JError{code: -32_000, message: "busy"}} =
+             UpstreamResponse.validate_unary(
+               ~s({"jsonrpc":"2.0","id":77,"error":{"code":-32000,"message":"busy"}}),
+               77,
+               77
+             )
+  end
+end


### PR DESCRIPTION
## Summary

Adds a strict, raw-preserving JSON-RPC upstream-response validator as an inert foundation for the
#500 transport cutover.

- Validates the complete JSON grammar and unary JSON-RPC envelope on OTP 27+.
- Rejects malformed/trailing JSON, batches/notifications on the unary path, duplicate reserved
  fields, nested/spoofed IDs, and responses containing both `result` and `error`.
- Preserves the exact raw response binary when the upstream and client IDs match.
- Locates the structural top-level ID for safe WebSocket correlation and exact ID restoration.
- Discards successful result trees while preserving complete JSON-RPC error message/data.
- Performs one strict decode per response; it does not call the legacy response parser again.

This PR does not wire the validator into production. Keeping it inert makes the parsing contract,
OTP prerequisite, and performance behavior independently reviewable and revertible before the
atomic lifecycle/HTTP/WebSocket runtime cutover.

## Performance evidence

The measured OTP discard candidate won every tested receipt, block, logs, trace, large-hex-result,
and error corpus cell versus Jason. On the local c64 mixed corpus it processed about 3,242
responses/s versus 934 responses/s for Jason, while preserving successful raw binaries and not
retaining result trees. These are diagnostic results, not an end-to-end Wayfinder or eRPC claim.

The production 100 KiB error regression uses about 14.6k reductions after removing a second full
parse (previous candidate: roughly 220k). Memory assertions cover retained heap after GC, not peak
transient allocation. Valid errors intentionally retain the decoded error tree until request
settlement; successful result payloads remain undecoded.

Prototype and realistic-corpus evidence: `prototype/500-response-parser` at `47b9f8d3` and the
linked #50 comment.

## Verification

- Fresh independent parser review: APPROVE.
- 100 repeated focused runs: 1,200 cases/assertions, no failures.
- OTP 27.3 production-container focused run: 12/12.
- Additional key-order permutations and adversarial escaped/duplicate vectors.
- Full integration-enabled suite on the stacked worktree: 1,223 tests, 0 failures.
- `mix format --check-formatted`.
- warnings-as-errors compilation.
- Credo strict.
- Dialyzer.
- dependency audit (only documented cowlib exceptions).
- clean production Docker build.

## Contract decisions

- Strict upstream JSON validation is intentional because dispatch/failover/breaker truth depends on
  a valid provider response.
- `result` plus `error` is rejected by default.
- OTP 27 is now the minimum runtime because the implementation uses the standard-library
  `:json.decode/3` callback surface.
