### PR TITLE
Add stamped transport execution protocol

### DIFF
--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -68,6 +68,9 @@ defmodule Lasso.Application do
         # Error classification sample store (attaches to telemetry)
         Lasso.Core.Support.ErrorClassificationStore,
 
+        # Dispatch truth is boot-critical for tracked HTTP attempts.
+        Lasso.Core.Transport.HTTP.DispatchTracker,
+
         # Start Finch HTTP client for RPC provider requests
         # Pool size tuned for typical RPC proxy workloads:
         # - size: max connections per pool (per unique host)
@@ -79,13 +82,14 @@ defmodule Lasso.Application do
          name: Lasso.Finch,
          pools: %{
            :default => [
+             protocols: [:http1],
              size: 30,
              count: 3,
              pool_max_idle_time: :timer.seconds(60),
              conn_opts: [
-               timeout: 30_000,
                idle_timeout: 60_000,
                transport_opts: [
+                 timeout: 5_000,
                  reuse_sessions: true
                ]
              ]

--- a/lib/lasso/core/request/execution_reducer.ex
+++ b/lib/lasso/core/request/execution_reducer.ex
@@ -75,6 +75,11 @@ defmodule Lasso.RPC.ExecutionReducer do
 
   @spec close_deadline(t()) :: t()
   def close_deadline(%__MODULE__{terminal: nil} = state) do
+    state =
+      if unresolved_send?(state, state.deadline_us),
+        do: promote(state, :indeterminate),
+        else: state
+
     %{state | terminal: :deadline, terminal_at_us: state.deadline_us, committed: true}
   end
 
@@ -176,7 +181,7 @@ defmodule Lasso.RPC.ExecutionReducer do
     violation(state, event, :observation_after_terminal)
   end
 
-  defp fold(state, %{kind: :send_started}), do: promote(state, :indeterminate)
+  defp fold(state, %{kind: :send_started}), do: state
   defp fold(state, %{kind: :send_confirmed}), do: promote(state, :dispatched)
 
   defp fold(state, %{kind: :not_dispatched} = event) do
@@ -203,6 +208,8 @@ defmodule Lasso.RPC.ExecutionReducer do
 
   defp fold(state, %{kind: kind, event_us: event_us, certainty: certainty} = event)
        when kind in [:transport_failure, :cancelled] do
+    {certainty, event} = resolve_terminal_certainty(state, event, certainty)
+
     if @certainty_rank[certainty] < @certainty_rank[state.dispatch_certainty] do
       violation(state, event, :certainty_regression)
     else
@@ -425,9 +432,34 @@ defmodule Lasso.RPC.ExecutionReducer do
        when kind in [:response, :invalid_response, :send_confirmed],
        do: :dispatched
 
-  defp event_certainty(%{kind: :send_started}), do: :indeterminate
   defp event_certainty(%{certainty: certainty}), do: certainty
   defp event_certainty(_event), do: nil
+
+  defp resolve_terminal_certainty(state, %{kind: :cancelled} = event, :not_dispatched) do
+    if unresolved_send?(state, event.event_us) do
+      {:indeterminate, %{event | certainty: :indeterminate}}
+    else
+      {:not_dispatched, event}
+    end
+  end
+
+  defp resolve_terminal_certainty(_state, event, certainty), do: {certainty, event}
+
+  defp unresolved_send?(state, boundary_us) do
+    case Map.fetch(state.observations, :send_started) do
+      {:ok, started} when started.event_us <= boundary_us ->
+        case Map.fetch(state.observations, :not_dispatched) do
+          {:ok, proof} ->
+            proof.event_us < started.event_us or proof.event_us > boundary_us
+
+          :error ->
+            true
+        end
+
+      _ ->
+        false
+    end
+  end
 
   defp diagnose_reused_id(state, event) do
     if existing_event(state, event.id) == fingerprint(event),

--- a/lib/lasso/core/support/attempt_lifecycle.ex
+++ b/lib/lasso/core/support/attempt_lifecycle.ex
@@ -5,14 +5,25 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
   alias Lasso.Core.Support.CircuitBreaker
   alias Lasso.Core.Support.CircuitBreaker.AdmissionReceipt
+  alias Lasso.Core.Transport.AttemptProtocol
   alias Lasso.JSONRPC.Error, as: JError
 
   @dispatch_context_key :lasso_attempt_dispatch_context
-  @dispatch_settle_timeout 1_000
+  @deadline_key :lasso_attempt_deadline_us
+  @settlement_deadline_key :lasso_attempt_settlement_deadline_us
+  @dispatch_receipt_key :lasso_attempt_dispatch_receipt
+  @dispatch_timestamp_unset -9_223_372_036_854_775_808
+  @open_unset 0
+  @open_ambiguous 1
+  @open_not_dispatched 2
+  @open_dispatched 3
+  @closed_offset 4
+  @settlement_margin_us 1_000
+  @minimum_settlement_budget_ms 25
 
   @type terminal_callback :: CircuitBreaker.terminal_callback() | nil
   @type dispatch_callback :: (integer() -> term()) | nil
-  @type dispatch_context :: {pid(), reference()}
+  @type dispatch_context :: AttemptProtocol.context()
 
   @spec run(
           pid(),
@@ -99,35 +110,93 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         deadline_us
       ) do
     lifecycle_ref = make_ref()
+    lifecycle_start_ref = make_ref()
+    dispatch_latch = new_dispatch_latch()
+    decision_deadline_us = decision_deadline_us(deadline_us, timeout)
+    attempt_deadline_us = attempt_deadline_us(decision_deadline_us, timeout)
+    settlement_deadline_us = min(deadline_us, attempt_deadline_us + @settlement_margin_us)
 
-    {lifecycle_pid, monitor_ref} =
-      spawn_monitor(fn ->
-        execute(%{
+    lifecycle_deadline_us = settlement_deadline_us
+
+    case claim_for_execution(receipt, caller_pid, dispatch_latch, attempt_deadline_us) do
+      :ok ->
+        context = %{
           caller_pid: caller_pid,
           lifecycle_ref: lifecycle_ref,
+          lifecycle_start_ref: lifecycle_start_ref,
           receipt: receipt,
-          breaker_id: receipt.breaker_id,
           fun: fun,
           timeout: timeout,
-          terminal_callback: terminal_callback,
-          dispatch_callback: dispatch_callback,
+          legacy_terminal_callback: terminal_callback,
           dispatch_mode: dispatch_mode,
-          deadline_us: deadline_us
-        })
-      end)
+          attempt_deadline_us: attempt_deadline_us,
+          settlement_deadline_us: settlement_deadline_us,
+          lifecycle_deadline_us: lifecycle_deadline_us,
+          dispatch_latch: dispatch_latch
+        }
 
-    receive do
-      {^lifecycle_ref, result} ->
-        Process.demonitor(monitor_ref, [:flush])
+        {lifecycle_pid, monitor_ref} = spawn_monitor(fn -> execute(context) end)
+
+        terminal_dispatch_callback =
+          prepare_dispatch(
+            dispatch_mode,
+            dispatch_latch,
+            dispatch_callback,
+            attempt_deadline_us
+          )
+
+        send(lifecycle_pid, {:start_attempt_lifecycle, lifecycle_start_ref})
+
+        terminal_candidate =
+          receive do
+            {^lifecycle_ref,
+             {:attempt_terminal_candidate, result, elapsed_ms, accounting?, callback_eligible?}} ->
+              {:candidate, result, elapsed_ms, accounting?, callback_eligible?}
+
+            {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, reason} ->
+              {:owner_down, reason}
+          after
+            deadline_wait_ms(deadline_us) ->
+              :client_timeout
+          end
+
+        {certainty, dispatched_at_us} = close_dispatch_latch(dispatch_latch)
+
+        {result, elapsed_ms, accounting?} =
+          outer_terminal_candidate(
+            terminal_candidate,
+            certainty,
+            dispatched_at_us,
+            timeout
+          )
+
+        if accounting? do
+          finalize_receipt(dispatch_latch, receipt, result, certainty, terminal_callback)
+
+          publish_owner_terminal(
+            receipt.breaker_id,
+            result,
+            certainty,
+            dispatched_at_us,
+            terminal_dispatch_callback
+          )
+        end
+
+        finish_compatibility_lifecycle(
+          terminal_candidate,
+          lifecycle_pid,
+          monitor_ref,
+          lifecycle_ref,
+          result,
+          terminal_elapsed_ms(elapsed_ms, dispatched_at_us),
+          accounting?,
+          certainty
+        )
+
         result
 
-      {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, reason} ->
-        {:exception, {:exit, reason, []}}
-    after
-      deadline_wait_ms(deadline_us) ->
-        send(lifecycle_pid, {:attempt_caller_timeout, lifecycle_ref})
-        Process.demonitor(monitor_ref, [:flush])
-        {:__attempt_lifecycle_rejected__, :timeout}
+      {:error, reason} ->
+        {:__attempt_lifecycle_rejected__, reason}
     end
   end
 
@@ -161,58 +230,64 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   def dispatch_context, do: Process.get(@dispatch_context_key)
 
   @doc false
+  @spec deadline_us() :: integer() | nil
+  def deadline_us, do: Process.get(@deadline_key)
+
+  @doc false
+  @spec settlement_deadline_us() :: integer() | nil
+  def settlement_deadline_us, do: Process.get(@settlement_deadline_key)
+
+  @doc false
+  @spec dispatch_owner_alive?() :: boolean()
+  def dispatch_owner_alive? do
+    case Process.get(@dispatch_receipt_key) do
+      %{caller_pid: caller_pid} -> Process.alive?(caller_pid)
+      _ -> true
+    end
+  end
+
+  @doc false
+  @spec record_dispatch_state(:ambiguous | :not_dispatched | :dispatched, integer()) ::
+          :ok | {:error, :owner_down | :deadline_expired}
+  def record_dispatch_state(certainty, event_us)
+      when certainty in [:ambiguous, :not_dispatched, :dispatched] and is_integer(event_us) do
+    case Process.get(@dispatch_receipt_key) do
+      %{latch: latch, caller_pid: caller_pid} ->
+        deadline_us = deadline_us()
+
+        cond do
+          not Process.alive?(caller_pid) -> {:error, :owner_down}
+          is_integer(deadline_us) and event_us >= deadline_us -> {:error, :deadline_expired}
+          true -> transition_dispatch_latch(latch, certainty, event_us)
+        end
+
+      %{latch: latch} ->
+        transition_dispatch_latch(latch, certainty, event_us)
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
   @spec authorize_dispatch(dispatch_context() | nil) :: :ok | {:error, :cancelled}
   def authorize_dispatch(nil), do: :ok
 
-  def authorize_dispatch({lifecycle_pid, dispatch_ref}) do
-    authorization_ref = make_ref()
-    monitor_ref = Process.monitor(lifecycle_pid)
-
-    send(
-      lifecycle_pid,
-      {:authorize_attempt_dispatch, dispatch_ref, self(), authorization_ref}
-    )
-
-    receive do
-      {:attempt_dispatch_authorized, ^authorization_ref} ->
-        Process.demonitor(monitor_ref, [:flush])
-        :ok
-
-      {:attempt_dispatch_rejected, ^authorization_ref} ->
-        Process.demonitor(monitor_ref, [:flush])
-        {:error, :cancelled}
-
-      {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, _reason} ->
-        {:error, :cancelled}
-    after
-      1_000 ->
-        Process.demonitor(monitor_ref, [:flush])
-        _abort_result = abort_dispatch({lifecycle_pid, dispatch_ref})
-        {:error, :cancelled}
-    end
-  end
+  def authorize_dispatch({lifecycle_pid, _dispatch_ref}),
+    do: if(Process.alive?(lifecycle_pid), do: :ok, else: {:error, :cancelled})
 
   @doc false
   @spec confirm_dispatched(dispatch_context() | nil) :: :ok | {:error, :cancelled}
   def confirm_dispatched(nil), do: :ok
 
-  def confirm_dispatched({lifecycle_pid, dispatch_ref}) do
-    confirmation_ref = make_ref()
-    monitor_ref = Process.monitor(lifecycle_pid)
-
-    send(lifecycle_pid, {:attempt_dispatched, dispatch_ref, self(), confirmation_ref})
-
-    receive do
-      {:attempt_dispatch_confirmed, ^confirmation_ref} ->
-        Process.demonitor(monitor_ref, [:flush])
-        :ok
-
-      {:attempt_dispatch_rejected, ^confirmation_ref} ->
-        Process.demonitor(monitor_ref, [:flush])
-        {:error, :cancelled}
-
-      {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, _reason} ->
-        {:error, :cancelled}
+  def confirm_dispatched({lifecycle_pid, _dispatch_ref} = context) do
+    if Process.alive?(lifecycle_pid) do
+      case AttemptProtocol.send_started(context) do
+        :ok -> AttemptProtocol.send_confirmed(context)
+        {:error, _reason} -> {:error, :cancelled}
+      end
+    else
+      {:error, :cancelled}
     end
   end
 
@@ -220,57 +295,91 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   @spec abort_dispatch(dispatch_context() | nil) :: :ok | {:error, :cancelled}
   def abort_dispatch(nil), do: :ok
 
-  def abort_dispatch({lifecycle_pid, dispatch_ref}) do
-    abort_ref = make_ref()
-    monitor_ref = Process.monitor(lifecycle_pid)
-    send(lifecycle_pid, {:attempt_dispatch_aborted, dispatch_ref, self(), abort_ref})
-
-    receive do
-      {:attempt_dispatch_aborted, ^abort_ref} ->
-        Process.demonitor(monitor_ref, [:flush])
-        :ok
-
-      {:attempt_dispatch_rejected, ^abort_ref} ->
-        Process.demonitor(monitor_ref, [:flush])
-        {:error, :cancelled}
-
-      {:DOWN, ^monitor_ref, :process, ^lifecycle_pid, _reason} ->
-        {:error, :cancelled}
+  def abort_dispatch({lifecycle_pid, _dispatch_ref} = context) do
+    if Process.alive?(lifecycle_pid) do
+      AttemptProtocol.predispatch_failure(context, :local)
+    else
+      {:error, :cancelled}
     end
   end
 
   @doc false
   @spec mark_dispatched(dispatch_context() | nil) :: :ok | {:error, :cancelled}
-  def mark_dispatched(context) do
-    with :ok <- authorize_dispatch(context), do: confirm_dispatched(context)
+  def mark_dispatched(context), do: confirm_dispatched(context)
+
+  defp claim_for_execution(receipt, caller_pid, dispatch_latch, attempt_deadline_us) do
+    case claim_receipt(receipt, caller_pid) do
+      :ok ->
+        mark_receipt_claimed(dispatch_latch)
+
+        if Process.alive?(caller_pid) and
+             System.monotonic_time(:microsecond) < attempt_deadline_us do
+          :ok
+        else
+          release_receipt(receipt)
+          mark_receipt_finalized(dispatch_latch)
+          {:error, :timeout}
+        end
+
+      {:error, reason} ->
+        abandon_unclaimed_receipt(receipt, caller_pid)
+        mark_receipt_finalized(dispatch_latch)
+        {:error, reason}
+    end
+  end
+
+  defp prepare_dispatch(:deferred, _latch, dispatch_callback, _attempt_deadline_us),
+    do: dispatch_callback
+
+  defp prepare_dispatch(:immediate, latch, dispatch_callback, attempt_deadline_us) do
+    dispatched_at_us = System.monotonic_time(:microsecond)
+
+    if dispatched_at_us < attempt_deadline_us do
+      :ok = transition_dispatch_latch(latch, :dispatched, dispatched_at_us)
+      invoke_dispatch_callback(dispatch_callback, dispatched_at_us)
+      nil
+    else
+      dispatch_callback
+    end
   end
 
   defp execute(context) do
     Process.flag(:trap_exit, true)
     caller_monitor = Process.monitor(context.caller_pid)
 
-    case claim_receipt(context.receipt, context.caller_pid) do
-      :ok ->
+    receive do
+      {:start_attempt_lifecycle, start_ref} when start_ref == context.lifecycle_start_ref ->
         if Process.alive?(context.caller_pid) and
-             System.monotonic_time(:microsecond) < context.deadline_us do
+             System.monotonic_time(:microsecond) < context.attempt_deadline_us do
           start_attempt(Map.put(context, :caller_monitor, caller_monitor))
         else
           release_receipt(context.receipt)
+          mark_receipt_finalized(context.dispatch_latch)
 
-          send(context.caller_pid, {
-            context.lifecycle_ref,
-            {:__attempt_lifecycle_rejected__, :timeout}
-          })
+          send_terminal_candidate(
+            context,
+            {:__attempt_lifecycle_rejected__, :timeout},
+            nil,
+            false,
+            false
+          )
         end
 
-      {:error, reason} ->
-        Process.demonitor(caller_monitor, [:flush])
-        abandon_unclaimed_receipt(context.receipt, context.caller_pid)
+      {:DOWN, ^caller_monitor, :process, caller_pid, _reason}
+      when caller_pid == context.caller_pid ->
+        :ok
+    after
+      deadline_wait_ms(context.attempt_deadline_us) ->
+        release_receipt(context.receipt)
+        mark_receipt_finalized(context.dispatch_latch)
 
-        send(context.caller_pid, {
-          context.lifecycle_ref,
-          {:__attempt_lifecycle_rejected__, reason}
-        })
+        send_terminal_candidate(
+          context,
+          {:__attempt_lifecycle_rejected__, :timeout},
+          nil,
+          false,
+          false
+        )
     end
   end
 
@@ -283,10 +392,22 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
       :erlang.spawn_opt(
         fn ->
           Process.put(@dispatch_context_key, {lifecycle_pid, dispatch_ref})
+          Process.put(@deadline_key, context.attempt_deadline_us)
+          Process.put(@settlement_deadline_key, context.settlement_deadline_us)
+
+          Process.put(@dispatch_receipt_key, %{
+            latch: context.dispatch_latch,
+            caller_pid: context.caller_pid
+          })
 
           receive do
             {:run_attempt, ^task_ref} ->
-              send(lifecycle_pid, {:attempt_task_result, task_ref, execute_fun(context.fun)})
+              result = execute_fun(context.fun)
+
+              send(
+                lifecycle_pid,
+                {:attempt_task_result, task_ref, System.monotonic_time(:microsecond), result}
+              )
           end
         end,
         [:link, :monitor]
@@ -303,55 +424,28 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
         task_monitor: task_monitor,
         phase: phase,
         started_at_us: System.monotonic_time(:microsecond),
-        pending_terminal: nil,
-        pending_result: nil
+        terminal_candidate_at_us: nil,
+        completed_result: nil
       })
     )
   end
 
   defp loop(state) do
     receive do
-      {:authorize_attempt_dispatch, dispatch_ref, requester, authorization_ref}
-      when dispatch_ref == state.dispatch_ref ->
-        authorize_or_reject_dispatch(state, requester, authorization_ref)
+      {:transport_observation, dispatch_ref, observation}
+      when dispatch_ref == state.dispatch_ref and is_map(observation) ->
+        loop(apply_transport_observation(state, observation))
 
-      {:attempt_dispatched, dispatch_ref, requester, confirmation_ref}
-      when dispatch_ref == state.dispatch_ref ->
-        case confirmation_rejection(state) do
-          nil ->
-            {phase, transition} = confirm_phase(state.phase)
-            maybe_invoke_dispatch_callback(state.dispatch_callback, transition)
-            send(requester, {:attempt_dispatch_confirmed, confirmation_ref})
-
-            state
-            |> Map.put(:phase, phase)
-            |> resolve_pending_terminal()
-
-          reason ->
-            send(requester, {:attempt_dispatch_rejected, confirmation_ref})
-            finalize_unconfirmed(state, reason)
-        end
-
-      {:attempt_dispatch_aborted, dispatch_ref, requester, abort_ref}
-      when dispatch_ref == state.dispatch_ref ->
-        if match?({:dispatched, _}, state.phase) do
-          send(requester, {:attempt_dispatch_rejected, abort_ref})
-          loop(state)
-        else
-          send(requester, {:attempt_dispatch_aborted, abort_ref})
-
-          state
-          |> Map.put(:phase, :aborted)
-          |> resolve_pending_terminal()
-        end
-
-      {:attempt_task_result, task_ref, result} when task_ref == state.task_ref ->
+      {:attempt_task_result, task_ref, completed_at_us, result} when task_ref == state.task_ref ->
         Process.demonitor(state.task_monitor, [:flush])
-        handle_task_result(state, unwrap_result(result))
+
+        if result_eligible?(state, completed_at_us),
+          do: handle_task_result(state, unwrap_result(result)),
+          else: handle_interruption(state, :timeout)
 
       {:DOWN, monitor_ref, :process, caller_pid, _reason}
       when monitor_ref == state.caller_monitor and caller_pid == state.caller_pid ->
-        handle_interruption(state, :caller_down)
+        stop_task(state)
 
       {:DOWN, monitor_ref, :process, task_pid, reason}
       when monitor_ref == state.task_monitor and task_pid == state.task_pid ->
@@ -359,97 +453,121 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
 
       {:EXIT, task_pid, reason} when task_pid == state.task_pid ->
         handle_task_death(state, reason)
-
-      {:attempt_caller_timeout, lifecycle_ref} when lifecycle_ref == state.lifecycle_ref ->
-        loop(state)
     after
       remaining_timeout(state) ->
         handle_interruption(state, :timeout)
     end
   end
 
-  defp authorize_phase(:predispatch),
-    do: {:dispatching, System.monotonic_time(:microsecond)}
-
-  defp authorize_phase(phase), do: phase
-
-  defp authorize_or_reject_dispatch(state, requester, authorization_ref) do
-    cond do
-      state.phase == :aborted ->
-        send(requester, {:attempt_dispatch_rejected, authorization_ref})
-        loop(state)
-
-      not Process.alive?(state.caller_pid) ->
-        send(requester, {:attempt_dispatch_rejected, authorization_ref})
-        handle_interruption(state, :caller_down)
-
-      System.monotonic_time(:microsecond) >= state.deadline_us ->
-        send(requester, {:attempt_dispatch_rejected, authorization_ref})
-        handle_interruption(state, :timeout)
-
-      true ->
-        send(requester, {:attempt_dispatch_authorized, authorization_ref})
-        loop(%{state | phase: authorize_phase(state.phase)})
-    end
-  end
-
   defp initial_phase(%{dispatch_mode: :immediate} = context) do
-    dispatched_at_us = System.monotonic_time(:microsecond)
-    invoke_dispatch_callback(context.dispatch_callback, dispatched_at_us)
+    dispatched_at_us =
+      dispatch_timestamp(context.dispatch_latch) || System.monotonic_time(:microsecond)
+
+    transition_dispatch_latch(context.dispatch_latch, :dispatched, dispatched_at_us)
     {:dispatched, dispatched_at_us}
   end
 
   defp initial_phase(_context), do: :predispatch
 
-  defp confirm_phase({:dispatching, _authorized_at_us}) do
-    dispatched_at_us = System.monotonic_time(:microsecond)
-    {{:dispatched, dispatched_at_us}, {:transitioned, dispatched_at_us}}
-  end
-
-  defp confirm_phase({:dispatched, _dispatched_at_us} = phase), do: {phase, :unchanged}
-
-  defp confirm_phase(:predispatch) do
-    dispatched_at_us = System.monotonic_time(:microsecond)
-    {{:dispatched, dispatched_at_us}, {:transitioned, dispatched_at_us}}
-  end
-
-  defp confirmation_rejection(%{phase: :aborted}), do: :aborted
-
-  defp confirmation_rejection(%{pending_terminal: terminal}) when not is_nil(terminal),
-    do: terminal
-
-  defp confirmation_rejection(state) do
-    cond do
-      not Process.alive?(state.caller_pid) -> :caller_down
-      System.monotonic_time(:microsecond) >= state.deadline_us -> :timeout
-      true -> nil
+  defp open_send_phase(phase, started_at_us) do
+    case phase do
+      {:ambiguous, _} -> {phase, :unchanged}
+      {:dispatched, _} -> {phase, :unchanged}
+      _ -> {{:ambiguous, started_at_us}, {:transitioned, started_at_us}}
     end
   end
 
-  defp finalize_unconfirmed(state, :caller_down) do
-    handle_interruption(%{state | phase: :predispatch, pending_terminal: nil}, :caller_down)
+  defp confirm_phase(phase, dispatched_at_us) do
+    case phase do
+      {:ambiguous, started_at_us} -> {{:dispatched, started_at_us}, :unchanged}
+      {:dispatched, _} -> {phase, :unchanged}
+      _ -> {{:dispatched, dispatched_at_us}, {:transitioned, dispatched_at_us}}
+    end
   end
 
-  defp finalize_unconfirmed(state, :timeout) do
-    handle_interruption(%{state | phase: :predispatch, pending_terminal: nil}, :timeout)
+  defp abort_phase({:dispatched, _} = phase), do: phase
+  defp abort_phase(_phase), do: :aborted
+
+  defp apply_transport_observation(
+         state,
+         %{kind: :send_started, event_us: event_us}
+       )
+       when event_us < state.attempt_deadline_us do
+    transition_dispatch_latch(state.dispatch_latch, :ambiguous, event_us)
+    {phase, _transition} = open_send_phase(state.phase, event_us)
+    %{state | phase: phase}
   end
 
-  defp finalize_unconfirmed(state, :aborted) do
-    handle_interruption(%{state | phase: :aborted, pending_terminal: nil}, :caller_down)
+  defp apply_transport_observation(
+         state,
+         %{kind: :send_confirmed, event_us: event_us}
+       )
+       when event_us < state.attempt_deadline_us do
+    transition_dispatch_latch(state.dispatch_latch, :dispatched, event_us)
+    {phase, _transition} = confirm_phase(state.phase, event_us)
+    %{state | phase: phase}
   end
 
-  defp handle_task_result(%{phase: {:dispatching, _}} = state, result) do
-    loop(%{state | pending_result: result})
+  defp apply_transport_observation(
+         state,
+         %{kind: :predispatch_failure, event_us: event_us}
+       )
+       when event_us < state.attempt_deadline_us do
+    transition_dispatch_latch(state.dispatch_latch, :not_dispatched, event_us)
+    %{state | phase: abort_phase(state.phase), terminal_candidate_at_us: event_us}
   end
+
+  defp apply_transport_observation(
+         state,
+         %{kind: :transport_failure, event_us: event_us, certainty: :not_dispatched}
+       )
+       when event_us < state.attempt_deadline_us do
+    transition_dispatch_latch(state.dispatch_latch, :not_dispatched, event_us)
+    %{state | phase: abort_phase(state.phase), terminal_candidate_at_us: event_us}
+  end
+
+  defp apply_transport_observation(
+         state,
+         %{kind: :transport_failure, event_us: event_us, certainty: :indeterminate}
+       )
+       when event_us < state.attempt_deadline_us do
+    transition_dispatch_latch(state.dispatch_latch, :ambiguous, event_us)
+    {phase, _transition} = open_send_phase(state.phase, event_us)
+    %{state | phase: phase, terminal_candidate_at_us: event_us}
+  end
+
+  defp apply_transport_observation(
+         state,
+         %{kind: :transport_failure, event_us: event_us, certainty: :dispatched}
+       )
+       when event_us < state.attempt_deadline_us do
+    transition_dispatch_latch(state.dispatch_latch, :dispatched, event_us)
+    {phase, _transition} = confirm_phase(state.phase, event_us)
+    %{state | phase: phase, terminal_candidate_at_us: event_us}
+  end
+
+  defp apply_transport_observation(state, %{kind: kind, event_us: event_us})
+       when event_us < state.attempt_deadline_us and kind in [:response, :invalid_response] do
+    transition_dispatch_latch(state.dispatch_latch, :dispatched, event_us)
+    {phase, _transition} = confirm_phase(state.phase, event_us)
+    %{state | phase: phase, terminal_candidate_at_us: event_us}
+  end
+
+  defp apply_transport_observation(state, _observation), do: state
 
   defp handle_task_result(%{phase: {:dispatched, dispatched_at_us}} = state, result) do
     finalize_dispatched(state, result, elapsed_ms(dispatched_at_us))
+  end
+
+  defp handle_task_result(%{phase: {:ambiguous, started_at_us}} = state, result) do
+    finalize_dispatched(state, result, elapsed_ms(started_at_us))
   end
 
   defp handle_task_result(%{phase: :predispatch} = state, result) do
     if predispatch_result?(result) do
       finalize_predispatch(state, result)
     else
+      transition_dispatch_latch(state.dispatch_latch, :dispatched, state.started_at_us)
       finalize_dispatched(state, result, elapsed_ms(state.started_at_us))
     end
   end
@@ -459,18 +577,18 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   end
 
   defp handle_task_death(state, :normal) do
-    case state.pending_result do
-      nil -> handle_task_death(state, :missing_result)
-      result -> handle_task_result(state, result)
+    case take_completed_result(state) do
+      {:ok, result} -> handle_task_result(state, result)
+      :none -> handle_task_death(state, :missing_result)
     end
-  end
-
-  defp handle_task_death(%{phase: {:dispatching, _}} = state, reason) do
-    loop(%{state | pending_result: task_exit_result(reason)})
   end
 
   defp handle_task_death(%{phase: {:dispatched, dispatched_at_us}} = state, reason) do
     finalize_dispatched(state, task_exit_result(reason), elapsed_ms(dispatched_at_us))
+  end
+
+  defp handle_task_death(%{phase: {:ambiguous, started_at_us}} = state, reason) do
+    finalize_dispatched(state, task_exit_result(reason), elapsed_ms(started_at_us))
   end
 
   defp handle_task_death(%{phase: :predispatch} = state, reason) do
@@ -481,118 +599,107 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     finalize_predispatch(state, task_exit_result(reason))
   end
 
-  defp handle_interruption(
-         %{phase: {:dispatching, _dispatched_at_us}, pending_terminal: pending_terminal} = state,
-         _terminal
-       )
-       when not is_nil(pending_terminal) do
-    finalize_unconfirmed(state, pending_terminal)
+  defp handle_interruption(state, terminal) do
+    state = drain_queued_closure_messages(state)
+
+    case take_completed_result(state) do
+      {:ok, result} ->
+        Process.demonitor(state.task_monitor, [:flush])
+        handle_task_result(state, result)
+
+      :none ->
+        finalize_interruption(state, terminal)
+    end
   end
 
-  defp handle_interruption(%{phase: {:dispatching, _}} = state, terminal) do
-    loop(
-      state
-      |> Map.put(:pending_terminal, terminal)
-      |> Map.put(
-        :settle_deadline_us,
-        System.monotonic_time(:microsecond) + @dispatch_settle_timeout * 1_000
-      )
+  defp finalize_interruption(%{phase: :predispatch} = state, :timeout) do
+    stop_task(state)
+
+    send_terminal_candidate(
+      state,
+      {:__attempt_lifecycle_rejected__, :timeout},
+      nil,
+      true,
+      false
     )
   end
 
-  defp handle_interruption(%{phase: :predispatch} = state, :caller_down) do
+  defp finalize_interruption(%{phase: :aborted} = state, :timeout) do
     stop_task(state)
-    release_receipt(state.receipt)
+
+    send_terminal_candidate(
+      state,
+      {:__attempt_lifecycle_rejected__, :timeout},
+      nil,
+      true,
+      false
+    )
   end
 
-  defp handle_interruption(%{phase: :aborted} = state, :caller_down) do
+  defp finalize_interruption(%{phase: {certainty, started_at_us}} = state, :timeout)
+       when certainty in [:dispatched, :ambiguous] do
     stop_task(state)
-    release_receipt(state.receipt)
+    finalize_timeout(state, elapsed_ms(started_at_us))
   end
 
-  defp handle_interruption(%{phase: :predispatch} = state, :timeout) do
-    stop_task(state)
+  defp drain_queued_closure_messages(state) do
+    {observations, completed_result} =
+      take_queued_closure_messages(state.dispatch_ref, state.task_ref, [], state.completed_result)
 
-    result =
-      {:error,
-       JError.new(-32_008, "Local transport admission timed out",
-         category: :local_capacity_rejection,
-         retriable?: true,
-         breaker_penalty?: false
-       ), state.timeout}
+    state =
+      observations
+      |> Enum.reverse()
+      |> Enum.reduce(state, &apply_transport_observation(&2, &1))
 
-    finalize_predispatch(state, result)
+    %{state | completed_result: completed_result}
   end
 
-  defp handle_interruption(%{phase: :aborted} = state, :timeout) do
-    stop_task(state)
+  defp take_queued_closure_messages(dispatch_ref, task_ref, observations, completed_result) do
+    receive do
+      {:transport_observation, ^dispatch_ref, observation} when is_map(observation) ->
+        take_queued_closure_messages(
+          dispatch_ref,
+          task_ref,
+          [observation | observations],
+          completed_result
+        )
 
-    result =
-      {:error,
-       JError.new(-32_008, "Local transport admission timed out",
-         category: :local_capacity_rejection,
-         retriable?: true,
-         breaker_penalty?: false
-       ), state.timeout}
-
-    finalize_predispatch(state, result)
-  end
-
-  defp handle_interruption(%{phase: {:dispatched, dispatched_at_us}} = state, terminal) do
-    completed_result = take_completed_result(state)
-    stop_task(state)
-
-    case completed_result do
-      {:ok, result} ->
-        finalize_dispatched(state, result, elapsed_ms(dispatched_at_us))
-
-      :none when terminal == :caller_down ->
-        elapsed_ms = elapsed_ms(dispatched_at_us)
-
-        cancellation =
-          {:error,
-           JError.new(-32_000, "Upstream attempt cancelled",
-             category: :cancelled,
-             retriable?: false,
-             breaker_penalty?: false
-           ), elapsed_ms}
-
-        report_receipt(state.receipt, cancellation)
-        invoke_terminal_callback(state.terminal_callback, cancellation, elapsed_ms)
-
-      :none ->
-        finalize_timeout(state, elapsed_ms(dispatched_at_us))
+      {:attempt_task_result, ^task_ref, completed_at_us, result} ->
+        take_queued_closure_messages(
+          dispatch_ref,
+          task_ref,
+          observations,
+          {completed_at_us, result}
+        )
+    after
+      0 -> {observations, completed_result}
     end
-  end
-
-  defp resolve_pending_terminal(%{pending_terminal: nil, pending_result: nil} = state),
-    do: loop(state)
-
-  defp resolve_pending_terminal(%{pending_terminal: nil, pending_result: result} = state) do
-    handle_task_result(%{state | pending_result: nil}, result)
-  end
-
-  defp resolve_pending_terminal(%{phase: :aborted, pending_terminal: terminal} = state) do
-    handle_interruption(%{state | pending_terminal: nil}, terminal)
-  end
-
-  defp resolve_pending_terminal(%{phase: {:dispatched, _}, pending_terminal: terminal} = state) do
-    handle_interruption(%{state | pending_terminal: nil}, terminal)
   end
 
   defp take_completed_result(state) do
-    case state.pending_result do
+    case state.completed_result do
+      {completed_at_us, result} ->
+        if result_eligible?(state, completed_at_us),
+          do: {:ok, unwrap_result(result)},
+          else: :none
+
       nil ->
         receive do
-          {:attempt_task_result, task_ref, result} when task_ref == state.task_ref ->
-            {:ok, unwrap_result(result)}
+          {:attempt_task_result, task_ref, completed_at_us, result}
+          when task_ref == state.task_ref ->
+            if result_eligible?(state, completed_at_us),
+              do: {:ok, unwrap_result(result)},
+              else: :none
         after
           0 -> :none
         end
-
-      result ->
-        {:ok, result}
     end
+  end
+
+  defp result_eligible?(state, completed_at_us) do
+    completed_at_us < state.attempt_deadline_us or
+      (is_integer(state.terminal_candidate_at_us) and
+         state.terminal_candidate_at_us < state.attempt_deadline_us)
   end
 
   defp stop_task(state) do
@@ -601,34 +708,14 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   end
 
   defp finalize_predispatch(state, result) do
-    release_receipt(state.receipt)
-    Process.demonitor(state.caller_monitor, [:flush])
-    send(state.caller_pid, {state.lifecycle_ref, result})
+    send_terminal_candidate(state, result, nil, true, true)
   end
 
   defp finalize_dispatched(state, result, elapsed_ms) do
-    report_receipt(state.receipt, breaker_result(result, state.terminal_callback))
-
-    Process.demonitor(state.caller_monitor, [:flush])
-    invoke_terminal_callback(state.terminal_callback, result, elapsed_ms)
-    send(state.caller_pid, {state.lifecycle_ref, result})
+    send_terminal_candidate(state, result, elapsed_ms, true, true)
   end
 
   defp finalize_timeout(state, elapsed_ms) do
-    {instance_id, transport} = state.breaker_id
-
-    Logger.warning("Request timeout in circuit breaker",
-      instance_id: instance_id,
-      transport: transport,
-      timeout_ms: state.timeout
-    )
-
-    :telemetry.execute(
-      [:lasso, :circuit_breaker, :timeout],
-      %{timeout_ms: state.timeout},
-      %{instance_id: instance_id, transport: transport}
-    )
-
     result =
       {:error,
        JError.new(-32_000, "Request timeout after #{state.timeout}ms",
@@ -637,7 +724,7 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
          breaker_penalty?: true
        ), state.timeout}
 
-    finalize_dispatched(state, result, elapsed_ms)
+    send_terminal_candidate(state, result, elapsed_ms, true, false)
   end
 
   defp execute_fun(fun) do
@@ -677,9 +764,31 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
   end
 
   defp remaining_timeout(state) do
-    case Map.fetch(state, :settle_deadline_us) do
-      {:ok, settle_deadline_us} -> remaining_ms(settle_deadline_us, 1)
-      :error -> remaining_ms(state.deadline_us, 0)
+    remaining_ms(state.lifecycle_deadline_us, 0)
+  end
+
+  defp send_terminal_candidate(state, result, elapsed_ms, accounting?, callback_eligible?) do
+    send(
+      state.caller_pid,
+      {state.lifecycle_ref,
+       {:attempt_terminal_candidate, result, elapsed_ms, accounting?, callback_eligible?}}
+    )
+
+    if accounting? and callback_eligible?, do: await_compatibility_callback(state)
+  end
+
+  # Compatibility boundary: this process may be lost or remain blocked in a legacy callback.
+  # Owner cutover deletes this path in favor of the bounded projection dispatcher.
+  defp await_compatibility_callback(state) do
+    receive do
+      {lifecycle_ref, {:authorize_legacy_terminal_callback, result, elapsed_ms}}
+      when lifecycle_ref == state.lifecycle_ref ->
+        Process.demonitor(state.caller_monitor, [:flush])
+        invoke_terminal_callback(state.legacy_terminal_callback, result, elapsed_ms)
+
+      {:DOWN, monitor_ref, :process, caller_pid, _reason}
+      when monitor_ref == state.caller_monitor and caller_pid == state.caller_pid ->
+        :ok
     end
   end
 
@@ -768,8 +877,257 @@ defmodule Lasso.Core.Support.AttemptLifecycle do
     :ok
   end
 
-  defp maybe_invoke_dispatch_callback(callback, {:transitioned, dispatched_at_us}),
-    do: invoke_dispatch_callback(callback, dispatched_at_us)
+  defp new_dispatch_latch do
+    latch = :atomics.new(3, signed: true)
+    :atomics.put(latch, 1, @open_unset)
+    :atomics.put(latch, 2, @dispatch_timestamp_unset)
+    :atomics.put(latch, 3, 0)
+    latch
+  end
 
-  defp maybe_invoke_dispatch_callback(_callback, :unchanged), do: :ok
+  defp transition_dispatch_latch(latch, certainty, event_us) do
+    if certainty in [:ambiguous, :dispatched], do: record_dispatch_timestamp(latch, event_us)
+
+    current = :atomics.get(latch, 1)
+
+    case next_open_dispatch_state(current, certainty) do
+      :closed ->
+        {:error, :owner_down}
+
+      ^current ->
+        :ok
+
+      next ->
+        case :atomics.compare_exchange(latch, 1, current, next) do
+          :ok -> :ok
+          _raced -> transition_dispatch_latch(latch, certainty, event_us)
+        end
+    end
+  end
+
+  defp next_open_dispatch_state(current, _certainty) when current >= @closed_offset,
+    do: :closed
+
+  defp next_open_dispatch_state(@open_dispatched, _certainty), do: @open_dispatched
+  defp next_open_dispatch_state(@open_not_dispatched, :ambiguous), do: @open_not_dispatched
+  defp next_open_dispatch_state(_current, :ambiguous), do: @open_ambiguous
+  defp next_open_dispatch_state(_current, :not_dispatched), do: @open_not_dispatched
+  defp next_open_dispatch_state(_current, :dispatched), do: @open_dispatched
+
+  defp record_dispatch_timestamp(latch, event_us) do
+    _result =
+      :atomics.compare_exchange(latch, 2, @dispatch_timestamp_unset, event_us)
+
+    :ok
+  end
+
+  defp dispatch_timestamp(latch) do
+    case :atomics.get(latch, 2) do
+      @dispatch_timestamp_unset -> nil
+      event_us -> event_us
+    end
+  end
+
+  defp close_dispatch_latch(latch) do
+    current = :atomics.get(latch, 1)
+
+    if current >= @closed_offset do
+      closed_dispatch_state(latch, current)
+    else
+      case :atomics.compare_exchange(latch, 1, current, current + @closed_offset) do
+        :ok -> closed_dispatch_state(latch, current + @closed_offset)
+        _raced -> close_dispatch_latch(latch)
+      end
+    end
+  end
+
+  defp closed_dispatch_state(latch, closed_state) do
+    certainty =
+      case closed_state - @closed_offset do
+        @open_unset -> :unset
+        @open_ambiguous -> :ambiguous
+        @open_not_dispatched -> :not_dispatched
+        @open_dispatched -> :dispatched
+      end
+
+    dispatched_at_us =
+      case :atomics.get(latch, 2) do
+        @dispatch_timestamp_unset -> nil
+        event_us -> event_us
+      end
+
+    {certainty, dispatched_at_us}
+  end
+
+  defp mark_receipt_claimed(latch) do
+    _result = :atomics.compare_exchange(latch, 3, 0, 1)
+    :ok
+  end
+
+  defp mark_receipt_finalized(latch) do
+    case :atomics.get(latch, 3) do
+      2 ->
+        :ok
+
+      current ->
+        case :atomics.compare_exchange(latch, 3, current, 2) do
+          :ok -> :ok
+          _raced -> mark_receipt_finalized(latch)
+        end
+    end
+  end
+
+  defp outer_terminal_candidate(
+         {:candidate, {:__attempt_lifecycle_rejected__, :timeout}, _elapsed_ms, true,
+          _callback_eligible?},
+         certainty,
+         dispatched_at_us,
+         timeout
+       )
+       when certainty in [:ambiguous, :dispatched] do
+    {timeout_result(timeout), elapsed_from_dispatch(dispatched_at_us), true}
+  end
+
+  defp outer_terminal_candidate(
+         {:candidate, result, elapsed_ms, accounting?, _callback_eligible?},
+         _certainty,
+         _dispatched_at_us,
+         _timeout
+       ),
+       do: {result, elapsed_ms, accounting?}
+
+  defp outer_terminal_candidate(
+         {:owner_down, reason},
+         _certainty,
+         dispatched_at_us,
+         _timeout
+       ) do
+    {{:exception, {:exit, reason, []}}, elapsed_from_dispatch(dispatched_at_us), true}
+  end
+
+  defp outer_terminal_candidate(:client_timeout, certainty, dispatched_at_us, timeout)
+       when certainty in [:ambiguous, :dispatched],
+       do: {timeout_result(timeout), elapsed_from_dispatch(dispatched_at_us), true}
+
+  defp outer_terminal_candidate(:client_timeout, _certainty, _dispatched_at_us, _timeout),
+    do: {{:__attempt_lifecycle_rejected__, :timeout}, nil, true}
+
+  defp finish_compatibility_lifecycle(
+         {:candidate, _result, _elapsed_ms, _accounting?, true},
+         lifecycle_pid,
+         monitor_ref,
+         lifecycle_ref,
+         result,
+         elapsed_ms,
+         true,
+         certainty
+       )
+       when certainty in [:ambiguous, :dispatched] do
+    Process.demonitor(monitor_ref, [:flush])
+
+    send(
+      lifecycle_pid,
+      {lifecycle_ref, {:authorize_legacy_terminal_callback, result, elapsed_ms}}
+    )
+
+    :ok
+  end
+
+  defp finish_compatibility_lifecycle(
+         _terminal_candidate,
+         lifecycle_pid,
+         monitor_ref,
+         _lifecycle_ref,
+         _result,
+         _elapsed_ms,
+         _accounting?,
+         _certainty
+       ) do
+    terminate_lifecycle(lifecycle_pid, monitor_ref)
+  end
+
+  defp publish_owner_terminal(
+         breaker_id,
+         result,
+         certainty,
+         dispatched_at_us,
+         dispatch_callback
+       ) do
+    if certainty in [:ambiguous, :dispatched] do
+      dispatched_at_us = dispatched_at_us || System.monotonic_time(:microsecond)
+      invoke_dispatch_callback(dispatch_callback, dispatched_at_us)
+      maybe_emit_timeout(breaker_id, result)
+    end
+
+    :ok
+  end
+
+  defp finalize_receipt(latch, receipt, result, certainty, terminal_callback) do
+    case :atomics.compare_exchange(latch, 3, 1, 2) do
+      :ok ->
+        if certainty in [:ambiguous, :dispatched],
+          do: report_receipt(receipt, breaker_result(result, terminal_callback)),
+          else: release_receipt(receipt)
+
+      0 ->
+        case :atomics.compare_exchange(latch, 3, 0, 2) do
+          :ok -> abandon_unclaimed_receipt(receipt, self())
+          _raced -> finalize_receipt(latch, receipt, result, certainty, terminal_callback)
+        end
+
+      2 ->
+        :ok
+    end
+  end
+
+  defp timeout_result(timeout) do
+    {:error,
+     JError.new(-32_000, "Request timeout after #{timeout}ms",
+       category: :timeout,
+       retriable?: true,
+       breaker_penalty?: true
+     ), timeout}
+  end
+
+  defp elapsed_from_dispatch(nil), do: 0.0
+  defp elapsed_from_dispatch(dispatched_at_us), do: elapsed_ms(dispatched_at_us)
+
+  defp terminal_elapsed_ms(elapsed_ms, nil), do: elapsed_ms || 0.0
+
+  defp terminal_elapsed_ms(elapsed_ms, dispatched_at_us),
+    do: elapsed_ms || elapsed_ms(dispatched_at_us)
+
+  defp maybe_emit_timeout({instance_id, transport}, {:error, %JError{category: :timeout}, _}) do
+    Logger.warning("Request timeout in circuit breaker",
+      instance_id: instance_id,
+      transport: transport
+    )
+
+    :telemetry.execute(
+      [:lasso, :circuit_breaker, :timeout],
+      %{count: 1},
+      %{instance_id: instance_id, transport: transport}
+    )
+  end
+
+  defp maybe_emit_timeout(_breaker_id, _result), do: :ok
+
+  defp terminate_lifecycle(lifecycle_pid, monitor_ref) do
+    if Process.alive?(lifecycle_pid), do: Process.exit(lifecycle_pid, :kill)
+    Process.demonitor(monitor_ref, [:flush])
+    :ok
+  end
+
+  defp decision_deadline_us(deadline_us, timeout_ms)
+       when timeout_ms >= @minimum_settlement_budget_ms,
+       do: deadline_us - @settlement_margin_us
+
+  defp decision_deadline_us(deadline_us, _timeout_ms), do: deadline_us
+
+  defp attempt_deadline_us(decision_deadline_us, timeout_ms) do
+    min(
+      decision_deadline_us,
+      System.monotonic_time(:microsecond) + timeout_ms * 1_000
+    )
+  end
 end

--- a/lib/lasso/core/support/circuit_breaker.ex
+++ b/lib/lasso/core/support/circuit_breaker.ex
@@ -455,6 +455,27 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     end
   end
 
+  @doc false
+  @spec report_external_bounded(breaker_id(), term()) ::
+          :ok | {:error, :saturated | :stale}
+  def report_external_bounded(id, result) do
+    case Snapshot.lookup(id) do
+      {:ok, snapshot} ->
+        receipt = %AdmissionReceipt{
+          breaker_id: id,
+          kind: :closed,
+          generation: snapshot.generation,
+          epoch: snapshot.epoch,
+          owner_pid: self()
+        }
+
+        ControlRing.enqueue(receipt, control_signal(result, id))
+
+      :missing ->
+        {:error, :stale}
+    end
+  end
+
   @doc """
   Record a failed operation for the circuit breaker (synchronous).
   Returns the circuit state after recording the failure.
@@ -605,18 +626,10 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   end
 
   @impl true
-  def handle_call({:claim_attempt, token, caller_pid}, {lifecycle_pid, _tag}, state) do
+  def handle_call({:claim_attempt, token, caller_pid}, _from, state) do
     case Map.fetch(state.inflight_attempts, token) do
-      {:ok, %{owner_pid: ^caller_pid, owner_monitor: owner_monitor} = attempt} ->
-        Process.demonitor(owner_monitor, [:flush])
-        lifecycle_monitor = Process.monitor(lifecycle_pid)
-
-        claimed_attempt = %{
-          attempt
-          | owner_pid: lifecycle_pid,
-            owner_monitor: lifecycle_monitor,
-            claimed?: true
-        }
+      {:ok, %{owner_pid: ^caller_pid} = attempt} ->
+        claimed_attempt = %{attempt | claimed?: true}
 
         attempts = Map.put(state.inflight_attempts, token, claimed_attempt)
         {:reply, :ok, %{state | inflight_attempts: attempts}}
@@ -708,7 +721,7 @@ defmodule Lasso.Core.Support.CircuitBreaker do
   @impl true
   def handle_call(
         {:claim_attempt, token, caller_pid, expected_generation, expected_epoch, deadline_us},
-        {lifecycle_pid, _tag},
+        _from,
         state
       ) do
     cond do
@@ -721,17 +734,9 @@ defmodule Lasso.Core.Support.CircuitBreaker do
 
       true ->
         case Map.fetch(state.inflight_attempts, token) do
-          {:ok, %{owner_pid: ^caller_pid, owner_monitor: owner_monitor} = attempt} ->
-            persist_claimed_owner({state.instance_id, state.transport}, token, lifecycle_pid)
-            Process.demonitor(owner_monitor, [:flush])
-            lifecycle_monitor = Process.monitor(lifecycle_pid)
-
-            claimed_attempt = %{
-              attempt
-              | owner_pid: lifecycle_pid,
-                owner_monitor: lifecycle_monitor,
-                claimed?: true
-            }
+          {:ok, %{owner_pid: ^caller_pid} = attempt} ->
+            persist_claimed_owner({state.instance_id, state.transport}, token, caller_pid)
+            claimed_attempt = %{attempt | claimed?: true}
 
             attempts = Map.put(state.inflight_attempts, token, claimed_attempt)
             {:reply, :ok, %{state | inflight_attempts: attempts}}
@@ -1154,12 +1159,12 @@ defmodule Lasso.Core.Support.CircuitBreaker do
     ArgumentError -> 0
   end
 
-  defp persist_claimed_owner(breaker_id, token, lifecycle_pid) do
+  defp persist_claimed_owner(breaker_id, token, owner_pid) do
     case :ets.lookup(Storage.lease_table(), breaker_id) do
       [{^breaker_id, %{token: ^token} = lease}] ->
         :ets.insert(
           Storage.lease_table(),
-          {breaker_id, lease |> Map.put(:owner_pid, lifecycle_pid) |> Map.put(:claimed?, true)}
+          {breaker_id, lease |> Map.put(:owner_pid, owner_pid) |> Map.put(:claimed?, true)}
         )
 
       _ ->

--- a/lib/lasso/core/transport/attempt_protocol.ex
+++ b/lib/lasso/core/transport/attempt_protocol.ex
@@ -1,0 +1,181 @@
+defmodule Lasso.Core.Transport.AttemptProtocol do
+  @moduledoc false
+
+  alias Lasso.Core.Support.AttemptLifecycle
+
+  @type context :: {pid(), reference()}
+  @type certainty :: :not_dispatched | :indeterminate | :dispatched
+  @type send_start_error :: :deadline_expired | :owner_down
+
+  @terminal_kinds [:predispatch_failure, :response, :invalid_response, :transport_failure]
+
+  @spec context() :: context() | nil
+  def context, do: AttemptLifecycle.dispatch_context()
+
+  @spec deadline_us() :: integer() | nil
+  def deadline_us, do: AttemptLifecycle.deadline_us()
+
+  @spec settlement_deadline_us() :: integer() | nil
+  def settlement_deadline_us, do: AttemptLifecycle.settlement_deadline_us()
+
+  @spec authorized?(context() | nil, integer() | nil) :: boolean()
+  def authorized?(nil, deadline_us), do: before_deadline?(deadline_us)
+  def authorized?(_context, deadline_us), do: before_deadline?(deadline_us)
+
+  @spec send_started(context() | nil) :: :ok | {:error, send_start_error()}
+  def send_started(context) do
+    send_started_at(context, System.monotonic_time(:microsecond))
+  end
+
+  @doc false
+  @spec send_started_at(context() | nil, integer()) :: :ok | {:error, send_start_error()}
+  def send_started_at(context, event_us) when is_integer(event_us) do
+    with :ok <- validate_send_start(context, event_us),
+         :ok <- AttemptLifecycle.record_dispatch_state(:ambiguous, event_us) do
+      deliver_observation(context, :send_started, event_us, %{})
+    end
+  end
+
+  @spec send_confirmed(context() | nil) :: :ok
+  def send_confirmed(context), do: observe(context, :send_confirmed, %{})
+
+  @spec predispatch_failure(context() | nil, atom()) :: :ok
+  def predispatch_failure(context, reason) when is_atom(reason) do
+    observe(context, :predispatch_failure, %{reason: predispatch_reason(reason), elapsed_us: 0})
+  end
+
+  @spec terminal(context() | nil, atom(), map()) :: :ok
+  def terminal(context, kind, fields) when kind in @terminal_kinds and is_map(fields) do
+    terminal_at(context, kind, fields, System.monotonic_time(:microsecond))
+  end
+
+  @spec terminal_at(context() | nil, atom(), map(), integer()) :: :ok
+  def terminal_at(context, kind, fields, event_us)
+      when kind in @terminal_kinds and is_map(fields) and is_integer(event_us) do
+    observe_at(context, kind, event_us, normalize_terminal(kind, fields))
+  end
+
+  @spec observe(context() | nil, atom(), map()) :: :ok | {:error, send_start_error()}
+  def observe(context, kind, fields),
+    do: observe_at(context, kind, System.monotonic_time(:microsecond), fields)
+
+  @spec observe_at(context() | nil, atom(), integer(), map()) ::
+          :ok | {:error, send_start_error()}
+  def observe_at(context, :send_started, event_us, _fields),
+    do: send_started_at(context, event_us)
+
+  def observe_at(context, :send_confirmed, event_us, fields) do
+    _result = AttemptLifecycle.record_dispatch_state(:dispatched, event_us)
+    deliver_observation(context, :send_confirmed, event_us, fields)
+    :ok
+  end
+
+  def observe_at(context, :predispatch_failure, event_us, fields) do
+    _result = AttemptLifecycle.record_dispatch_state(:not_dispatched, event_us)
+    deliver_observation(context, :predispatch_failure, event_us, fields)
+  end
+
+  def observe_at(context, kind, event_us, fields)
+      when kind in [:response, :invalid_response] do
+    _result = AttemptLifecycle.record_dispatch_state(:dispatched, event_us)
+    deliver_observation(context, kind, event_us, fields)
+  end
+
+  def observe_at(context, :transport_failure, event_us, %{certainty: certainty} = fields) do
+    shared_certainty =
+      case certainty do
+        :not_dispatched -> :not_dispatched
+        :dispatched -> :dispatched
+        :indeterminate -> :ambiguous
+      end
+
+    _result = AttemptLifecycle.record_dispatch_state(shared_certainty, event_us)
+    deliver_observation(context, :transport_failure, event_us, fields)
+  end
+
+  def observe_at(context, kind, event_us, fields),
+    do: deliver_observation(context, kind, event_us, fields)
+
+  defp deliver_observation(nil, _kind, _event_us, _fields), do: :ok
+
+  defp deliver_observation({owner, attempt_ref}, kind, event_us, fields)
+       when is_pid(owner) and is_reference(attempt_ref) and is_atom(kind) and is_integer(event_us) and
+              is_map(fields) do
+    observation =
+      fields
+      |> Map.take([
+        :certainty,
+        :reason,
+        :response_kind,
+        :error_code,
+        :error_category,
+        :retry_after_ms,
+        :io_duration_us,
+        :elapsed_us,
+        :censoring_boundary_us
+      ])
+      |> Map.merge(%{
+        id: System.unique_integer([:positive, :monotonic]),
+        kind: kind,
+        event_us: event_us
+      })
+
+    send(owner, {:transport_observation, attempt_ref, observation})
+    :ok
+  end
+
+  defp validate_send_start(nil, _event_us), do: :ok
+
+  defp validate_send_start({owner, _attempt_ref}, event_us) do
+    cond do
+      not Process.alive?(owner) ->
+        {:error, :owner_down}
+
+      not AttemptLifecycle.dispatch_owner_alive?() ->
+        {:error, :owner_down}
+
+      deadline = deadline_us() ->
+        if(event_us < deadline, do: :ok, else: {:error, :deadline_expired})
+
+      true ->
+        :ok
+    end
+  end
+
+  defp normalize_terminal(:response, %{response_kind: :error} = fields),
+    do: %{fields | response_kind: :application_error}
+
+  defp normalize_terminal(:transport_failure, fields) do
+    Map.update!(fields, :reason, &transport_reason/1)
+  end
+
+  defp normalize_terminal(_kind, fields), do: fields
+
+  defp predispatch_reason(reason)
+       when reason in [:pool_unavailable, :not_connected, :invalid_frame],
+       do: reason
+
+  defp predispatch_reason(:encode_error), do: :encode
+  defp predispatch_reason(:request_build_error), do: :request_build
+
+  defp predispatch_reason(reason)
+       when reason in [:deadline, :registration_failed, :registration_exit],
+       do: :local
+
+  defp predispatch_reason(:stale_connection), do: :not_connected
+  defp predispatch_reason(_reason), do: :local
+
+  defp transport_reason(reason) when reason in [:timeout, :closed, :tls, :dns, :protocol],
+    do: reason
+
+  defp transport_reason(reason) when reason in [:network_error, :connection_error],
+    do: :connection
+
+  defp transport_reason(reason) when reason in [:rate_limited, :server_error, :client_error],
+    do: :protocol
+
+  defp transport_reason(_reason), do: :unknown
+
+  defp before_deadline?(nil), do: true
+  defp before_deadline?(deadline_us), do: System.monotonic_time(:microsecond) < deadline_us
+end

--- a/lib/lasso/core/transport/http/adapters/finch.ex
+++ b/lib/lasso/core/transport/http/adapters/finch.ex
@@ -1,308 +1,265 @@
 defmodule Lasso.RPC.Transport.HTTP.Client.Finch do
   @moduledoc """
-  Finch-based implementation of `Lasso.RPC.Transport.HTTP.Client`.
+  HTTP client adapter using Finch.
   """
 
   @behaviour Lasso.RPC.Transport.HTTP.Client
-  require Logger
 
-  alias Finch.HTTP1.Conn
-  alias Lasso.Core.Support.AttemptLifecycle
+  alias Lasso.Core.Transport.AttemptProtocol
+  alias Lasso.Core.Transport.HTTP.DispatchTracker
   alias Lasso.Providers.ProviderHeaders
-  alias Lasso.URLMask
+
+  @minimum_timeout_us 1_000
 
   @impl true
   def deferred_dispatch?, do: true
 
   @impl true
   def request(%{url: url} = provider, method, params, opts) do
-    # Extract options with defaults
     request_id = Keyword.get(opts, :request_id) || generate_id()
     timeout_ms = Keyword.get(opts, :timeout, 30_000)
+    deadline_us = Keyword.get(opts, :deadline_us) || deadline_from_timeout(timeout_ms)
     finch_name = Keyword.get(opts, :finch_name, Lasso.Finch)
+    context = Keyword.get(opts, :attempt_dispatch)
 
-    body = %{
-      "jsonrpc" => "2.0",
-      "method" => method,
-      "params" => params,
-      "id" => request_id
-    }
+    body = %{"jsonrpc" => "2.0", "method" => method, "params" => params, "id" => request_id}
 
-    dispatch_context = Keyword.get(opts, :attempt_dispatch)
-
-    with {:ok, json} <- encode_body(body, dispatch_context),
-         headers <- base_headers(provider),
-         {:ok, req} <- build_request(url, headers, json, dispatch_context),
-         {:ok, %Finch.Response{status: status, body: resp_body}} <-
-           finch_request(
-             req,
-             timeout_ms,
-             dispatch_context,
-             finch_name
-           ) do
-      handle_response(status, resp_body)
-    else
-      {:error, {:encode_error, _reason} = encode_error} ->
-        {:error, encode_error}
-
-      {:error, {:request_build_error, _reason} = build_error} ->
-        {:error, build_error}
-
-      {:error, {:local_capacity_rejection, _reason} = local_rejection} ->
-        {:error, local_rejection}
-
-      {:error, %Finch.TransportError{reason: :timeout}} ->
-        {:error, :timeout}
-
-      # Handle NimblePool checkout errors specifically
-      {:error, {:exit, {{:shutdown, :idle_timeout}, {NimblePool, :checkout, _}}}} ->
-        Logger.warning("Finch connection pool idle timeout",
-          provider_url: URLMask.mask(url),
-          request_id: request_id
-        )
-
-        # Emit telemetry for monitoring
-        :telemetry.execute(
-          [:lasso, :finch, :pool_idle_timeout],
-          %{count: 1},
-          %{provider_url: URLMask.mask(url), request_id: request_id}
-        )
-
-        {:error, {:local_capacity_rejection, :pool_idle_timeout}}
-
-      # Handle other NimblePool errors
-      {:error, {:exit, {{:shutdown, reason}, {NimblePool, :checkout, _}}}} ->
-        Logger.warning("Finch connection pool checkout failed",
-          provider_url: URLMask.mask(url),
-          request_id: request_id,
-          shutdown_reason: reason
-        )
-
-        # Emit telemetry for monitoring
-        :telemetry.execute(
-          [:lasso, :finch, :pool_checkout_failed],
-          %{count: 1},
-          %{provider_url: URLMask.mask(url), request_id: request_id, reason: reason}
-        )
-
-        {:error, {:local_capacity_rejection, {:pool_checkout_failed, reason}}}
-
-      {:error, %Finch.TransportError{reason: reason}} ->
-        Logger.debug("Finch request failed - Mint transport error",
-          provider_url: URLMask.mask(url),
-          request_id: request_id,
-          reason: reason
-        )
-
-        message =
-          case reason do
-            :timeout -> "Connection timeout"
-            :closed -> "Connection closed"
-            :econnrefused -> "Connection refused"
-            :nxdomain -> "DNS resolution failed"
-            {:error, reason} when is_atom(reason) -> "Connection error: #{reason}"
-            _ -> "Connection error"
-          end
-
-        {:error, {:network_error, message}}
-
-      {:error, reason} ->
-        Logger.debug("Finch request failed",
-          provider_url: URLMask.mask(url),
-          request_id: request_id,
-          error: inspect(reason)
-        )
-
-        {:error, {:network_error, "Request failed: #{inspect(reason)}"}}
+    with {:ok, json} <- encode_body(body, context),
+         {:ok, request} <- build_request(url, ProviderHeaders.build(provider), json, context),
+         {:ok, tracker_token} <- tracker_token(context) do
+      run_request(request, finch_name, deadline_us, context, tracker_token, opts)
     end
   end
 
-  defp base_headers(provider), do: ProviderHeaders.build(provider)
-
-  defp encode_body(body, dispatch_context) do
+  defp encode_body(body, context) do
     case Jason.encode(body) do
       {:ok, json} ->
         {:ok, json}
 
       {:error, reason} ->
-        AttemptLifecycle.abort_dispatch(dispatch_context)
+        AttemptProtocol.predispatch_failure(context, :encode_error)
         {:error, {:encode_error, Exception.message(reason)}}
     end
   end
 
-  defp build_request(url, headers, json, dispatch_context) do
-    {:ok, Finch.build(:post, url, headers, json)}
+  defp build_request(url, headers, json, context) do
+    request =
+      :post
+      |> Finch.build(url, headers, json)
+      |> Finch.Request.put_private(:lasso_attempt, context)
+
+    {:ok, request}
   rescue
     error ->
-      AttemptLifecycle.abort_dispatch(dispatch_context)
+      AttemptProtocol.predispatch_failure(context, :request_build_error)
       {:error, {:request_build_error, Exception.message(error)}}
   end
 
-  defp finch_request(request, timeout_ms, dispatch_context, finch_name) do
-    pool = %Finch.Pool{
-      scheme: request.scheme,
-      host: request.host,
-      port: request.port,
-      tag: request.pool_tag
-    }
+  defp tracker_token(nil), do: {:ok, nil}
 
-    request_opts = [
-      pool_timeout: timeout_ms,
-      receive_timeout: timeout_ms,
-      request_timeout: :infinity
-    ]
+  defp tracker_token(context) do
+    case DispatchTracker.ready_token() do
+      {:ok, token} ->
+        {:ok, token}
 
-    case Finch.Pool.Manager.get_pool(finch_name, pool, request_opts) do
-      {pool_pid, Finch.HTTP1.Pool} ->
-        http1_request(pool_pid, request, request_opts, dispatch_context, finch_name)
-
-      {_pool_pid, _pool_module} ->
-        {:error, {:local_capacity_rejection, :unsupported_http_protocol}}
-
-      _unavailable ->
-        {:error, {:local_capacity_rejection, :pool_not_available}}
-    end
-  rescue
-    error in RuntimeError ->
-      if String.contains?(Exception.message(error), "unable to provide a connection") do
-        {:error, {:local_capacity_rejection, :pool_checkout_timeout}}
-      else
-        reraise(error, __STACKTRACE__)
-      end
-  catch
-    :exit, {:timeout, {NimblePool, :checkout, _affected_pids}} ->
-      {:error, {:local_capacity_rejection, :pool_checkout_timeout}}
-
-    :exit, {{:shutdown, :idle_timeout}, {NimblePool, :checkout, _affected_pids}} ->
-      {:error, {:local_capacity_rejection, :pool_idle_timeout}}
-  end
-
-  defp http1_request(pool, request, opts, dispatch_context, finch_name) do
-    pool_timeout = Keyword.fetch!(opts, :pool_timeout)
-    receive_timeout = Keyword.fetch!(opts, :receive_timeout)
-    request_timeout = Keyword.fetch!(opts, :request_timeout)
-    acc = {nil, [], [], []}
-
-    response =
-      NimblePool.checkout!(
-        pool,
-        :checkout,
-        fn from, {checkout_state, conn, idle_time} ->
-          case AttemptLifecycle.mark_dispatched(dispatch_context) do
-            :ok ->
-              execute_http1_request(
-                conn,
-                {checkout_state, idle_time, from},
-                request,
-                acc,
-                {receive_timeout, request_timeout, finch_name}
-              )
-
-            {:error, :cancelled} ->
-              result = {:error, {:local_capacity_rejection, :dispatch_cancelled}, acc}
-              {result, transfer_if_open(conn, checkout_state, from)}
-          end
-        end,
-        pool_timeout
-      )
-
-    case response do
-      {:ok, {status, headers, body, trailers}} ->
-        {:ok,
-         %Finch.Response{
-           status: status,
-           headers: headers,
-           body: IO.iodata_to_binary(body),
-           trailers: trailers
-         }}
-
-      {:error, error, _acc} ->
-        {:error, error}
+      {:error, :unavailable} ->
+        AttemptProtocol.predispatch_failure(context, :tracker_unavailable)
+        {:error, {:local_capacity_rejection, :dispatch_tracker_unavailable}}
     end
   end
 
-  defp execute_http1_request(
-         conn,
-         {checkout_state, idle_time, from},
-         request,
-         acc,
-         {receive_timeout, request_timeout, finch_name}
-       ) do
-    result =
-      case Conn.connect(conn, finch_name) do
-        {:ok, conn} ->
-          Conn.request(
-            conn,
-            request,
-            acc,
-            &collect_response/2,
-            finch_name,
-            receive_timeout,
-            request_timeout,
-            idle_time
-          )
-          |> case do
-            {:ok, conn, response_acc} -> {:ok, conn, response_acc}
-            {:error, conn, error, response_acc} -> {:error, conn, error, response_acc}
-          end
+  defp request_options(deadline_us, context, opts) do
+    monotonic_now =
+      Keyword.get(opts, :monotonic_now_fun, fn -> System.monotonic_time(:microsecond) end)
 
-        {:error, conn, error} ->
-          {:error, conn, error, acc}
-      end
+    remaining_us = deadline_us - monotonic_now.()
 
-    case result do
-      {:ok, conn, response_acc} ->
-        {{:ok, response_acc}, transfer_if_open(conn, checkout_state, from)}
+    if remaining_us >= @minimum_timeout_us do
+      remaining_ms = div(remaining_us, 1_000)
 
-      {:error, conn, error, response_acc} ->
-        {{:error, error, response_acc}, transfer_if_open(conn, checkout_state, from)}
-    end
-  end
-
-  defp collect_response({:status, value}, {_, headers, body, trailers}),
-    do: {:cont, {value, headers, body, trailers}}
-
-  defp collect_response({:headers, value}, {status, headers, body, trailers}),
-    do: {:cont, {status, headers ++ value, body, trailers}}
-
-  defp collect_response({:data, value}, {status, headers, body, trailers}),
-    do: {:cont, {status, headers, [body | value], trailers}}
-
-  defp collect_response({:trailers, value}, {status, headers, body, trailers}),
-    do: {:cont, {status, headers, body, trailers ++ value}}
-
-  defp transfer_if_open(conn, checkout_state, {pid, _tag} = from) do
-    if Conn.open?(conn) do
-      if checkout_state == :fresh do
-        NimblePool.update(from, conn)
-
-        case Conn.transfer(conn, pid) do
-          {:ok, conn} -> {:ok, conn}
-          {:error, _conn, _reason} -> :closed
-        end
-      else
-        {:ok, conn}
-      end
+      {:ok,
+       [
+         pool_timeout: remaining_ms,
+         receive_timeout: remaining_ms,
+         request_timeout: remaining_ms
+       ]}
     else
-      :closed
+      AttemptProtocol.predispatch_failure(context, :deadline)
+      {:error, {:local_capacity_rejection, :deadline}}
     end
   end
 
-  defp handle_response(status, body) when status in 200..299 do
-    # Return raw bytes for passthrough optimization
-    # The caller (HTTP transport) will parse using Response.from_bytes/1
-    {:ok, {:raw, body}}
+  defp run_request(request, finch_name, deadline_us, context, tracker_token, opts) do
+    DispatchTracker.begin_attempt(context, tracker_token)
+
+    case request_options(deadline_us, context, opts) do
+      {:ok, request_options} ->
+        with :ok <- DispatchTracker.open_send(context, tracker_token),
+             :ok <- final_deadline_gate(deadline_us, context, opts) do
+          outcome =
+            try do
+              {:returned, finch_request(request, finch_name, request_options, opts)}
+            rescue
+              error -> {:raised, error}
+            catch
+              kind, reason -> {:caught, kind, reason}
+            end
+
+          dispatch_state = DispatchTracker.attempt_state(context)
+
+          tracker_healthy? =
+            is_nil(context) or dispatch_state != :not_started or
+              DispatchTracker.session_healthy?(tracker_token)
+
+          DispatchTracker.clear_attempt(context)
+          handle_request_outcome({outcome, dispatch_state, tracker_healthy?}, context)
+        else
+          {:error, reason} ->
+            DispatchTracker.clear_attempt(context)
+            send_start_error(reason, context)
+        end
+
+      {:error, _reason} = error ->
+        DispatchTracker.clear_attempt(context)
+        error
+    end
   end
 
-  defp handle_response(429, body), do: {:error, {:rate_limit, %{status: 429, body: body}}}
+  defp final_deadline_gate(deadline_us, _context, opts) do
+    monotonic_now =
+      Keyword.get(opts, :monotonic_now_fun, fn -> System.monotonic_time(:microsecond) end)
 
-  # Treat 408 Request Timeout as retriable infrastructure failure
+    if monotonic_now.() < deadline_us, do: :ok, else: {:error, :deadline_expired}
+  end
+
+  defp send_start_error(:deadline_expired, context) do
+    AttemptProtocol.predispatch_failure(context, :deadline)
+    {:error, {:local_capacity_rejection, :deadline}}
+  end
+
+  defp send_start_error(:owner_down, context) do
+    AttemptProtocol.predispatch_failure(context, :local)
+    {:error, {:local_capacity_rejection, :dispatch_cancelled}}
+  end
+
+  defp finch_request(request, finch_name, request_options, opts) do
+    case Keyword.get(opts, :request_fun) do
+      nil ->
+        Finch.request(request, finch_name, request_options)
+
+      request_fun when is_function(request_fun, 3) ->
+        request_fun.(request, finch_name, request_options)
+    end
+  end
+
+  defp handle_request_outcome(
+         {{:returned, {:ok, %Finch.Response{status: status, body: body}}}, _state, _healthy?},
+         context
+       ) do
+    case handle_response(status, body) do
+      {:error, reason} = error ->
+        AttemptProtocol.terminal(context, :transport_failure, %{
+          reason: http_status_reason(reason),
+          certainty: :dispatched
+        })
+
+        error
+
+      success ->
+        success
+    end
+  end
+
+  defp handle_request_outcome(
+         {{:returned, {:error, reason}}, dispatch_state, tracker_healthy?},
+         context
+       ) do
+    certainty = dispatch_certainty(dispatch_state, tracker_healthy?)
+    emit_failure(context, reason, certainty)
+    normalize_finch_error(reason)
+  end
+
+  defp handle_request_outcome({{:raised, error}, dispatch_state, tracker_healthy?}, context) do
+    certainty = dispatch_certainty(dispatch_state, tracker_healthy?)
+    emit_failure(context, error, certainty)
+
+    if certainty == :not_dispatched do
+      {:error, {:local_capacity_rejection, :pool_checkout_timeout}}
+    else
+      {:error, {:network_error, "Request failed"}}
+    end
+  end
+
+  defp handle_request_outcome(
+         {{:caught, _kind, reason}, dispatch_state, tracker_healthy?},
+         context
+       ) do
+    certainty = dispatch_certainty(dispatch_state, tracker_healthy?)
+    emit_failure(context, reason, certainty)
+
+    if certainty == :not_dispatched do
+      {:error, {:local_capacity_rejection, :pool_unavailable}}
+    else
+      {:error, {:network_error, "Request failed"}}
+    end
+  end
+
+  defp dispatch_certainty(:confirmed, _tracker_healthy?), do: :dispatched
+  defp dispatch_certainty(:started, _tracker_healthy?), do: :indeterminate
+  defp dispatch_certainty(:not_started, true), do: :not_dispatched
+  defp dispatch_certainty(:not_started, false), do: :indeterminate
+
+  defp emit_failure(context, _reason, :not_dispatched) do
+    AttemptProtocol.predispatch_failure(context, :pool_unavailable)
+  end
+
+  defp emit_failure(context, reason, certainty) do
+    AttemptProtocol.terminal(context, :transport_failure, %{
+      reason: transport_reason(reason),
+      certainty: certainty
+    })
+  end
+
+  defp normalize_finch_error(%Finch.TransportError{reason: :timeout}), do: {:error, :timeout}
+
+  defp normalize_finch_error(%Finch.TransportError{reason: reason}),
+    do: {:error, {:network_error, transport_message(reason)}}
+
+  defp normalize_finch_error(%Finch.Error{reason: reason}),
+    do: {:error, {:local_capacity_rejection, reason}}
+
+  defp normalize_finch_error(%Finch.HTTPError{}),
+    do: {:error, {:network_error, "HTTP protocol error"}}
+
+  defp normalize_finch_error(reason), do: {:error, reason}
+
+  defp transport_reason(%Finch.TransportError{reason: :timeout}), do: :timeout
+  defp transport_reason(%Finch.TransportError{reason: :nxdomain}), do: :dns
+  defp transport_reason(%Finch.TransportError{reason: :closed}), do: :closed
+  defp transport_reason(%Finch.HTTPError{}), do: :protocol
+  defp transport_reason(_reason), do: :connection
+
+  defp transport_message(:closed), do: "Connection closed"
+  defp transport_message(:econnrefused), do: "Connection refused"
+  defp transport_message(:nxdomain), do: "DNS resolution failed"
+  defp transport_message(reason) when is_atom(reason), do: "Connection error: #{reason}"
+  defp transport_message(_reason), do: "Connection error"
+
+  defp handle_response(status, body) when status in 200..299, do: {:ok, {:raw, body}}
+  defp handle_response(429, body), do: {:error, {:rate_limit, %{status: 429, body: body}}}
   defp handle_response(408, body), do: {:error, {:server_error, %{status: 408, body: body}}}
 
   defp handle_response(status, body) when status >= 500,
     do: {:error, {:server_error, %{status: status, body: body}}}
 
   defp handle_response(status, body), do: {:error, {:client_error, %{status: status, body: body}}}
+
+  defp http_status_reason({:rate_limit, _body}), do: :rate_limited
+  defp http_status_reason({:server_error, _body}), do: :server_error
+  defp http_status_reason({:client_error, _body}), do: :client_error
+
+  defp deadline_from_timeout(timeout_ms),
+    do: System.monotonic_time(:microsecond) + timeout_ms * 1_000
 
   defp generate_id, do: :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
 end

--- a/lib/lasso/core/transport/http/dispatch_tracker.ex
+++ b/lib/lasso/core/transport/http/dispatch_tracker.ex
@@ -1,0 +1,353 @@
+defmodule Lasso.Core.Transport.HTTP.DispatchTracker do
+  @moduledoc false
+
+  use GenServer
+
+  alias Lasso.Core.Transport.AttemptProtocol
+
+  @table :lasso_http_dispatch_tracker
+  @handler_id "lasso-finch-dispatch-tracker"
+  @failure_handler_id "lasso-finch-dispatch-tracker-failures"
+  @dispatch_events [[:finch, :send, :start], [:finch, :send, :stop]]
+  @failure_event [:telemetry, :handler, :failure]
+  @session_key :lasso_finch_dispatch_session
+  @audit_interval_ms 1_000
+
+  @type token :: reference()
+  @type dispatch_state :: :not_started | :started | :confirmed
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @spec ready?() :: boolean()
+  def ready?, do: match?({:ok, _token}, ready_token())
+
+  @spec ready_token() :: {:ok, token()} | {:error, :unavailable}
+  def ready_token do
+    case :ets.lookup(@table, :ready) do
+      [{:ready, token}] when is_reference(token) -> {:ok, token}
+      _ -> {:error, :unavailable}
+    end
+  rescue
+    ArgumentError -> {:error, :unavailable}
+  end
+
+  @spec status() :: map()
+  def status do
+    case :ets.lookup(@table, :status) do
+      [{:status, status}] -> status
+      _ -> %{ready?: false, degraded_count: 0, reason: :unavailable}
+    end
+  rescue
+    ArgumentError -> %{ready?: false, degraded_count: 0, reason: :unavailable}
+  end
+
+  @spec audit_now() :: :ok | {:error, :unavailable}
+  def audit_now do
+    GenServer.call(__MODULE__, :audit)
+  catch
+    :exit, _reason -> {:error, :unavailable}
+  end
+
+  @spec begin_attempt(AttemptProtocol.context() | nil, token() | nil) :: :ok
+  def begin_attempt(nil, _token), do: :ok
+
+  def begin_attempt(context, token) when is_reference(token) do
+    Process.put(@session_key, %{
+      context: context,
+      token: token,
+      state: :not_started,
+      protocol_open?: false
+    })
+
+    :ok
+  end
+
+  @spec open_send(AttemptProtocol.context() | nil, token() | nil) ::
+          :ok | {:error, AttemptProtocol.send_start_error()}
+  def open_send(nil, _token), do: :ok
+
+  def open_send(context, token) when is_reference(token) do
+    with :ok <- AttemptProtocol.send_started(context) do
+      case Process.get(@session_key) do
+        %{context: ^context, token: ^token} = session ->
+          Process.put(@session_key, %{session | protocol_open?: true})
+
+        _ ->
+          :ok
+      end
+
+      :ok
+    end
+  end
+
+  @spec attempt_state(AttemptProtocol.context() | nil) :: dispatch_state()
+  def attempt_state(nil), do: :not_started
+
+  def attempt_state(context) do
+    case Process.get(@session_key) do
+      %{context: ^context, state: state} -> state
+      _ -> :not_started
+    end
+  end
+
+  @spec clear_attempt(AttemptProtocol.context() | nil) :: :ok
+  def clear_attempt(nil), do: :ok
+
+  def clear_attempt(_context) do
+    Process.delete(@session_key)
+    :ok
+  end
+
+  @spec session_healthy?(token()) :: boolean()
+  def session_healthy?(token) when is_reference(token) do
+    Process.whereis(__MODULE__) != nil and exact_attachment?(token)
+  end
+
+  @impl true
+  def init(opts) do
+    table =
+      :ets.new(@table, [
+        :named_table,
+        :protected,
+        :set,
+        read_concurrency: true
+      ])
+
+    token = make_ref()
+    audit_interval_ms = Keyword.get(opts, :audit_interval_ms, @audit_interval_ms)
+    state = %{token: token, degraded_count: 0, audit_interval_ms: audit_interval_ms}
+
+    reclaim_handlers()
+
+    case attach_handlers(token) do
+      :ok ->
+        publish_status(table, state, true, nil)
+        schedule_audit(audit_interval_ms)
+        {:ok, state}
+
+      {:error, reason} ->
+        publish_status(table, state, false, reason)
+        reclaim_handlers()
+        {:stop, {:dispatch_tracker_attach_failed, reason}}
+    end
+  end
+
+  @impl true
+  def handle_call(:audit, _from, state) do
+    {result, state} = audit_attachment(state)
+    {:reply, result, state}
+  end
+
+  @impl true
+  def handle_info(:audit, state) do
+    {_result, state} = audit_attachment(state)
+    schedule_audit(state.audit_interval_ms)
+    {:noreply, state}
+  end
+
+  def handle_info({:handler_failed, token}, %{token: token} = state) do
+    {_result, state} = repair_attachment(state, :handler_failed)
+    {:noreply, state}
+  end
+
+  def handle_info({:handler_failed, _stale_token}, state), do: {:noreply, state}
+
+  @impl true
+  def terminate(_reason, _state) do
+    reclaim_handlers()
+    :ok
+  end
+
+  @doc false
+  @spec handle_event([atom()], map(), map(), map()) :: :ok
+  def handle_event([:finch, :send, :start], _measurements, metadata, %{token: token}) do
+    with %{request: %{private: private}} <- metadata,
+         context when not is_nil(context) <- Map.get(private, :lasso_attempt) do
+      if mark_started(context, token), do: AttemptProtocol.send_started(context)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  def handle_event([:finch, :send, :stop], _measurements, metadata, %{token: token}) do
+    with false <- Map.has_key?(metadata, :error),
+         %{request: %{private: private}} <- metadata,
+         context when not is_nil(context) <- Map.get(private, :lasso_attempt) do
+      update_attempt(context, token, :confirmed)
+      AttemptProtocol.send_confirmed(context)
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  @doc false
+  @spec handle_failure_event([atom()], map(), map(), map()) :: :ok
+  def handle_failure_event([:telemetry, :handler, :failure], _measurements, metadata, %{
+        token: token
+      }) do
+    if Map.get(metadata, :handler_id) == @handler_id do
+      send(__MODULE__, {:handler_failed, token})
+    end
+
+    :ok
+  rescue
+    _ -> :ok
+  end
+
+  defp update_attempt(context, _token, state) do
+    case Process.get(@session_key) do
+      %{context: ^context} = session ->
+        Process.put(@session_key, %{session | state: promote_state(session.state, state)})
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp mark_started(context, _token) do
+    case Process.get(@session_key) do
+      %{context: ^context} = session ->
+        Process.put(@session_key, %{
+          session
+          | state: promote_state(session.state, :started),
+            protocol_open?: true
+        })
+
+        not session.protocol_open?
+
+      _ ->
+        true
+    end
+  end
+
+  defp audit_attachment(state) do
+    if exact_attachment?(state.token) do
+      publish_status(@table, state, true, nil)
+      {:ok, state}
+    else
+      repair_attachment(state, :attachment_mismatch)
+    end
+  end
+
+  defp repair_attachment(state, reason) do
+    degraded_state = %{
+      state
+      | token: make_ref(),
+        degraded_count: state.degraded_count + 1
+    }
+
+    publish_status(@table, degraded_state, false, reason)
+    emit_degraded(degraded_state, reason)
+    reclaim_handlers()
+
+    case attach_handlers(degraded_state.token) do
+      :ok ->
+        publish_status(@table, degraded_state, true, :recovered)
+        {:ok, degraded_state}
+
+      {:error, attach_reason} ->
+        publish_status(@table, degraded_state, false, attach_reason)
+        {{:error, attach_reason}, degraded_state}
+    end
+  end
+
+  defp attach_handlers(token) do
+    config = %{token: token}
+
+    with :ok <-
+           :telemetry.attach_many(
+             @handler_id,
+             @dispatch_events,
+             &__MODULE__.handle_event/4,
+             config
+           ),
+         :ok <-
+           :telemetry.attach(
+             @failure_handler_id,
+             @failure_event,
+             &__MODULE__.handle_failure_event/4,
+             config
+           ),
+         true <- exact_attachment?(token) do
+      :ok
+    else
+      false -> {:error, :attachment_validation_failed}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp exact_attachment?(token) do
+    dispatch_config = %{token: token}
+
+    dispatch_ok? =
+      Enum.all?(@dispatch_events, fn event ->
+        exact_handler?(
+          event,
+          @handler_id,
+          &__MODULE__.handle_event/4,
+          dispatch_config
+        )
+      end)
+
+    dispatch_ok? and
+      exact_handler?(
+        @failure_event,
+        @failure_handler_id,
+        &__MODULE__.handle_failure_event/4,
+        dispatch_config
+      )
+  end
+
+  defp exact_handler?(event, id, function, config) do
+    Enum.any?(:telemetry.list_handlers(event), fn handler ->
+      handler.id == id and handler.function == function and handler.config == config and
+        handler.event_name == event
+    end)
+  end
+
+  defp reclaim_handlers do
+    :telemetry.detach(@handler_id)
+    :telemetry.detach(@failure_handler_id)
+  end
+
+  defp publish_status(table, state, ready?, reason) do
+    if ready? do
+      :ets.insert(table, {:ready, state.token})
+    else
+      :ets.delete(table, :ready)
+    end
+
+    :ets.insert(table, {
+      :status,
+      %{
+        ready?: ready?,
+        degraded_count: state.degraded_count,
+        reason: reason,
+        incarnation: state.token
+      }
+    })
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp emit_degraded(state, reason) do
+    :telemetry.execute(
+      [:lasso, :finch, :dispatch_tracker, :degraded],
+      %{count: 1},
+      %{reason: reason, degraded_count: state.degraded_count}
+    )
+  end
+
+  defp schedule_audit(:infinity), do: :ok
+  defp schedule_audit(interval_ms), do: Process.send_after(self(), :audit, interval_ms)
+
+  defp promote_state(:confirmed, _state), do: :confirmed
+  defp promote_state(_state, :confirmed), do: :confirmed
+  defp promote_state(:started, _state), do: :started
+  defp promote_state(_state, :started), do: :started
+end

--- a/lib/lasso/core/transport/http/http.ex
+++ b/lib/lasso/core/transport/http/http.ex
@@ -9,10 +9,9 @@ defmodule Lasso.RPC.Transports.HTTP do
 
   @behaviour Lasso.RPC.Transport
 
-  require Logger
   alias Lasso.Core.Support.{AttemptLifecycle, ErrorClassifier, ErrorNormalizer}
+  alias Lasso.Core.Transport.{AttemptProtocol, UpstreamResponse}
   alias Lasso.JSONRPC.Error, as: JError
-  alias Lasso.RPC.Response
   alias Lasso.RPC.Transport.HTTP.Client, as: HttpClient
 
   # Channel is the provider configuration for HTTP (stateless)
@@ -70,59 +69,29 @@ defmodule Lasso.RPC.Transports.HTTP do
 
     io_start_us = System.monotonic_time(:microsecond)
     dispatch_context = AttemptLifecycle.dispatch_context()
+    deadline_us = request_deadline_us(io_start_us, timeout, AttemptProtocol.deadline_us())
 
     result =
       case HttpClient.request(provider_config, method, params,
              request_id: request_id,
              timeout: timeout,
+             deadline_us: deadline_us,
              attempt_dispatch: dispatch_context
            ) do
         {:ok, {:raw, raw_bytes}} ->
-          # Parse raw bytes using envelope parser for passthrough optimization
-          case Response.from_bytes(raw_bytes) do
-            {:ok, %Response.Success{} = resp} ->
-              {:ok, resp}
+          received_at_us = System.monotonic_time(:microsecond)
+          validation = UpstreamResponse.validate_unary(raw_bytes, request_id, request_id)
+          validated_at_us = System.monotonic_time(:microsecond)
 
-            {:ok, %Response.Error{error: jerr}} ->
-              %{category: category, retriable?: retriable?, breaker_penalty?: breaker_penalty?} =
-                ErrorClassifier.classify(jerr.code, jerr.message,
-                  data: jerr.data,
-                  provider_id: provider_id
-                )
-
-              enriched_jerr = %{
-                jerr
-                | provider_id: provider_id,
-                  source: :jsonrpc,
-                  transport: :http,
-                  category: category,
-                  retriable?: retriable?,
-                  breaker_penalty?: breaker_penalty?
-              }
-
-              {:error, enriched_jerr}
-
-            {:error, parse_reason} ->
-              Logger.warning("Unparseable JSON-RPC envelope from provider",
-                provider_id: provider_id,
-                reason: parse_reason,
-                raw_bytes_size: byte_size(raw_bytes),
-                raw_sample: binary_part(raw_bytes, 0, min(200, byte_size(raw_bytes)))
-              )
-
-              {:error,
-               JError.new(-32_700, "Invalid JSON-RPC response format",
-                 data: %{reason: parse_reason, raw_bytes_size: byte_size(raw_bytes)},
-                 provider_id: provider_id,
-                 source: :transport,
-                 transport: :http,
-                 # Upstream returned malformed/non-enveloped bytes.
-                 # Treat as provider-side server failure so pipeline can fail over.
-                 category: :server_error,
-                 retriable?: true,
-                 breaker_penalty?: true
-               )}
-          end
+          settle_raw_response(%{
+            validation: validation,
+            raw_bytes: raw_bytes,
+            provider_id: provider_id,
+            dispatch_context: dispatch_context,
+            deadline_us: deadline_us,
+            io_duration_us: max(received_at_us - io_start_us, 0),
+            validated_at_us: validated_at_us
+          })
 
         {:error, reason} ->
           {:error,
@@ -136,27 +105,12 @@ defmodule Lasso.RPC.Transports.HTTP do
     # Calculate I/O latency
     io_ms = div(System.monotonic_time(:microsecond) - io_start_us, 1000)
 
-    # Emit telemetry
-    :telemetry.execute(
-      [:lasso, :http, :request, :io],
-      %{io_ms: io_ms},
-      %{provider_id: provider_id, method: method}
-    )
-
     # Return latency as third tuple element for both success and error
     case result do
       {:ok, response} ->
         {:ok, response, io_ms}
 
       {:error, reason} ->
-        Logger.debug("HTTP request failed",
-          provider: provider_id,
-          method: method,
-          rpc_id: request_id,
-          io_latency_ms: io_ms,
-          error: inspect(reason, limit: 500, printable_limit: 1000)
-        )
-
         {:error, reason, io_ms}
     end
   end
@@ -183,5 +137,92 @@ defmodule Lasso.RPC.Transports.HTTP do
 
   defp get_http_url(provider_config) do
     Map.get(provider_config, :url) || Map.get(provider_config, :http_url)
+  end
+
+  defp request_deadline_us(started_at_us, timeout, decision_deadline_us)
+       when is_integer(timeout) and timeout >= 0 and is_integer(decision_deadline_us),
+       do: min(decision_deadline_us, started_at_us + timeout * 1_000)
+
+  defp request_deadline_us(started_at_us, timeout, nil)
+       when is_integer(timeout) and timeout >= 0,
+       do: started_at_us + timeout * 1_000
+
+  defp settle_raw_response(%{validated_at_us: validated_at_us, deadline_us: deadline_us} = input)
+       when validated_at_us >= deadline_us do
+    AttemptProtocol.terminal_at(
+      input.dispatch_context,
+      :transport_failure,
+      %{reason: :timeout, certainty: :dispatched},
+      validated_at_us
+    )
+
+    {:error,
+     ErrorNormalizer.normalize(:timeout,
+       provider_id: input.provider_id,
+       context: :transport,
+       transport: :http
+     )}
+  end
+
+  defp settle_raw_response(%{validation: {:ok, response}} = input) do
+    AttemptProtocol.terminal_at(
+      input.dispatch_context,
+      :response,
+      %{response_kind: :success, io_duration_us: input.io_duration_us},
+      input.validated_at_us
+    )
+
+    {:ok, response}
+  end
+
+  defp settle_raw_response(%{validation: {:error, %JError{} = jerr}} = input) do
+    %{category: category, retriable?: retriable?, breaker_penalty?: breaker_penalty?} =
+      ErrorClassifier.classify(jerr.code, jerr.message,
+        data: jerr.data,
+        provider_id: input.provider_id
+      )
+
+    AttemptProtocol.terminal_at(
+      input.dispatch_context,
+      :response,
+      %{
+        response_kind: :error,
+        error_code: jerr.code,
+        error_category: category,
+        io_duration_us: input.io_duration_us
+      },
+      input.validated_at_us
+    )
+
+    {:error,
+     %{
+       jerr
+       | provider_id: input.provider_id,
+         source: :jsonrpc,
+         transport: :http,
+         category: category,
+         retriable?: retriable?,
+         breaker_penalty?: breaker_penalty?
+     }}
+  end
+
+  defp settle_raw_response(%{validation: {:invalid, parse_reason}} = input) do
+    AttemptProtocol.terminal_at(
+      input.dispatch_context,
+      :invalid_response,
+      %{reason: parse_reason, io_duration_us: input.io_duration_us},
+      input.validated_at_us
+    )
+
+    {:error,
+     JError.new(-32_700, "Invalid JSON-RPC response format",
+       data: %{reason: parse_reason, raw_bytes_size: byte_size(input.raw_bytes)},
+       provider_id: input.provider_id,
+       source: :transport,
+       transport: :http,
+       category: :server_error,
+       retriable?: true,
+       breaker_penalty?: true
+     )}
   end
 end

--- a/lib/lasso/core/transport/websocket/connection.ex
+++ b/lib/lasso/core/transport/websocket/connection.ex
@@ -71,7 +71,10 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   require Logger
 
   alias Lasso.Core.Support.{AttemptLifecycle, CircuitBreaker}
+  alias Lasso.Core.Support.CircuitBreaker.Snapshot
   alias Lasso.Core.Support.{ErrorClassifier, ErrorNormalizer}
+  alias Lasso.Core.Transport.UpstreamResponse
+  alias Lasso.Core.Transport.UpstreamResponse.Validated
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.{Catalog, InstanceState}
   alias Lasso.RPC.Response
@@ -85,6 +88,9 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   # (Cloudflare in front of most providers will rate-limit a synchronized burst).
   # Configurable so tests can disable jitter; defaults to 3s in dev/prod.
   @default_startup_jitter_ms 3_000
+  @default_transport_pending_limit 256
+  @default_send_cleanup_ms 100
+  @max_diagnostic_count 9_223_372_036_854_775_807
 
   # Client API
 
@@ -162,6 +168,10 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       connected: false,
       reconnect_attempts: 0,
       pending_requests: %{},
+      transport_pending: %{},
+      control_sends: %{},
+      transport_pending_limit: transport_pending_limit(),
+      transport_diagnostics: %{},
       heartbeat_ref: nil,
       reconnect_ref: nil,
       stability_timer_ref: nil,
@@ -184,8 +194,109 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     end
   end
 
+  @doc false
+  @spec transport_snapshot(String.t(), timeout()) ::
+          {:ok, {pid(), term()}} | {:error, :not_connected}
+  def transport_snapshot(instance_id, timeout_ms) do
+    GenServer.call(via_instance_name(instance_id), :transport_snapshot, timeout_ms)
+  end
+
+  @doc false
+  @spec authorize_transport(
+          String.t(),
+          String.t(),
+          pid(),
+          integer(),
+          integer(),
+          binary(),
+          timeout()
+        ) ::
+          {:ok, {pid(), term(), reference()}}
+          | {:error,
+             :authorization_unknown
+             | :capacity
+             | :cancelled
+             | :deadline
+             | :duplicate_transport_id
+             | :invalid_transport_id
+             | :not_connected}
+  def authorize_transport(
+        instance_id,
+        transport_id,
+        owner,
+        decision_deadline_us,
+        settlement_deadline_us,
+        encoded,
+        timeout_ms
+      ) do
+    GenServer.call(
+      via_instance_name(instance_id),
+      {:authorize_transport, transport_id, owner, decision_deadline_us, settlement_deadline_us,
+       encoded},
+      timeout_ms
+    )
+  catch
+    :exit, _reason -> {:error, :authorization_unknown}
+  end
+
+  @doc false
+  @spec register_transport(String.t(), {pid(), term()}, term(), pid(), integer(), timeout()) ::
+          {:ok, reference()}
+          | {:error,
+             :capacity
+             | :deadline
+             | :duplicate_transport_id
+             | :invalid_transport_id
+             | :stale_connection}
+  def register_transport(instance_id, snapshot, transport_id, owner, deadline_us, timeout_ms) do
+    GenServer.call(
+      via_instance_name(instance_id),
+      {:register_transport, snapshot, transport_id, owner, deadline_us},
+      timeout_ms
+    )
+  end
+
+  @doc false
+  @spec queue_transport(
+          String.t(),
+          term(),
+          term(),
+          reference(),
+          binary(),
+          timeout()
+        ) :: :ok | {:error, :cancelled | :deadline | :queue_unknown | :stale_connection}
+  def queue_transport(instance_id, transport_id, generation, token, encoded, timeout_ms) do
+    GenServer.call(
+      via_instance_name(instance_id),
+      {:queue_transport, transport_id, generation, token, encoded},
+      timeout_ms
+    )
+  catch
+    :exit, _reason -> {:error, :queue_unknown}
+  end
+
+  @doc false
+  @spec cancel_transport(String.t(), term(), term(), reference()) :: :ok
+  def cancel_transport(instance_id, transport_id, generation, token) do
+    GenServer.cast(
+      via_instance_name(instance_id),
+      {:cancel_transport, transport_id, generation, token}
+    )
+  end
+
   defp startup_jitter_ms do
     Application.get_env(:lasso, :ws_startup_jitter_ms, @default_startup_jitter_ms)
+  end
+
+  defp transport_pending_limit do
+    case Application.get_env(
+           :lasso,
+           :ws_transport_pending_limit,
+           @default_transport_pending_limit
+         ) do
+      limit when is_integer(limit) and limit > 0 -> limit
+      _invalid -> @default_transport_pending_limit
+    end
   end
 
   @doc """
@@ -329,12 +440,18 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
   defp do_connect(state, breaker_id) do
     ws_connection_pid = self()
+    connection_generation = generate_connection_id()
 
-    case connect_to_websocket(state.endpoint, ws_connection_pid) do
+    case connect_to_websocket(state.endpoint, ws_connection_pid, connection_generation) do
       {:ok, connection} ->
         # Success - don't report to circuit breaker yet!
         # Recovery will be signaled when connection proves stable (5s)
-        state = %{state | connection: connection}
+        state = %{
+          state
+          | connection: connection,
+            connection_id: connection_generation
+        }
+
         {:noreply, state}
 
       {:error, error} ->
@@ -345,7 +462,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
         )
 
         if jerr.breaker_penalty? do
-          CircuitBreaker.record_failure(breaker_id, jerr)
+          _ = CircuitBreaker.report_external_bounded(breaker_id, {:error, jerr})
         end
 
         :telemetry.execute(
@@ -447,15 +564,221 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
   @impl true
   def handle_call(:status, _from, state) do
+    legacy_pending = map_size(state.pending_requests)
+    transport_pending = map_size(state.transport_pending)
+    control_sends = map_size(state.control_sends)
+
     status = %{
       connected: state.connected,
       connection_stable: state.connection_stable,
       endpoint_id: state.endpoint.id,
       reconnect_attempts: state.reconnect_attempts,
-      pending_requests: map_size(state.pending_requests)
+      pending_requests: legacy_pending + transport_pending + control_sends,
+      legacy_pending_requests: legacy_pending,
+      transport_pending_requests: transport_pending,
+      transport_tombstones: count_send_state(state.transport_pending, :tombstone),
+      queued_control_sends: control_sends,
+      transport_pending_limit: state.transport_pending_limit,
+      transport_diagnostics: state.transport_diagnostics
     }
 
     {:reply, status, state}
+  end
+
+  def handle_call(:transport_snapshot, _from, %{connected: true} = state) do
+    {:reply, {:ok, {state.connection, state.connection_id}}, state}
+  end
+
+  def handle_call(:transport_snapshot, _from, state),
+    do: {:reply, {:error, :not_connected}, state}
+
+  def handle_call(
+        {:authorize_transport, transport_id, owner, decision_deadline_us, settlement_deadline_us,
+         encoded},
+        _from,
+        %{connected: true, connection: connection, connection_id: generation} = state
+      )
+      when is_binary(encoded) and is_pid(owner) do
+    now_us = System.monotonic_time(:microsecond)
+
+    cond do
+      now_us >= decision_deadline_us ->
+        {:reply, {:error, :deadline}, state}
+
+      settlement_deadline_us < decision_deadline_us or
+          settlement_deadline_us > decision_deadline_us + 1_000 ->
+        {:reply, {:error, :deadline}, state}
+
+      not Process.alive?(owner) ->
+        {:reply, {:error, :cancelled}, state}
+
+      not UpstreamResponse.transport_id?(transport_id) ->
+        {:reply, {:error, :invalid_transport_id}, state}
+
+      Map.has_key?(state.transport_pending, transport_id) ->
+        {:reply, {:error, :duplicate_transport_id}, state}
+
+      send_capacity_used(state) >= state.transport_pending_limit ->
+        {:reply, {:error, :capacity}, state}
+
+      true ->
+        token = make_ref()
+        cancel_latch = :atomics.new(1, signed: false)
+        monitor = Process.monitor(owner)
+
+        timer =
+          Process.send_after(
+            self(),
+            {:transport_timeout, transport_id, generation, token},
+            ceil_milliseconds(settlement_deadline_us - now_us)
+          )
+
+        pending = %{
+          owner: owner,
+          owner_monitor: monitor,
+          token: token,
+          timer: timer,
+          generation: generation,
+          deadline_us: decision_deadline_us,
+          decision_deadline_us: decision_deadline_us,
+          settlement_deadline_us: settlement_deadline_us,
+          connection: connection,
+          cancel_latch: cancel_latch,
+          send_state: :queued
+        }
+
+        next_state =
+          %{state | transport_pending: Map.put(state.transport_pending, transport_id, pending)}
+
+        case cast_send(
+               next_state,
+               {:transport, transport_id, token},
+               decision_deadline_us,
+               cancel_latch,
+               {:text, encoded}
+             ) do
+          :ok ->
+            {:reply, {:ok, {connection, generation, token}}, next_state}
+
+          {:error, _reason} ->
+            cleanup_send_entry(pending)
+            {:reply, {:error, :cancelled}, state}
+        end
+    end
+  end
+
+  def handle_call(
+        {:authorize_transport, _transport_id, _owner, _decision_deadline, _settlement_deadline,
+         _encoded},
+        _from,
+        state
+      ),
+      do: {:reply, {:error, :not_connected}, state}
+
+  def handle_call(
+        {:register_transport, {connection, generation}, transport_id, owner, deadline_us},
+        _from,
+        %{connected: true, connection: connection, connection_id: generation} = state
+      ) do
+    remaining_us = deadline_us - System.monotonic_time(:microsecond)
+
+    cond do
+      remaining_us <= 0 ->
+        {:reply, {:error, :deadline}, state}
+
+      not transport_id_for_generation?(transport_id, generation) ->
+        {:reply, {:error, :invalid_transport_id}, state}
+
+      Map.has_key?(state.transport_pending, transport_id) ->
+        {:reply, {:error, :duplicate_transport_id}, state}
+
+      send_capacity_used(state) >= state.transport_pending_limit ->
+        {:reply, {:error, :capacity}, state}
+
+      true ->
+        token = make_ref()
+        cancel_latch = :atomics.new(1, signed: false)
+        monitor = Process.monitor(owner)
+        timeout_ms = ceil_milliseconds(remaining_us)
+
+        timer =
+          Process.send_after(
+            self(),
+            {:transport_timeout, transport_id, generation, token},
+            timeout_ms
+          )
+
+        pending = %{
+          owner: owner,
+          owner_monitor: monitor,
+          token: token,
+          timer: timer,
+          generation: generation,
+          deadline_us: deadline_us,
+          decision_deadline_us: deadline_us,
+          settlement_deadline_us: deadline_us,
+          connection: connection,
+          cancel_latch: cancel_latch,
+          send_state: :registered
+        }
+
+        {:reply, {:ok, token},
+         %{state | transport_pending: Map.put(state.transport_pending, transport_id, pending)}}
+    end
+  end
+
+  def handle_call({:register_transport, _snapshot, _id, _owner, _deadline}, _from, state),
+    do: {:reply, {:error, :stale_connection}, state}
+
+  def handle_call(
+        {:queue_transport, transport_id, generation, token, encoded},
+        _from,
+        %{connected: true, connection_id: generation} = state
+      ) do
+    now_us = System.monotonic_time(:microsecond)
+
+    case Map.get(state.transport_pending, transport_id) do
+      %{generation: ^generation, token: ^token, send_state: :registered} = pending ->
+        cond do
+          now_us >= pending.deadline_us ->
+            state = cancel_registered_transport(state, transport_id, pending)
+            {:reply, {:error, :deadline}, state}
+
+          not Process.alive?(pending.owner) ->
+            state = cancel_registered_transport(state, transport_id, pending)
+            {:reply, {:error, :cancelled}, state}
+
+          true ->
+            pending = %{pending | send_state: :queued}
+            state = put_in(state, [:transport_pending, transport_id], pending)
+
+            case cast_send(
+                   state,
+                   {:transport, transport_id, token},
+                   pending.deadline_us,
+                   pending.cancel_latch,
+                   {:text, encoded}
+                 ) do
+              :ok ->
+                {:reply, :ok, state}
+
+              {:error, _reason} ->
+                state = cancel_registered_transport(state, transport_id, pending)
+                {:reply, {:error, :cancelled}, state}
+            end
+        end
+
+      _missing_or_stale ->
+        {:reply, {:error, :cancelled}, state}
+    end
+  end
+
+  def handle_call({:queue_transport, _id, _generation, _token, _encoded}, _from, state),
+    do: {:reply, {:error, :stale_connection}, state}
+
+  @impl true
+  def handle_cast({:cancel_transport, transport_id, generation, token}, state) do
+    {:noreply, cancel_transport_by_key(state, transport_id, generation, token)}
   end
 
   defp handle_authorized_request(
@@ -468,53 +791,72 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
          timeout_ms,
          state
        ) do
-    sent_at = System.monotonic_time(:microsecond)
-    confirmation = AttemptLifecycle.confirm_dispatched(dispatch_context)
+    caller_pid = elem(from, 0)
 
-    case {confirmation, send_frame_if_confirmed(confirmation, state.connection, encoded_message)} do
-      {{:error, :cancelled}, _not_sent} ->
-        jerr =
-          JError.new(-32_008, "WebSocket request cancelled before dispatch",
-            provider_id: state.endpoint.id,
-            retriable?: true,
-            breaker_penalty?: false,
-            category: :cancelled
+    cond do
+      not Process.alive?(caller_pid) ->
+        {:reply, {:error, cancelled_request_error(state)}, state}
+
+      send_capacity_used(state) >= state.transport_pending_limit ->
+        AttemptLifecycle.abort_dispatch(dispatch_context)
+        {:reply, {:error, capacity_error(state)}, state}
+
+      Map.has_key?(state.pending_requests, request_id) ->
+        AttemptLifecycle.abort_dispatch(dispatch_context)
+        {:reply, {:error, capacity_error(state)}, state}
+
+      true ->
+        sent_at = System.monotonic_time(:microsecond)
+        deadline_us = sent_at + timeout_ms * 1_000
+        token = make_ref()
+        cancel_latch = :atomics.new(1, signed: false)
+        owner_monitor = Process.monitor(caller_pid)
+
+        timer =
+          Process.send_after(
+            self(),
+            {:request_timeout, request_id, state.connection_id, token},
+            timeout_ms
           )
 
-        {:reply, {:error, jerr}, state}
+        pending = %{
+          from: from,
+          owner: caller_pid,
+          owner_monitor: owner_monitor,
+          timer: timer,
+          sent_at: sent_at,
+          method: method,
+          timeout_ms: timeout_ms,
+          token: token,
+          generation: state.connection_id,
+          connection: state.connection,
+          deadline_us: deadline_us,
+          cancel_latch: cancel_latch,
+          send_state: :queued
+        }
 
-      {:ok, :ok} ->
-        :telemetry.execute(
-          [:lasso, :websocket, :request, :sent],
-          %{},
-          %{
-            provider_id: state.endpoint.id,
-            method: method,
-            request_id: request_id,
-            timeout_ms: timeout_ms
-          }
-        )
+        state = put_in(state, [:pending_requests, request_id], pending)
 
-        timer = Process.send_after(self(), {:request_timeout, request_id}, timeout_ms)
+        case cast_send(
+               state,
+               {:legacy, request_id, token},
+               deadline_us,
+               cancel_latch,
+               {:text, encoded_message}
+             ) do
+          :ok ->
+            {:noreply, state}
 
-        pending =
-          Map.put(state.pending_requests, request_id, %{
-            from: from,
-            timer: timer,
-            sent_at: sent_at,
-            method: method
-          })
+          {:error, reason} ->
+            state = remove_legacy_pending(state, request_id, pending)
 
-        {:noreply, %{state | pending_requests: pending}}
-
-      {:ok, {:error, reason}} ->
-        jerr =
-          ErrorNormalizer.normalize(reason,
-            provider_id: state.endpoint.id,
-            transport: :ws
-          )
-
-        {:reply, {:error, jerr}, state}
+            {:reply,
+             {:error,
+              ErrorNormalizer.normalize(reason,
+                provider_id: state.endpoint.id,
+                transport: :ws
+              )}, state}
+        end
     end
   end
 
@@ -539,25 +881,108 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     {:reply, {:error, jerr}, state}
   end
 
-  defp send_frame_if_confirmed(:ok, connection, encoded_message) do
-    send_frame(connection, {:text, encoded_message})
+  @impl true
+  def handle_info(
+        {:ws_send_decision, connection, generation, {:transport, transport_id, token}, decision,
+         decided_at_us},
+        %{connection: connection, connection_id: generation} = state
+      ) do
+    case Map.get(state.transport_pending, transport_id) do
+      %{generation: ^generation, token: ^token, send_state: :queued} = pending ->
+        case decision do
+          :accepted ->
+            send(pending.owner, {:ws_transport_send_accepted, token, generation, decided_at_us})
+
+            {:noreply,
+             put_in(state, [:transport_pending, transport_id], %{pending | send_state: :accepted})}
+
+          {:rejected, reason} ->
+            send(pending.owner, {:ws_transport_send_rejected, token, generation, reason})
+            {:noreply, remove_transport_entry(state, transport_id, pending)}
+        end
+
+      %{generation: ^generation, token: ^token, send_state: :tombstone} = pending ->
+        {:noreply, remove_transport_entry(state, transport_id, pending)}
+
+      _missing_or_stale ->
+        {:noreply, increment_transport_diagnostic(state, :stale_send_decision)}
+    end
   end
 
-  defp send_frame_if_confirmed({:error, :cancelled}, _connection, _encoded_message),
-    do: :not_sent
+  def handle_info(
+        {:ws_send_decision, connection, generation, {:legacy, request_id, token}, decision,
+         _decided_at_us},
+        %{connection: connection, connection_id: generation} = state
+      ) do
+    case Map.get(state.pending_requests, request_id) do
+      %{generation: ^generation, token: ^token, send_state: :queued} = pending ->
+        case decision do
+          :accepted ->
+            :telemetry.execute(
+              [:lasso, :websocket, :request, :sent],
+              %{},
+              %{
+                provider_id: state.endpoint.id,
+                method: pending.method,
+                request_id: request_id,
+                timeout_ms: pending.timeout_ms
+              }
+            )
 
-  @impl true
+            {:noreply,
+             put_in(state, [:pending_requests, request_id], %{pending | send_state: :accepted})}
+
+          {:rejected, reason} ->
+            GenServer.reply(
+              pending.from,
+              {:error,
+               ErrorNormalizer.normalize(reason,
+                 provider_id: state.endpoint.id,
+                 transport: :ws
+               )}
+            )
+
+            {:noreply, remove_legacy_pending(state, request_id, pending)}
+        end
+
+      %{generation: ^generation, token: ^token, send_state: :tombstone} = pending ->
+        {:noreply, remove_legacy_pending(state, request_id, pending)}
+
+      _missing_or_stale ->
+        {:noreply, increment_transport_diagnostic(state, :stale_send_decision)}
+    end
+  end
+
+  def handle_info(
+        {:ws_send_decision, connection, generation, {:control, token}, decision, _decided_at_us},
+        %{connection: connection, connection_id: generation} = state
+      ) do
+    case Map.get(state.control_sends, token) do
+      %{generation: ^generation} = control ->
+        state = remove_control_send(state, token, control)
+        {:noreply, handle_control_decision(state, control, decision)}
+
+      _missing_or_stale ->
+        {:noreply, increment_transport_diagnostic(state, :stale_send_decision)}
+    end
+  end
+
+  def handle_info({:ws_send_decision, _connection, _generation, _key, _decision, _at}, state) do
+    {:noreply, increment_transport_diagnostic(state, :stale_send_decision)}
+  end
+
   def handle_info(:initial_connect, state), do: handle_continue(:connect, state)
 
-  def handle_info({:ws_connected}, state) do
+  def handle_info(
+        {:ws_connected, connection, connection_generation},
+        %{connection: connection, connection_id: connection_generation} = state
+      ) do
     # NOTE: We intentionally do NOT call signal_recovery here.
     # Recovery is signaled only after the connection proves stable (see {:connection_stable}).
     # This allows circuit breaker failures to accumulate when providers accept connections
     # but immediately drop them (e.g., dRPC connection limits).
 
-    # Generate new connection_id for this connection instance
-    # This allows consumers to detect when subscriptions are stale (from previous connection)
-    connection_id = generate_connection_id()
+    connection_id = connection_generation
 
     :telemetry.execute(
       [:lasso, :websocket, :connected],
@@ -573,7 +998,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     # Mark as connected but DON'T reset reconnect_attempts yet.
     # Schedule stability timer - only reset attempts after connection proves stable.
     # This prevents thrashing when providers drop connections immediately after connect.
-    state = %{state | connected: true, connection_id: connection_id}
+    state = %{state | connected: true}
 
     # Cancel any pending reconnect timer (stale) now that we're connected
     state =
@@ -610,26 +1035,102 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     {:noreply, state}
   end
 
-  def handle_info({:ws_message, raw_bytes, _frame_received_at}, state) do
-    case Response.from_bytes(raw_bytes) do
-      {:ok, %Response.Success{id: nil}} ->
-        # Safety guard: Response with nil id is likely a misclassified notification.
-        # This shouldn't happen with proper EnvelopeParser method-field detection,
-        # but provides defense-in-depth.
-        handle_non_response_message(raw_bytes, state)
+  def handle_info({:ws_connected, _connection, _connection_generation}, state) do
+    {:noreply, increment_transport_diagnostic(state, :stale_generation)}
+  end
 
-      {:ok, %Response.Success{id: id} = resp} ->
-        handle_response_success(id, resp, state)
+  def handle_info(
+        {:ws_message, connection, generation, parsed, raw_bytes, frame_received_at, validated_at},
+        %{connection: connection, connection_id: generation} = state
+      ) do
+    {:noreply,
+     route_ws_message(
+       state,
+       connection,
+       generation,
+       parsed,
+       raw_bytes,
+       frame_received_at,
+       validated_at
+     )}
+  end
 
-      {:ok, %Response.Error{id: id, error: jerr}} ->
-        handle_response_error(id, jerr, state)
+  def handle_info(
+        {:ws_message, _connection, _generation, _parsed, _raw_bytes, _received_at, _validated_at},
+        state
+      ) do
+    {:noreply, increment_transport_diagnostic(state, :stale_generation)}
+  end
 
-      {:ok, %Response.Notification{} = notification} ->
-        handle_notification(notification, state)
+  def handle_info({:ws_message, _raw_bytes, _frame_received_at}, state) do
+    {:noreply, increment_transport_diagnostic(state, :unstamped_frame)}
+  end
 
-      {:error, _parse_reason} ->
-        handle_non_response_message(raw_bytes, state)
+  def handle_info({:transport_timeout, transport_id, generation, token}, state) do
+    case Map.get(state.transport_pending, transport_id) do
+      %{generation: ^generation, token: ^token, send_state: :tombstone} ->
+        {:noreply, state}
+
+      %{generation: ^generation, token: ^token} = pending ->
+        now_us = System.monotonic_time(:microsecond)
+
+        if now_us < pending.settlement_deadline_us do
+          timer =
+            Process.send_after(
+              self(),
+              {:transport_timeout, transport_id, generation, token},
+              ceil_milliseconds(pending.settlement_deadline_us - now_us)
+            )
+
+          updated = %{pending | timer: timer}
+
+          {:noreply,
+           %{state | transport_pending: Map.put(state.transport_pending, transport_id, updated)}}
+        else
+          case take_eligible_transport_frame(pending, transport_id) do
+            {:ok, parsed, raw_bytes, frame_received_at, validated_at} ->
+              {:noreply,
+               route_ws_message(
+                 state,
+                 pending.connection,
+                 generation,
+                 parsed,
+                 raw_bytes,
+                 frame_received_at,
+                 validated_at
+               )}
+
+            :none ->
+              send(pending.owner, {:ws_transport_timeout, token, generation})
+              {:noreply, retire_transport_send(state, transport_id, pending)}
+          end
+        end
+
+      _ ->
+        {:noreply, state}
     end
+  end
+
+  def handle_info({:DOWN, monitor, :process, owner, _reason}, state) do
+    state =
+      Enum.reduce(state.transport_pending, state, fn {id, entry}, current_state ->
+        if entry.owner_monitor == monitor and entry.owner == owner do
+          retire_transport_send(current_state, id, entry)
+        else
+          current_state
+        end
+      end)
+
+    state =
+      Enum.reduce(state.pending_requests, state, fn {id, entry}, current_state ->
+        if entry.owner_monitor == monitor and entry.owner == owner do
+          retire_legacy_send(current_state, id, entry)
+        else
+          current_state
+        end
+      end)
+
+    {:noreply, state}
   end
 
   def handle_info({:ws_error, error}, state) do
@@ -647,6 +1148,17 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     end)
 
     {:noreply, state}
+  end
+
+  def handle_info(
+        {:ws_disconnect_event, connection, generation, disconnect_info},
+        %{connection: connection, connection_id: generation} = state
+      ) do
+    handle_info(disconnect_info, state)
+  end
+
+  def handle_info({:ws_disconnect_event, _connection, _generation, _disconnect_info}, state) do
+    {:noreply, increment_transport_diagnostic(state, :stale_generation)}
   end
 
   def handle_info({:ws_disconnect, :close_frame, _code, _reason}, %{connected: false} = state) do
@@ -678,7 +1190,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
         state
       end
 
-    had_pending = map_size(state.pending_requests) > 0
+    had_pending = active_pending?(state)
 
     jerr =
       ErrorNormalizer.normalize({:ws_close, code, reason},
@@ -707,7 +1219,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     end
 
     # Clean up any pending requests
-    pending_count = map_size(state.pending_requests)
+    pending_count = total_pending_count(state)
     state = cleanup_pending_requests(state, jerr)
     state = %{state | connected: false, connection: nil, connection_stable: false}
 
@@ -729,18 +1241,13 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
     jerr_with_penalty = %{jerr | breaker_penalty?: should_penalize and jerr.breaker_penalty?}
 
-    # Record failure to circuit breaker synchronously when penalizing
-    # This prevents hammering providers that accept connections but immediately drop them
     circuit_state =
       if should_penalize do
         breaker_id = {state.instance_id, :ws}
 
-        case CircuitBreaker.record_failure_sync(breaker_id, jerr_with_penalty) do
-          {:ok, state} -> state
-          {:error, _} -> :closed
-        end
+        CircuitBreaker.report_external_bounded(breaker_id, {:error, jerr_with_penalty})
       else
-        :closed
+        :not_penalized
       end
 
     Logger.debug("Circuit breaker state after close frame",
@@ -788,7 +1295,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
           state
         end
 
-      had_pending = map_size(state.pending_requests) > 0
+      had_pending = active_pending?(state)
 
       jerr =
         ErrorNormalizer.normalize({:ws_disconnect, reason},
@@ -802,7 +1309,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       )
 
       # Clean up any pending requests
-      pending_count = map_size(state.pending_requests)
+      pending_count = total_pending_count(state)
       state = cleanup_pending_requests(state, jerr)
       state = %{state | connected: false, connection: nil, connection_stable: false}
 
@@ -824,20 +1331,15 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       # Unexpected disconnects always warrant circuit breaker penalty
       jerr_with_penalty = %{jerr | breaker_penalty?: true}
 
-      Logger.debug("Recording circuit breaker failure (sync)",
+      Logger.debug("Enqueuing circuit breaker failure",
         provider_id: state.endpoint.id,
         breaker_penalty: jerr_with_penalty.breaker_penalty?
       )
 
-      # Record failure to circuit breaker synchronously
-      # This ensures the circuit state is updated before we schedule reconnect
       breaker_id = {state.instance_id, :ws}
 
       circuit_state =
-        case CircuitBreaker.record_failure_sync(breaker_id, jerr_with_penalty) do
-          {:ok, state} -> state
-          {:error, _} -> :closed
-        end
+        CircuitBreaker.report_external_bounded(breaker_id, {:error, jerr_with_penalty})
 
       Logger.debug("Circuit breaker state after disconnect",
         provider_id: state.endpoint.id,
@@ -860,59 +1362,20 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
   def handle_info(
         {:heartbeat},
-        %{connected: true, connection: connection, endpoint: endpoint} = state
+        %{connected: true, endpoint: endpoint} = state
       ) do
-    case send_frame(connection, :ping) do
-      :ok ->
-        # Emit telemetry event
-        :telemetry.execute(
-          [:lasso, :websocket, :heartbeat, :sent],
-          %{},
-          %{
-            provider_id: endpoint.id
-          }
-        )
+    case enqueue_control_send(state, :heartbeat, :ping, control_send_timeout_ms()) do
+      {:ok, state} ->
+        {:noreply, %{state | heartbeat_ref: nil}}
 
-        state = schedule_heartbeat(state)
-        {:noreply, state}
-
-      {:error, :timeout} ->
-        Logger.warning(
-          "Heartbeat ping timeout for #{endpoint.id} - connection appears hung, reconnecting"
-        )
-
-        # Emit telemetry event
+      {:error, reason, state} ->
         :telemetry.execute(
           [:lasso, :websocket, :heartbeat, :failed],
           %{},
-          %{
-            provider_id: endpoint.id,
-            reason: :timeout
-          }
+          %{provider_id: endpoint.id, reason: reason}
         )
 
-        # Connection is hung - treat as disconnect and reconnect
-        jerr =
-          JError.new(-32_000, "Heartbeat timeout",
-            provider_id: endpoint.id,
-            retriable?: true
-          )
-
-        state = cleanup_pending_requests(state, jerr)
-        state = %{state | connected: false, connection: nil}
-
-        broadcast_conn_event(state, fn provider_id ->
-          {:ws_disconnected, provider_id, jerr}
-        end)
-
-        state = schedule_reconnect(state)
-        write_ws_status(state.instance_id, :disconnected, state.reconnect_attempts)
-        {:noreply, state}
-
-      {:error, reason} ->
-        Logger.debug("Heartbeat ping failed for #{endpoint.id}: #{inspect(reason)}")
-
-        {:noreply, state}
+        {:noreply, schedule_heartbeat(%{state | heartbeat_ref: nil})}
     end
   end
 
@@ -920,38 +1383,87 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     {:noreply, state}
   end
 
-  def handle_info({:request_timeout, request_id}, state) do
-    case Map.pop(state.pending_requests, request_id) do
-      {nil, _} ->
+  def handle_info({:control_send_timeout, token, generation}, state) do
+    case Map.get(state.control_sends, token) do
+      %{generation: ^generation} = control ->
+        _ = cancel_latch(control.cancel_latch)
+        control = %{control | send_state: :tombstone}
+        state = put_in(state, [:control_sends, token], control)
+
+        if control.kind == :heartbeat and is_pid(state.connection) do
+          Process.exit(state.connection, :kill)
+        end
+
         {:noreply, state}
 
-      {%{from: from, sent_at: sent_at, method: method}, new_pending} ->
-        timeout_ms = div(System.monotonic_time(:microsecond) - sent_at, 1000)
+      _missing_or_stale ->
+        {:noreply, state}
+    end
+  end
 
-        # Emit telemetry event
-        :telemetry.execute(
-          [:lasso, :websocket, :request, :timeout],
-          %{
-            timeout_ms: timeout_ms
-          },
-          %{
-            provider_id: state.endpoint.id,
-            method: method,
-            request_id: request_id
-          }
-        )
+  def handle_info(
+        {:send_cleanup_expired, connection, generation, send_key, token, cleanup_expiry_us},
+        state
+      ) do
+    {:noreply,
+     expire_send_tombstone(
+       state,
+       connection,
+       generation,
+       send_key,
+       token,
+       cleanup_expiry_us
+     )}
+  end
 
-        GenServer.reply(
-          from,
-          {:error,
-           JError.new(-32_000, "WebSocket request timeout",
-             category: :timeout,
-             retriable?: true,
-             provider_id: state.endpoint.id
-           )}
-        )
+  def handle_info({:request_timeout, request_id, generation, token}, state) do
+    case Map.get(state.pending_requests, request_id) do
+      nil ->
+        {:noreply, state}
 
-        {:noreply, %{state | pending_requests: new_pending}}
+      %{generation: ^generation, token: ^token, send_state: :tombstone} ->
+        {:noreply, state}
+
+      %{generation: ^generation, token: ^token} = pending ->
+        now_us = System.monotonic_time(:microsecond)
+
+        if now_us < pending.deadline_us do
+          timer =
+            Process.send_after(
+              self(),
+              {:request_timeout, request_id, generation, token},
+              ceil_milliseconds(pending.deadline_us - now_us)
+            )
+
+          {:noreply, put_in(state, [:pending_requests, request_id, :timer], timer)}
+        else
+          timeout_ms = div(now_us - pending.sent_at, 1000)
+
+          :telemetry.execute(
+            [:lasso, :websocket, :request, :timeout],
+            %{timeout_ms: timeout_ms},
+            %{
+              provider_id: state.endpoint.id,
+              method: pending.method,
+              request_id: request_id
+            }
+          )
+
+          GenServer.reply(
+            pending.from,
+            {:error,
+             JError.new(-32_000, "WebSocket request timeout",
+               category: :timeout,
+               retriable?: true,
+               provider_id: state.endpoint.id
+             )}
+          )
+
+          {:noreply, retire_legacy_send(state, request_id, pending)}
+        end
+
+      _stale_timer ->
+        {:noreply, state}
     end
   end
 
@@ -1022,7 +1534,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
         state
       end
 
-    had_pending = map_size(state.pending_requests) > 0
+    had_pending = active_pending?(state)
 
     jerr =
       ErrorNormalizer.normalize({:ws_exit, reason},
@@ -1036,7 +1548,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     )
 
     # Clean up pending requests
-    pending_count = map_size(state.pending_requests)
+    pending_count = total_pending_count(state)
     state = cleanup_pending_requests(state, jerr)
     state = %{state | connected: false, connection: nil, connection_stable: false}
 
@@ -1059,10 +1571,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     breaker_id = {state.instance_id, :ws}
 
     circuit_state =
-      case CircuitBreaker.record_failure_sync(breaker_id, jerr_with_penalty) do
-        {:ok, cb_state} -> cb_state
-        {:error, _} -> :closed
-      end
+      CircuitBreaker.report_external_bounded(breaker_id, {:error, jerr_with_penalty})
 
     Logger.debug("Circuit breaker state after WebSockex exit",
       provider_id: state.endpoint.id,
@@ -1148,29 +1657,33 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   # Private functions
 
   defp handle_response_success(id, resp, state) do
-    case Map.pop(state.pending_requests, id) do
-      {nil, _pending} ->
+    case Map.get(state.pending_requests, id) do
+      nil ->
         {:noreply, state}
 
-      {%{from: from, timer: timer, sent_at: sent_at, method: method}, new_pending} ->
-        Process.cancel_timer(timer)
-        duration_ms = div(System.monotonic_time(:microsecond) - sent_at, 1000)
+      %{send_state: :tombstone} = pending ->
+        {:noreply, remove_legacy_pending(state, id, pending)}
 
-        emit_completion_telemetry(state.endpoint.id, method, id, :success, duration_ms)
-        GenServer.reply(from, {:ok, resp})
+      pending ->
+        duration_ms = div(System.monotonic_time(:microsecond) - pending.sent_at, 1000)
 
-        {:noreply, %{state | pending_requests: new_pending}}
+        emit_completion_telemetry(state.endpoint.id, pending.method, id, :success, duration_ms)
+        GenServer.reply(pending.from, {:ok, resp})
+
+        {:noreply, remove_legacy_pending(state, id, pending)}
     end
   end
 
   defp handle_response_error(id, jerr, state) do
-    case Map.pop(state.pending_requests, id) do
-      {nil, _pending} ->
+    case Map.get(state.pending_requests, id) do
+      nil ->
         {:noreply, state}
 
-      {%{from: from, timer: timer, sent_at: sent_at, method: method}, new_pending} ->
-        Process.cancel_timer(timer)
-        duration_ms = div(System.monotonic_time(:microsecond) - sent_at, 1000)
+      %{send_state: :tombstone} = pending ->
+        {:noreply, remove_legacy_pending(state, id, pending)}
+
+      pending ->
+        duration_ms = div(System.monotonic_time(:microsecond) - pending.sent_at, 1000)
 
         %{category: category, retriable?: retriable?, breaker_penalty?: breaker_penalty?} =
           ErrorClassifier.classify(jerr.code, jerr.message,
@@ -1187,10 +1700,10 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
             breaker_penalty?: breaker_penalty?
         }
 
-        emit_completion_telemetry(state.endpoint.id, method, id, :error, duration_ms)
-        GenServer.reply(from, {:error, enriched})
+        emit_completion_telemetry(state.endpoint.id, pending.method, id, :error, duration_ms)
+        GenServer.reply(pending.from, {:error, enriched})
 
-        {:noreply, %{state | pending_requests: new_pending}}
+        {:noreply, remove_legacy_pending(state, id, pending)}
     end
   end
 
@@ -1246,7 +1759,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   defp normalize_connect_error(other, endpoint_id),
     do: JError.from(other, provider_id: endpoint_id)
 
-  defp connect_to_websocket(endpoint, parent_pid) do
+  defp connect_to_websocket(endpoint, parent_pid, connection_generation) do
     # Start a separate WebSocket handler process
     # Pass connection_id in opts for test-mode failure injection (MockWSClient)
     # WebSockex ignores unknown opts, so this is safe for production
@@ -1255,7 +1768,11 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
     case ws_client().start_link(
            endpoint.ws_url,
            Lasso.RPC.Transport.WebSocket.Handler,
-           %{endpoint: endpoint, parent: parent_pid},
+           %{
+             endpoint: endpoint,
+             parent: parent_pid,
+             connection_generation: connection_generation
+           },
            opts
          ) do
       {:ok, pid} ->
@@ -1291,8 +1808,8 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   end
 
   defp schedule_reconnect_with_circuit_check(state) do
-    case CircuitBreaker.get_state({state.instance_id, :ws}) do
-      %{state: :open} ->
+    case Snapshot.lookup({state.instance_id, :ws}) do
+      {:ok, %Snapshot{state: :open}} ->
         # Circuit is open - use longer delay before next reconnect attempt
         Logger.debug("Circuit breaker open for #{state.endpoint.id}, delaying reconnect")
 
@@ -1427,7 +1944,7 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
   end
 
   defp cleanup_pending_requests(state, error) do
-    pending_count = map_size(state.pending_requests)
+    pending_count = total_pending_count(state)
 
     if pending_count > 0 do
       # Emit telemetry for production visibility (metrics)
@@ -1443,15 +1960,495 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       )
 
       Enum.each(state.pending_requests, fn {_id, req_info} ->
-        Process.cancel_timer(req_info.timer)
-        GenServer.reply(req_info.from, {:error, error})
+        _ = cancel_latch(req_info.cancel_latch)
+        cleanup_send_entry(req_info)
+
+        if req_info.send_state != :tombstone do
+          GenServer.reply(req_info.from, {:error, error})
+        end
       end)
 
-      %{state | pending_requests: %{}}
+      state
+      |> Map.put(:pending_requests, %{})
+      |> cleanup_transport_pending(error)
+      |> cleanup_control_sends()
     else
       state
+      |> cleanup_transport_pending(error)
+      |> cleanup_control_sends()
     end
   end
+
+  defp cleanup_transport_pending(state, error) do
+    Enum.each(state.transport_pending, fn {_id, pending} ->
+      _ = cancel_latch(pending.cancel_latch)
+      cleanup_send_entry(pending)
+
+      if pending.send_state != :tombstone do
+        send(
+          pending.owner,
+          {:ws_transport_disconnected, pending.token, pending.generation, error}
+        )
+      end
+    end)
+
+    %{state | transport_pending: %{}}
+  end
+
+  defp route_ws_message(
+         state,
+         connection,
+         generation,
+         parsed,
+         raw_bytes,
+         frame_received_at,
+         validated_at
+       )
+       when is_binary(raw_bytes) and is_integer(frame_received_at) and is_integer(validated_at) do
+    case parsed do
+      {:transport, %Validated{id: transport_id} = validated} ->
+        route_transport_id(
+          state,
+          connection,
+          generation,
+          transport_id,
+          {:ok, validated},
+          raw_bytes,
+          frame_received_at,
+          validated_at
+        )
+
+      {:transport_invalid, transport_id, reason} ->
+        route_transport_id(
+          state,
+          connection,
+          generation,
+          transport_id,
+          {:invalid, reason},
+          raw_bytes,
+          frame_received_at,
+          validated_at
+        )
+
+      :legacy ->
+        legacy_ws_state(raw_bytes, state)
+
+      {:unattributable, _reason} ->
+        increment_transport_diagnostic(state, :unattributable_frame)
+    end
+  end
+
+  defp route_ws_message(
+         state,
+         _connection,
+         _generation,
+         _parsed,
+         _raw_bytes,
+         _frame_received_at,
+         _validated_at
+       ),
+       do: increment_transport_diagnostic(state, :invalid_frame_stamp)
+
+  defp route_transport_id(
+         state,
+         connection,
+         generation,
+         transport_id,
+         validation,
+         raw_bytes,
+         frame_received_at,
+         validated_at
+       ) do
+    case Map.get(state.transport_pending, transport_id) do
+      %{
+        generation: ^generation,
+        connection: ^connection,
+        send_state: send_state
+      } = pending
+      when send_state != :tombstone ->
+        cleanup_send_entry(pending)
+
+        send(
+          pending.owner,
+          {:ws_transport_response, pending.token, generation, connection, validation, raw_bytes,
+           frame_received_at, validated_at}
+        )
+
+        %{state | transport_pending: Map.delete(state.transport_pending, transport_id)}
+
+      %{generation: ^generation, connection: ^connection} = pending ->
+        state
+        |> remove_transport_entry(transport_id, pending)
+        |> increment_transport_diagnostic(:late_or_uncorrelated_response)
+
+      _missing_or_stale ->
+        increment_transport_diagnostic(state, :late_or_uncorrelated_response)
+    end
+  end
+
+  defp legacy_ws_state(raw_bytes, state) do
+    case handle_legacy_ws_message(raw_bytes, state) do
+      {:noreply, new_state} -> new_state
+    end
+  end
+
+  defp take_eligible_transport_frame(pending, transport_id) do
+    connection = pending.connection
+    generation = pending.generation
+    decision_deadline_us = pending.decision_deadline_us
+
+    receive do
+      {:ws_message, ^connection, ^generation,
+       {:transport, %Validated{id: ^transport_id}} = parsed, raw_bytes, frame_received_at,
+       validated_at}
+      when is_binary(raw_bytes) and is_integer(frame_received_at) and is_integer(validated_at) and
+             validated_at < decision_deadline_us ->
+        {:ok, parsed, raw_bytes, frame_received_at, validated_at}
+
+      {:ws_message, ^connection, ^generation,
+       {:transport_invalid, ^transport_id, _reason} = parsed, raw_bytes, frame_received_at,
+       validated_at}
+      when is_binary(raw_bytes) and is_integer(frame_received_at) and is_integer(validated_at) and
+             validated_at < decision_deadline_us ->
+        {:ok, parsed, raw_bytes, frame_received_at, validated_at}
+    after
+      0 -> :none
+    end
+  end
+
+  defp increment_transport_diagnostic(state, reason) do
+    diagnostics =
+      Map.update(state.transport_diagnostics, reason, 1, fn count ->
+        min(count + 1, @max_diagnostic_count)
+      end)
+
+    %{state | transport_diagnostics: diagnostics}
+  end
+
+  defp transport_id_for_generation?(transport_id, generation)
+       when is_binary(transport_id) and is_binary(generation) do
+    UpstreamResponse.transport_id?(transport_id) and
+      String.starts_with?(transport_id, "lasso-#{generation}-")
+  end
+
+  defp transport_id_for_generation?(_transport_id, _generation), do: false
+
+  defp ceil_milliseconds(remaining_us) when remaining_us > 0,
+    do: div(remaining_us + 999, 1_000)
+
+  defp ceil_milliseconds(_remaining_us), do: 0
+
+  defp handle_legacy_ws_message(raw_bytes, state) do
+    case Response.from_bytes(raw_bytes) do
+      {:ok, %Response.Success{id: nil}} ->
+        handle_non_response_message(raw_bytes, state)
+
+      {:ok, %Response.Success{id: id} = resp} ->
+        handle_response_success(id, resp, state)
+
+      {:ok, %Response.Error{id: id, error: jerr}} ->
+        handle_response_error(id, jerr, state)
+
+      {:ok, %Response.Notification{} = notification} ->
+        handle_notification(notification, state)
+
+      {:error, _parse_reason} ->
+        handle_non_response_message(raw_bytes, state)
+    end
+  end
+
+  defp cancel_transport_by_key(state, transport_id, generation, token) do
+    case Map.get(state.transport_pending, transport_id) do
+      %{generation: ^generation, token: ^token} = pending ->
+        retire_transport_send(state, transport_id, pending)
+
+      _ ->
+        state
+    end
+  end
+
+  defp cancel_registered_transport(state, transport_id, pending) do
+    _ = cancel_latch(pending.cancel_latch)
+    remove_transport_entry(state, transport_id, pending)
+  end
+
+  defp retire_transport_send(state, transport_id, %{send_state: :registered} = pending),
+    do: cancel_registered_transport(state, transport_id, pending)
+
+  defp retire_transport_send(state, transport_id, %{send_state: :queued} = pending) do
+    case cancel_latch(pending.cancel_latch) do
+      :cancelled ->
+        cleanup_send_entry(pending)
+
+        put_in(
+          state,
+          [:transport_pending, transport_id],
+          tombstone(pending, {:transport, transport_id})
+        )
+
+      :accepted ->
+        remove_transport_entry(state, transport_id, pending)
+    end
+  end
+
+  defp retire_transport_send(state, transport_id, pending),
+    do: remove_transport_entry(state, transport_id, pending)
+
+  defp retire_legacy_send(state, request_id, %{send_state: :queued} = pending) do
+    case cancel_latch(pending.cancel_latch) do
+      :cancelled ->
+        cleanup_send_entry(pending)
+
+        put_in(
+          state,
+          [:pending_requests, request_id],
+          tombstone(pending, {:legacy, request_id})
+        )
+
+      :accepted ->
+        remove_legacy_pending(state, request_id, pending)
+    end
+  end
+
+  defp retire_legacy_send(state, request_id, pending),
+    do: remove_legacy_pending(state, request_id, pending)
+
+  defp tombstone(pending, send_key) do
+    cleanup_expiry_us =
+      System.monotonic_time(:microsecond) + send_cleanup_ms() * 1_000
+
+    cleanup_timer =
+      Process.send_after(
+        self(),
+        {:send_cleanup_expired, pending.connection, pending.generation, send_key, pending.token,
+         cleanup_expiry_us},
+        send_cleanup_ms()
+      )
+
+    Map.merge(pending, %{
+      from: nil,
+      owner: nil,
+      owner_monitor: nil,
+      timer: cleanup_timer,
+      cleanup_expiry_us: cleanup_expiry_us,
+      send_state: :tombstone
+    })
+  end
+
+  defp expire_send_tombstone(
+         state,
+         connection,
+         generation,
+         send_key,
+         token,
+         cleanup_expiry_us
+       ) do
+    case tombstone_entry(state, send_key) do
+      %{
+        connection: ^connection,
+        generation: ^generation,
+        token: ^token,
+        cleanup_expiry_us: ^cleanup_expiry_us,
+        send_state: :tombstone
+      } = pending ->
+        now_us = System.monotonic_time(:microsecond)
+
+        if now_us < cleanup_expiry_us do
+          timer =
+            Process.send_after(
+              self(),
+              {:send_cleanup_expired, connection, generation, send_key, token, cleanup_expiry_us},
+              ceil_milliseconds(cleanup_expiry_us - now_us)
+            )
+
+          put_tombstone_entry(state, send_key, %{pending | timer: timer})
+        else
+          terminate_connection_generation(state, connection, generation)
+        end
+
+      _missing_or_stale ->
+        state
+    end
+  end
+
+  defp tombstone_entry(state, {:transport, transport_id}),
+    do: Map.get(state.transport_pending, transport_id)
+
+  defp tombstone_entry(state, {:legacy, request_id}),
+    do: Map.get(state.pending_requests, request_id)
+
+  defp put_tombstone_entry(state, {:transport, transport_id}, pending),
+    do: put_in(state, [:transport_pending, transport_id], pending)
+
+  defp put_tombstone_entry(state, {:legacy, request_id}, pending),
+    do: put_in(state, [:pending_requests, request_id], pending)
+
+  defp terminate_connection_generation(
+         %{connection: connection, connection_id: generation} = state,
+         connection,
+         generation
+       )
+       when is_pid(connection) do
+    Process.exit(connection, :kill)
+    increment_transport_diagnostic(state, :send_cleanup_expired)
+  end
+
+  defp terminate_connection_generation(state, _connection, _generation), do: state
+
+  defp remove_transport_entry(state, transport_id, pending) do
+    cleanup_send_entry(pending)
+    %{state | transport_pending: Map.delete(state.transport_pending, transport_id)}
+  end
+
+  defp remove_legacy_pending(state, request_id, pending) do
+    cleanup_send_entry(pending)
+    %{state | pending_requests: Map.delete(state.pending_requests, request_id)}
+  end
+
+  defp cleanup_send_entry(pending) do
+    if is_reference(pending[:timer]), do: Process.cancel_timer(pending.timer)
+
+    if is_reference(pending[:owner_monitor]),
+      do: Process.demonitor(pending.owner_monitor, [:flush])
+  end
+
+  defp cancel_latch(latch) do
+    case :atomics.compare_exchange(latch, 1, 0, 1) do
+      value when value in [:ok, 0, 1] -> :cancelled
+      2 -> :accepted
+    end
+  rescue
+    ArgumentError -> :cancelled
+  end
+
+  defp cast_send(state, send_key, deadline_us, cancel_latch, frame) do
+    ws_client().cast(
+      state.connection,
+      {:send_if_live, state.connection_id, send_key, deadline_us, cancel_latch, frame}
+    )
+  catch
+    :exit, _reason -> {:error, :connection_down}
+  end
+
+  defp enqueue_control_send(state, kind, frame, timeout_ms) do
+    cond do
+      not state.connected or not is_pid(state.connection) ->
+        {:error, :not_connected, state}
+
+      send_capacity_used(state) >= state.transport_pending_limit ->
+        {:error, :capacity, state}
+
+      true ->
+        token = make_ref()
+        latch = :atomics.new(1, signed: false)
+        deadline_us = System.monotonic_time(:microsecond) + timeout_ms * 1_000
+
+        timer =
+          Process.send_after(
+            self(),
+            {:control_send_timeout, token, state.connection_id},
+            timeout_ms
+          )
+
+        control = %{
+          kind: kind,
+          generation: state.connection_id,
+          cancel_latch: latch,
+          timer: timer,
+          send_state: :queued
+        }
+
+        state = put_in(state, [:control_sends, token], control)
+
+        case cast_send(state, {:control, token}, deadline_us, latch, frame) do
+          :ok -> {:ok, state}
+          {:error, reason} -> {:error, reason, remove_control_send(state, token, control)}
+        end
+    end
+  end
+
+  defp remove_control_send(state, token, control) do
+    if is_reference(control.timer), do: Process.cancel_timer(control.timer)
+    %{state | control_sends: Map.delete(state.control_sends, token)}
+  end
+
+  defp cleanup_control_sends(state) do
+    Enum.each(state.control_sends, fn {_token, control} ->
+      _ = cancel_latch(control.cancel_latch)
+      if is_reference(control.timer), do: Process.cancel_timer(control.timer)
+    end)
+
+    %{state | control_sends: %{}}
+  end
+
+  defp handle_control_decision(state, %{kind: :heartbeat}, :accepted) do
+    :telemetry.execute(
+      [:lasso, :websocket, :heartbeat, :sent],
+      %{},
+      %{provider_id: state.endpoint.id}
+    )
+
+    schedule_heartbeat(state)
+  end
+
+  defp handle_control_decision(state, %{kind: :heartbeat}, {:rejected, reason}) do
+    :telemetry.execute(
+      [:lasso, :websocket, :heartbeat, :failed],
+      %{},
+      %{provider_id: state.endpoint.id, reason: reason}
+    )
+
+    schedule_heartbeat(state)
+  end
+
+  defp handle_control_decision(state, _control, _decision), do: state
+
+  defp count_send_state(pending, send_state) do
+    Enum.count(pending, fn {_id, entry} -> entry.send_state == send_state end)
+  end
+
+  defp send_capacity_used(state) do
+    map_size(state.pending_requests) + map_size(state.transport_pending) +
+      map_size(state.control_sends)
+  end
+
+  defp control_send_timeout_ms do
+    case Application.get_env(:lasso, :ws_control_send_timeout_ms, 5_000) do
+      timeout when is_integer(timeout) and timeout > 0 -> timeout
+      _invalid -> 5_000
+    end
+  end
+
+  defp send_cleanup_ms do
+    case Application.get_env(:lasso, :ws_send_cleanup_ms, @default_send_cleanup_ms) do
+      timeout when is_integer(timeout) and timeout >= 0 -> timeout
+      _invalid -> @default_send_cleanup_ms
+    end
+  end
+
+  defp capacity_error(state) do
+    JError.new(-32_008, "WebSocket pending capacity exhausted",
+      provider_id: state.endpoint.id,
+      retriable?: true,
+      breaker_penalty?: false,
+      category: :local_capacity_rejection
+    )
+  end
+
+  defp cancelled_request_error(state) do
+    JError.new(-32_008, "WebSocket request cancelled before dispatch",
+      provider_id: state.endpoint.id,
+      retriable?: true,
+      breaker_penalty?: false,
+      category: :local_capacity_rejection
+    )
+  end
+
+  defp active_pending?(state) do
+    total_pending_count(state) > 0
+  end
+
+  defp total_pending_count(state), do: send_capacity_used(state)
 
   # Provider-emitted JSON-RPC error without correlation id -> treat as connection-level
   defp handle_websocket_message(
@@ -1474,11 +2471,21 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
       end)
 
       # Proactively close on timeout-like provider errors to force clean reconnect
-      if (is_integer(code) and code == -32_701) or
-           (is_binary(msg) and String.contains?(String.downcase(msg), "timeout")) do
-        # Ignore result - best effort close
-        _ = send_frame(state.connection, {:close, 1013, "connection timeout"})
-      end
+      state =
+        if (is_integer(code) and code == -32_701) or
+             (is_binary(msg) and String.contains?(String.downcase(msg), "timeout")) do
+          case enqueue_control_send(
+                 state,
+                 :provider_timeout_close,
+                 {:close, 1013, "connection timeout"},
+                 control_send_timeout_ms()
+               ) do
+            {:ok, state} -> state
+            {:error, _reason, state} -> state
+          end
+        else
+          state
+        end
 
       {:ok, state}
     end
@@ -1631,34 +2638,5 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
 
   defp ws_client do
     Application.get_env(:lasso, :ws_client_module, WebSockex)
-  end
-
-  # Wrapper around ws_client().send_frame that converts exits to error tuples
-  #
-  # WebSockex.send_frame normally returns:
-  #   :ok | {:error, %WebSockex.FrameEncodeError{} | %WebSockex.ConnError{} |
-  #                   %WebSockex.NotConnectedError{} | %WebSockex.InvalidFrameError{}}
-  #
-  # But it uses :gen.call internally (with 5s timeout), which can exit if:
-  #   - Process is hung/unresponsive (timeout)
-  #   - Process died (noproc)
-  #   - Process crashed
-  #
-  # This wrapper catches those exits and converts them to {:error, reason} tuples
-  # for consistent error handling.
-  defp send_frame(connection, frame) do
-    ws_client().send_frame(connection, frame)
-  catch
-    # Process is hung/unresponsive - :gen.call timed out (default 5s)
-    :exit, {:timeout, _call_info} ->
-      {:error, :timeout}
-
-    # Process died or noproc
-    :exit, {:noproc, _call_info} ->
-      {:error, :noproc}
-
-    # Other exit reasons (process crash, etc.)
-    :exit, {reason, _call_info} ->
-      {:error, {:exit, reason}}
   end
 end

--- a/lib/lasso/core/transport/websocket/handler.ex
+++ b/lib/lasso/core/transport/websocket/handler.ex
@@ -34,18 +34,23 @@ defmodule Lasso.RPC.Transport.WebSocket.Handler do
   use WebSockex
   require Logger
 
+  alias Lasso.Core.Transport.UpstreamResponse
+
   # WebSockex callbacks
 
   @spec handle_connect(map(), map()) :: {:ok, map()}
   def handle_connect(_conn, state) do
-    send(state.parent, {:ws_connected})
+    send(state.parent, {:ws_connected, self(), state.connection_generation})
     {:ok, state}
   end
 
   @spec handle_frame({:text, String.t()}, map()) :: {:ok, map()}
   def handle_frame({:text, message}, state) do
     received_at = System.monotonic_time(:microsecond)
-    send(state.parent, {:ws_message, message, received_at})
+    parsed = UpstreamResponse.parse_ws_frame(message)
+    validated_at = System.monotonic_time(:microsecond)
+    send_parsed_frame(state, parsed, message, received_at, validated_at)
+
     {:ok, state}
   end
 
@@ -60,6 +65,40 @@ defmodule Lasso.RPC.Transport.WebSocket.Handler do
     Logger.debug("Received pong")
     {:ok, state}
   end
+
+  @spec handle_cast(term(), map()) :: {:ok, map()} | {:reply, WebSockex.frame(), map()}
+  def handle_cast(
+        {:send_if_live, generation, send_key, deadline_us, cancel_latch, frame},
+        state
+      ) do
+    decided_at_us = System.monotonic_time(:microsecond)
+
+    decision =
+      cond do
+        generation != state.connection_generation ->
+          cancel_send(cancel_latch)
+          {:rejected, :stale_generation}
+
+        decided_at_us >= deadline_us ->
+          cancel_send(cancel_latch)
+          {:rejected, :deadline}
+
+        true ->
+          accept_send(cancel_latch)
+      end
+
+    send(
+      state.parent,
+      {:ws_send_decision, self(), state.connection_generation, send_key, decision, decided_at_us}
+    )
+
+    case decision do
+      :accepted -> {:reply, frame, state}
+      {:rejected, _reason} -> {:ok, state}
+    end
+  end
+
+  def handle_cast(_message, state), do: {:ok, state}
 
   # This fires for ALL disconnection events.
   # WebSockex embeds close frame info directly in the reason parameter,
@@ -98,7 +137,36 @@ defmodule Lasso.RPC.Transport.WebSocket.Handler do
           {:ws_disconnect, :error, other}
       end
 
-    send(state.parent, disconnect_info)
+    send(
+      state.parent,
+      {:ws_disconnect_event, self(), state.connection_generation, disconnect_info}
+    )
+
     {:ok, state}
+  end
+
+  defp send_parsed_frame(state, parsed, message, received_at, validated_at) do
+    send(
+      state.parent,
+      {:ws_message, self(), state.connection_generation, parsed, message, received_at,
+       validated_at}
+    )
+  end
+
+  defp accept_send(cancel_latch) do
+    case :atomics.compare_exchange(cancel_latch, 1, 0, 2) do
+      value when value in [:ok, 0] -> :accepted
+      1 -> {:rejected, :cancelled}
+      2 -> {:rejected, :already_accepted}
+    end
+  rescue
+    ArgumentError -> {:rejected, :invalid_latch}
+  end
+
+  defp cancel_send(cancel_latch) do
+    _previous = :atomics.compare_exchange(cancel_latch, 1, 0, 1)
+    :ok
+  rescue
+    ArgumentError -> :ok
   end
 end

--- a/lib/lasso/core/transport/websocket/websocket.ex
+++ b/lib/lasso/core/transport/websocket/websocket.ex
@@ -6,12 +6,20 @@ defmodule Lasso.RPC.Transports.WebSocket do
   (single request/response) and streaming subscriptions with proper connection
   management and error normalization. Implements the new Transport behaviour
   for transport-agnostic request routing.
+
+  Outbound frames use a one-way WebSockex cast guarded by the connection
+  generation, absolute decision cutoff, and a shared cancellation latch. Direct
+  `WebSockex.send_frame/2` is not used because its queued `GenServer.call` may
+  send after the waiting task has been cancelled or its deadline has expired.
+  Cast acceptance opens an indeterminate send phase; only a correlated response
+  proves positive dispatch.
   """
 
   @behaviour Lasso.RPC.Transport
 
   require Logger
-  alias Lasso.Core.Support.{AttemptLifecycle, ErrorNormalizer}
+  alias Lasso.Core.Support.{ErrorClassifier, ErrorNormalizer}
+  alias Lasso.Core.Transport.{AttemptProtocol, UpstreamResponse}
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.Catalog
   alias Lasso.RPC.Response
@@ -103,42 +111,368 @@ defmodule Lasso.RPC.Transports.WebSocket do
 
     io_start_us = System.monotonic_time(:microsecond)
 
-    result =
-      case WSConnection.request(
-             instance_id,
-             method,
-             params,
-             timeout,
-             request_id,
-             AttemptLifecycle.dispatch_context()
-           ) do
-        {:ok, result} ->
-          {:ok, result}
+    context = AttemptProtocol.context()
 
-        {:error, %JError{} = jerr} ->
-          {:error, jerr}
+    transport_deadline_us = io_start_us + timeout * 1_000
 
-        {:error, other} ->
-          {:error,
-           ErrorNormalizer.normalize(other,
-             provider_id: provider_id,
-             context: :transport,
-             transport: :ws
-           )}
+    decision_deadline_us =
+      case AttemptProtocol.deadline_us() do
+        nil -> transport_deadline_us
+        decision_deadline_us -> min(decision_deadline_us, transport_deadline_us)
       end
 
-    io_ms = div(System.monotonic_time(:microsecond) - io_start_us, 1000)
+    settlement_deadline_us =
+      case AttemptProtocol.settlement_deadline_us() do
+        nil -> decision_deadline_us
+        lifecycle_settlement_us -> max(decision_deadline_us, lifecycle_settlement_us)
+      end
 
-    :telemetry.execute(
-      [:lasso, :websocket, :request, :io],
-      %{io_ms: io_ms},
-      %{provider_id: provider_id, method: method, request_id: request_id}
-    )
+    result =
+      transport_request(
+        instance_id,
+        provider_id,
+        method,
+        params,
+        request_id,
+        context,
+        decision_deadline_us,
+        settlement_deadline_us
+      )
+
+    io_ms = div(System.monotonic_time(:microsecond) - io_start_us, 1000)
 
     case result do
       {:ok, response} -> {:ok, response, io_ms}
       {:error, reason} -> {:error, reason, io_ms}
     end
+  end
+
+  defp transport_request(
+         instance_id,
+         provider_id,
+         method,
+         params,
+         client_id,
+         context,
+         decision_deadline_us,
+         settlement_deadline_us
+       ) do
+    transport_id = generate_transport_id()
+
+    case Jason.encode(%{
+           "jsonrpc" => "2.0",
+           "id" => transport_id,
+           "method" => method,
+           "params" => params || []
+         }) do
+      {:ok, encoded} ->
+        authorize_transport_request(%{
+          instance_id: instance_id,
+          provider_id: provider_id,
+          transport_id: transport_id,
+          encoded: encoded,
+          client_id: client_id,
+          context: context,
+          decision_deadline_us: decision_deadline_us,
+          settlement_deadline_us: settlement_deadline_us
+        })
+
+      {:error, reason} ->
+        AttemptProtocol.predispatch_failure(context, :encode_error)
+        {:error, normalize_ws_error(reason, provider_id)}
+    end
+  end
+
+  defp authorize_transport_request(%{
+         instance_id: instance_id,
+         provider_id: provider_id,
+         transport_id: transport_id,
+         encoded: encoded,
+         client_id: client_id,
+         context: context,
+         decision_deadline_us: decision_deadline_us,
+         settlement_deadline_us: settlement_deadline_us
+       }) do
+    with true <- AttemptProtocol.authorized?(context, decision_deadline_us),
+         :ok <- AttemptProtocol.send_started(context),
+         send_started_us = System.monotonic_time(:microsecond),
+         true <- send_started_us < decision_deadline_us,
+         {:ok, {connection, generation, token}} <-
+           WSConnection.authorize_transport(
+             instance_id,
+             transport_id,
+             self(),
+             decision_deadline_us,
+             settlement_deadline_us,
+             encoded,
+             call_timeout_ms(decision_deadline_us)
+           ) do
+      await_transport_response(%{
+        token: token,
+        generation: generation,
+        transport_id: transport_id,
+        client_id: client_id,
+        provider_id: provider_id,
+        context: context,
+        deadline_us: decision_deadline_us,
+        started_us: send_started_us,
+        connection: connection
+      })
+    else
+      false ->
+        record_send_failure(context, :deadline)
+        {:error, normalize_start_error(:deadline, provider_id)}
+
+      {:error, :deadline_expired} ->
+        record_send_failure(context, :deadline)
+        {:error, normalize_start_error(:deadline, provider_id)}
+
+      {:error, :owner_down} ->
+        record_send_failure(context, :owner_down)
+        {:error, normalize_start_error(:owner_down, provider_id)}
+
+      {:error, reason} ->
+        record_send_failure(context, reason)
+        {:error, normalize_start_error(reason, provider_id)}
+    end
+  end
+
+  defp normalize_start_error(:owner_down, provider_id) do
+    JError.new(-32_000, "WebSocket attempt owner ended before send",
+      provider_id: provider_id,
+      transport: :ws,
+      category: :cancelled,
+      retriable?: false,
+      breaker_penalty?: false
+    )
+  end
+
+  defp normalize_start_error(reason, provider_id), do: normalize_ws_error(reason, provider_id)
+
+  defp await_transport_response(%{
+         token: token,
+         generation: generation,
+         transport_id: transport_id,
+         client_id: client_id,
+         provider_id: provider_id,
+         context: context,
+         deadline_us: deadline_us,
+         started_us: started_us,
+         connection: connection
+       }) do
+    receive do
+      {:ws_transport_send_accepted, ^token, ^generation, accepted_at_us} ->
+        await_transport_response(%{
+          token: token,
+          generation: generation,
+          transport_id: transport_id,
+          client_id: client_id,
+          provider_id: provider_id,
+          context: context,
+          deadline_us: deadline_us,
+          started_us: accepted_at_us,
+          connection: connection
+        })
+
+      {:ws_transport_send_rejected, ^token, ^generation, reason} ->
+        record_send_failure(context, reason)
+        {:error, normalize_start_error(reason, provider_id)}
+
+      {:ws_transport_response, ^token, ^generation, ^connection, validation, raw_bytes,
+       received_at_us, validated_at_us}
+      when validated_at_us < deadline_us ->
+        io_duration_us = max(received_at_us - started_us, 0)
+
+        settle_validated_response(%{
+          validation: validation,
+          raw_bytes: raw_bytes,
+          transport_id: transport_id,
+          client_id: client_id,
+          context: context,
+          provider_id: provider_id,
+          io_duration_us: io_duration_us,
+          validated_at_us: validated_at_us
+        })
+
+      {:ws_transport_response, ^token, ^generation, ^connection, _validation, _raw_bytes,
+       _received_at_us, _validated_at_us} ->
+        AttemptProtocol.terminal(context, :transport_failure, %{
+          reason: :timeout,
+          certainty: :dispatched
+        })
+
+        {:error, normalize_ws_error(:timeout, provider_id)}
+
+      {:ws_transport_timeout, ^token, ^generation} ->
+        AttemptProtocol.terminal(context, :transport_failure, %{
+          reason: :timeout,
+          certainty: :indeterminate
+        })
+
+        {:error, normalize_ws_error(:timeout, provider_id)}
+
+      {:ws_transport_disconnected, ^token, ^generation, reason} ->
+        AttemptProtocol.terminal(context, :transport_failure, %{
+          reason: :connection_error,
+          certainty: :indeterminate
+        })
+
+        {:error, normalize_ws_error(reason, provider_id)}
+    end
+  end
+
+  defp settle_validated_response(%{
+         validation: validation,
+         raw_bytes: raw_bytes,
+         transport_id: transport_id,
+         client_id: client_id,
+         context: context,
+         provider_id: provider_id,
+         io_duration_us: io_duration_us,
+         validated_at_us: validated_at_us
+       }) do
+    finalized =
+      case validation do
+        {:ok, validated} ->
+          UpstreamResponse.finalize_unary(validated, raw_bytes, transport_id, client_id)
+
+        {:invalid, reason} ->
+          {:invalid, reason}
+      end
+
+    case finalized do
+      {:ok, response} ->
+        AttemptProtocol.terminal_at(
+          context,
+          :response,
+          %{response_kind: :success, io_duration_us: io_duration_us},
+          validated_at_us
+        )
+
+        {:ok, response}
+
+      {:error, %JError{} = error} ->
+        %{category: category, retriable?: retriable?, breaker_penalty?: breaker_penalty?} =
+          ErrorClassifier.classify(error.code, error.message,
+            data: error.data,
+            provider_id: provider_id
+          )
+
+        AttemptProtocol.terminal_at(
+          context,
+          :response,
+          %{
+            response_kind: :error,
+            error_code: error.code,
+            error_category: category,
+            io_duration_us: io_duration_us
+          },
+          validated_at_us
+        )
+
+        {:error,
+         %{
+           error
+           | provider_id: provider_id,
+             transport: :ws,
+             category: category,
+             retriable?: retriable?,
+             breaker_penalty?: breaker_penalty?
+         }}
+
+      {:invalid, reason} ->
+        AttemptProtocol.terminal_at(
+          context,
+          :invalid_response,
+          %{reason: reason, io_duration_us: io_duration_us},
+          validated_at_us
+        )
+
+        {:error,
+         JError.new(-32_700, "Invalid JSON-RPC response",
+           provider_id: provider_id,
+           transport: :ws,
+           category: :server_error,
+           retriable?: true,
+           breaker_penalty?: true,
+           data: %{reason: reason}
+         )}
+    end
+  end
+
+  defp send_error_certainty(:deadline), do: :not_dispatched
+  defp send_error_certainty(:owner_down), do: :not_dispatched
+  defp send_error_certainty(:cancelled), do: :not_dispatched
+  defp send_error_certainty(:stale_generation), do: :not_dispatched
+  defp send_error_certainty(:stale_connection), do: :not_dispatched
+  defp send_error_certainty(:invalid_latch), do: :not_dispatched
+  defp send_error_certainty(:capacity), do: :not_dispatched
+  defp send_error_certainty(:not_connected), do: :not_dispatched
+  defp send_error_certainty(:duplicate_transport_id), do: :not_dispatched
+  defp send_error_certainty(:invalid_transport_id), do: :not_dispatched
+  defp send_error_certainty(_reason), do: :indeterminate
+
+  defp ws_reason(:deadline), do: :deadline
+  defp ws_reason(:owner_down), do: :cancelled
+  defp ws_reason(:cancelled), do: :cancelled
+  defp ws_reason(:stale_generation), do: :stale_connection
+  defp ws_reason(:stale_connection), do: :stale_connection
+  defp ws_reason(:not_connected), do: :not_connected
+  defp ws_reason(_reason), do: :send_error
+
+  defp record_send_failure(context, reason) do
+    case send_error_certainty(reason) do
+      :not_dispatched ->
+        AttemptProtocol.predispatch_failure(context, ws_reason(reason))
+
+      certainty ->
+        AttemptProtocol.terminal(context, :transport_failure, %{
+          reason: ws_reason(reason),
+          certainty: certainty
+        })
+    end
+  end
+
+  defp normalize_ws_error(:capacity, provider_id) do
+    JError.new(-32_008, "WebSocket transport admission unavailable",
+      provider_id: provider_id,
+      transport: :ws,
+      category: :local_capacity_rejection,
+      retriable?: true,
+      breaker_penalty?: false,
+      data: %{reason: :capacity}
+    )
+  end
+
+  defp normalize_ws_error(:deadline, provider_id),
+    do:
+      ErrorNormalizer.normalize(:timeout,
+        provider_id: provider_id,
+        context: :transport,
+        transport: :ws
+      )
+
+  defp normalize_ws_error(reason, provider_id) do
+    ErrorNormalizer.normalize(reason,
+      provider_id: provider_id,
+      context: :transport,
+      transport: :ws
+    )
+  end
+
+  defp call_timeout_ms(deadline_us) do
+    case remaining_us(deadline_us) do
+      0 -> 0
+      remaining_us -> div(remaining_us + 999, 1_000)
+    end
+  end
+
+  defp remaining_us(deadline_us),
+    do: max(deadline_us - System.monotonic_time(:microsecond), 0)
+
+  defp generate_transport_id do
+    sequence = System.unique_integer([:positive, :monotonic])
+    "lasso-#{sequence}"
   end
 
   @impl true

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule Lasso.MixProject do
       {:plug_cowboy, "~> 2.8"},
       {:decimal, "~> 3.0"},
       {:yaml_elixir, "~> 2.9"},
-      {:finch, "~> 0.22"},
+      {:finch, "~> 0.23.0"},
       {:phoenix_live_dashboard, "~> 0.8", only: :dev},
       {:esbuild, "~> 0.8", runtime: Mix.env() == :dev},
       {:tailwind, "~> 0.2.0", runtime: Mix.env() == :dev},

--- a/test/integration/attempt_evidence_integration_test.exs
+++ b/test/integration/attempt_evidence_integration_test.exs
@@ -236,21 +236,18 @@ defmodule Lasso.RPC.AttemptEvidenceIntegrationTest do
     refute_receive {[:lasso, :rpc, :attempt, :stop], _, %{request_id: "failure-request"}}, 50
   end
 
-  test "attempt timeout is right-censored once", %{chain: chain} do
+  test "attempt timeout authorizes no late compatibility evidence", %{chain: chain} do
     setup_providers([
       %{id: "timeout", priority: 10, behavior: :always_timeout, profile: "public"}
     ])
 
     {:error, _error, _ctx} = execute(chain, "timeout", false, "timeout-request", 50)
-    [event] = attempt_events("timeout-request", 1)
 
-    assert event.metadata.outcome == :timeout
-    assert event.metadata.censored
-    assert event.measurements.duration_ms >= 30
-    assert event.measurements.duration_ms < 100
+    refute_receive {[:lasso, :rpc, :attempt, :stop], _, %{request_id: "timeout-request"}},
+                   250
   end
 
-  test "killing a request process records one cancelled attempt", %{chain: chain} do
+  test "killing the request owner may lose its owner-local terminal fact", %{chain: chain} do
     test_pid = self()
 
     blocking =
@@ -269,13 +266,8 @@ defmodule Lasso.RPC.AttemptEvidenceIntegrationTest do
     assert_receive :upstream_attempt_started, 2_000
     Process.exit(request_pid, :kill)
 
-    [event] = attempt_events("cancelled-request", 1)
-    assert event.metadata.outcome == :cancelled
-    assert event.metadata.censored
-    assert event.measurements.duration_ms >= 0
-
     refute_receive {[:lasso, :rpc, :attempt, :stop], _, %{request_id: "cancelled-request"}},
-                   100
+                   250
   end
 
   test "circuit rejection emits admission evidence and no attempt", %{chain: chain} do

--- a/test/lasso/core/request/execution_reducer_test.exs
+++ b/test/lasso/core/request/execution_reducer_test.exs
@@ -55,7 +55,12 @@ defmodule Lasso.RPC.ExecutionReducerTest do
     reduced =
       ExecutionReducer.new(state().identity, origin, origin + 50_000)
       |> ExecutionReducer.observe(%{id: 1, kind: :send_started, event_us: origin + 1})
-      |> ExecutionReducer.close_deadline()
+
+    assert reduced.dispatch_certainty == :not_dispatched
+
+    reduced = ExecutionReducer.close_deadline(reduced)
+
+    assert reduced.dispatch_certainty == :indeterminate
 
     assert %Lasso.RPC.AttemptTerminal.Deadline{censoring_boundary_us: 50_000} =
              ExecutionReducer.terminal_fact(reduced)
@@ -72,17 +77,18 @@ defmodule Lasso.RPC.ExecutionReducerTest do
     assert [%{reason: :certainty_regression}] = reduced.protocol_violations
   end
 
-  test "duplicates are idempotent and contradictions are diagnostic" do
+  test "send start remains open until authoritative predispatch proof" do
     event = %{id: 1, kind: :send_started, event_us: 10}
     once = ExecutionReducer.observe(state(), event)
     assert ExecutionReducer.observe(once, event) == once
 
-    contradicted =
+    resolved =
       once
       |> ExecutionReducer.observe(predispatch(2, 20))
 
-    assert contradicted.terminal == nil
-    assert [%{reason: :predispatch_after_send}] = contradicted.protocol_violations
+    assert resolved.terminal == :predispatch_failure
+    assert resolved.dispatch_certainty == :not_dispatched
+    assert resolved.protocol_violations == []
 
     reused = ExecutionReducer.observe(once, response(1, 10))
     assert [%{reason: :observation_id_reused}] = reused.protocol_violations
@@ -171,7 +177,7 @@ defmodule Lasso.RPC.ExecutionReducerTest do
   test "bounded ID tracking preserves earlier derived protocol violations" do
     contradicted =
       state(1_000)
-      |> ExecutionReducer.observe(%{id: 1, kind: :send_started, event_us: 1})
+      |> ExecutionReducer.observe(%{id: 1, kind: :send_confirmed, event_us: 1})
       |> ExecutionReducer.observe(%{id: 2, kind: :not_dispatched, event_us: 2})
 
     filled =
@@ -184,7 +190,7 @@ defmodule Lasso.RPC.ExecutionReducerTest do
     reasons = Enum.map(overflowed.protocol_violations, & &1.reason)
     assert :certainty_regression in reasons
     assert map_size(overflowed.seen) == 16
-    assert map_size(overflowed.observations) == 2
+    assert map_size(overflowed.observations) == 3
   end
 
   test "terminal linearization is unaffected by mailbox order" do
@@ -215,5 +221,43 @@ defmodule Lasso.RPC.ExecutionReducerTest do
 
     assert %Lasso.RPC.AttemptTerminal.TransportFailure{reason: :unknown} =
              ExecutionReducer.terminal_fact(reduced)
+  end
+
+  test "cancellation during unresolved send is indeterminate" do
+    reduced =
+      state()
+      |> ExecutionReducer.observe(%{id: 1, kind: :send_started, event_us: 10})
+      |> ExecutionReducer.observe(%{
+        id: 2,
+        kind: :cancelled,
+        event_us: 20,
+        reason: :caller_abandoned,
+        certainty: :not_dispatched,
+        censoring_boundary_us: 20
+      })
+
+    assert reduced.terminal == :cancelled
+    assert reduced.dispatch_certainty == :indeterminate
+
+    assert %Lasso.RPC.AttemptTerminal.Cancelled{dispatch_certainty: :indeterminate} =
+             ExecutionReducer.terminal_fact(reduced)
+  end
+
+  test "authoritative not-dispatched proof closes ambiguity before cancellation" do
+    reduced =
+      state()
+      |> ExecutionReducer.observe(%{id: 1, kind: :send_started, event_us: 10})
+      |> ExecutionReducer.observe(%{id: 2, kind: :not_dispatched, event_us: 15})
+      |> ExecutionReducer.observe(%{
+        id: 3,
+        kind: :cancelled,
+        event_us: 20,
+        reason: :caller_abandoned,
+        certainty: :not_dispatched,
+        censoring_boundary_us: 0
+      })
+
+    assert reduced.dispatch_certainty == :not_dispatched
+    assert reduced.protocol_violations == []
   end
 end

--- a/test/lasso/core/transport/attempt_protocol_test.exs
+++ b/test/lasso/core/transport/attempt_protocol_test.exs
@@ -1,0 +1,68 @@
+defmodule Lasso.Core.Transport.AttemptProtocolTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Core.Transport.AttemptProtocol
+
+  test "terminal_at preserves the authoritative transport timestamp" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+
+    assert :ok =
+             AttemptProtocol.terminal_at(
+               context,
+               :response,
+               %{response_kind: :error, io_duration_us: 7},
+               41
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{
+                      kind: :response,
+                      event_us: 41,
+                      response_kind: :application_error,
+                      io_duration_us: 7
+                    }}
+  end
+
+  test "not-dispatched transport failure remains authoritative" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+
+    assert :ok =
+             AttemptProtocol.terminal_at(
+               context,
+               :transport_failure,
+               %{reason: :network_error, certainty: :not_dispatched, elapsed_us: 0},
+               42
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{
+                      kind: :transport_failure,
+                      event_us: 42,
+                      certainty: :not_dispatched,
+                      reason: :connection
+                    }}
+  end
+
+  test "authorization is a local deadline check and sends no lifecycle message" do
+    lifecycle_pid = spawn(fn -> Process.sleep(:infinity) end)
+    context = {lifecycle_pid, make_ref()}
+    now = System.monotonic_time(:microsecond)
+
+    assert AttemptProtocol.authorized?(context, now + 1_000_000)
+    refute AttemptProtocol.authorized?(context, now - 1)
+    assert {:message_queue_len, 0} = Process.info(lifecycle_pid, :message_queue_len)
+
+    Process.exit(lifecycle_pid, :kill)
+  end
+
+  test "send start rejects a dead lifecycle owner" do
+    lifecycle_pid = spawn(fn -> :ok end)
+    monitor = Process.monitor(lifecycle_pid)
+    assert_receive {:DOWN, ^monitor, :process, ^lifecycle_pid, :normal}
+
+    assert {:error, :owner_down} =
+             AttemptProtocol.send_started({lifecycle_pid, make_ref()})
+  end
+end

--- a/test/lasso/core/transport/http/dispatch_tracker_test.exs
+++ b/test/lasso/core/transport/http/dispatch_tracker_test.exs
@@ -1,0 +1,237 @@
+defmodule Lasso.Core.Transport.HTTP.DispatchTrackerTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.Transport.HTTP.DispatchTracker
+
+  @handler_id "lasso-finch-dispatch-tracker"
+  @events [[:finch, :send, :start], [:finch, :send, :stop]]
+
+  setup do
+    if Process.whereis(DispatchTracker) == nil, do: start_supervised!(DispatchTracker)
+    assert :ok = DispatchTracker.audit_now()
+    :ok
+  end
+
+  test "application boot leaves the tracker ready before managed HTTP dispatch" do
+    assert is_pid(Process.whereis(DispatchTracker))
+    assert is_pid(Process.whereis(Lasso.Finch))
+    assert {:ok, token} = DispatchTracker.ready_token()
+    assert DispatchTracker.session_healthy?(token)
+  end
+
+  test "synchronously forwards bounded send observations correlated through request private" do
+    attempt_ref = make_ref()
+    {:ok, token} = DispatchTracker.ready_token()
+    context = {self(), attempt_ref}
+
+    request =
+      Finch.build(:post, "http://localhost", [], "{}")
+      |> Finch.Request.put_private(:lasso_attempt, context)
+
+    DispatchTracker.begin_attempt(context, token)
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{kind: :send_started, event_us: started_us}}
+
+    assert DispatchTracker.attempt_state(context) == :started
+
+    :telemetry.execute([:finch, :send, :stop], %{duration: 1}, %{request: request})
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{kind: :send_confirmed, event_us: confirmed_us}}
+
+    assert confirmed_us >= started_us
+    assert DispatchTracker.attempt_state(context) == :confirmed
+    DispatchTracker.clear_attempt(context)
+  end
+
+  test "adapter-opened ambiguity is emitted once before Finch reaches its send boundary" do
+    attempt_ref = make_ref()
+    {:ok, token} = DispatchTracker.ready_token()
+    context = {self(), attempt_ref}
+
+    request =
+      Finch.build(:post, "http://localhost", [], "{}")
+      |> Finch.Request.put_private(:lasso_attempt, context)
+
+    DispatchTracker.begin_attempt(context, token)
+    assert :ok = DispatchTracker.open_send(context, token)
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{kind: :send_started, event_us: event_us}}
+
+    assert is_integer(event_us)
+
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+    assert DispatchTracker.attempt_state(context) == :started
+    DispatchTracker.clear_attempt(context)
+  end
+
+  test "send stop carrying an error never confirms dispatch" do
+    attempt_ref = make_ref()
+    {:ok, token} = DispatchTracker.ready_token()
+    context = {self(), attempt_ref}
+
+    request =
+      Finch.build(:post, "http://localhost", [], "{}")
+      |> Finch.Request.put_private(:lasso_attempt, context)
+
+    DispatchTracker.begin_attempt(context, token)
+
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+
+    :telemetry.execute([:finch, :send, :stop], %{duration: 1}, %{
+      request: request,
+      error: :closed
+    })
+
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :send_confirmed}}
+    assert DispatchTracker.attempt_state(context) == :started
+    DispatchTracker.clear_attempt(context)
+  end
+
+  test "wrong handler replacement is rejected and repaired off the hot path" do
+    {:ok, old_token} = DispatchTracker.ready_token()
+    previous_count = DispatchTracker.status().degraded_count
+
+    :ok = :telemetry.detach(@handler_id)
+
+    assert :ok =
+             :telemetry.attach_many(@handler_id, @events, fn _, _, _, _ -> :ok end, :wrong)
+
+    refute DispatchTracker.session_healthy?(old_token)
+    assert :ok = DispatchTracker.audit_now()
+    assert DispatchTracker.ready?()
+    assert DispatchTracker.status().degraded_count == previous_count + 1
+    assert {:ok, new_token} = DispatchTracker.ready_token()
+    assert new_token != old_token
+
+    assert Enum.all?(@events, fn event ->
+             Enum.any?(:telemetry.list_handlers(event), fn handler ->
+               handler.id == @handler_id and
+                 handler.function == (&DispatchTracker.handle_event/4) and
+                 handler.config == %{token: new_token}
+             end)
+           end)
+  end
+
+  test "repair gives in-flight sessions a fresh incarnation without certainty regression" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+    {:ok, old_token} = DispatchTracker.ready_token()
+
+    request =
+      Finch.build(:post, "http://localhost", [], "{}")
+      |> Finch.Request.put_private(:lasso_attempt, context)
+
+    DispatchTracker.begin_attempt(context, old_token)
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+    assert DispatchTracker.attempt_state(context) == :started
+
+    :ok = :telemetry.detach(@handler_id)
+    assert :ok = DispatchTracker.audit_now()
+    assert {:ok, new_token} = DispatchTracker.ready_token()
+    assert new_token != old_token
+    refute DispatchTracker.session_healthy?(old_token)
+    assert DispatchTracker.attempt_state(context) == :started
+
+    :telemetry.execute([:finch, :send, :stop], %{duration: 1}, %{request: request})
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_confirmed}}
+    assert DispatchTracker.attempt_state(context) == :confirmed
+
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+    assert DispatchTracker.attempt_state(context) == :confirmed
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+    DispatchTracker.clear_attempt(context)
+  end
+
+  test "restart keeps a session with no observations conservatively unproven" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+    {:ok, old_token} = DispatchTracker.ready_token()
+    DispatchTracker.begin_attempt(context, old_token)
+
+    old_pid = Process.whereis(DispatchTracker)
+    monitor = Process.monitor(old_pid)
+    Process.exit(old_pid, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^old_pid, :killed}
+
+    _new_pid = await_restarted_tracker(old_pid)
+    assert {:ok, new_token} = DispatchTracker.ready_token()
+    assert new_token != old_token
+    refute DispatchTracker.session_healthy?(old_token)
+    assert DispatchTracker.attempt_state(context) == :not_started
+    DispatchTracker.clear_attempt(context)
+  end
+
+  test "confirmed attempt certainty survives tracker restart" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+    {:ok, old_token} = DispatchTracker.ready_token()
+
+    request =
+      Finch.build(:post, "http://localhost", [], "{}")
+      |> Finch.Request.put_private(:lasso_attempt, context)
+
+    DispatchTracker.begin_attempt(context, old_token)
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+
+    :telemetry.execute([:finch, :send, :stop], %{duration: 1}, %{request: request})
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_confirmed}}
+    assert DispatchTracker.attempt_state(context) == :confirmed
+
+    old_pid = Process.whereis(DispatchTracker)
+    monitor = Process.monitor(old_pid)
+    Process.exit(old_pid, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^old_pid, :killed}
+
+    _new_pid = await_restarted_tracker(old_pid)
+    assert {:ok, new_token} = DispatchTracker.ready_token()
+    assert new_token != old_token
+    refute DispatchTracker.session_healthy?(old_token)
+    assert DispatchTracker.attempt_state(context) == :confirmed
+
+    :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+    assert DispatchTracker.attempt_state(context) == :confirmed
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+    DispatchTracker.clear_attempt(context)
+  end
+
+  test "tracker crash reclaims its stale handler and restarts ready" do
+    old_pid = Process.whereis(DispatchTracker)
+    {:ok, old_token} = DispatchTracker.ready_token()
+    monitor = Process.monitor(old_pid)
+
+    Process.exit(old_pid, :kill)
+    assert_receive {:DOWN, ^monitor, :process, ^old_pid, :killed}
+
+    new_pid = await_restarted_tracker(old_pid)
+    assert is_pid(new_pid)
+    assert new_pid != old_pid
+    assert {:ok, new_token} = DispatchTracker.ready_token()
+    assert new_token != old_token
+    assert DispatchTracker.session_healthy?(new_token)
+  end
+
+  defp await_restarted_tracker(old_pid, attempts \\ 100)
+
+  defp await_restarted_tracker(_old_pid, 0), do: nil
+
+  defp await_restarted_tracker(old_pid, attempts) do
+    case Process.whereis(DispatchTracker) do
+      pid when is_pid(pid) and pid != old_pid ->
+        pid
+
+      _ ->
+        receive do
+        after
+          10 -> await_restarted_tracker(old_pid, attempts - 1)
+        end
+    end
+  end
+end

--- a/test/lasso/core/transport/http/finch_dispatch_test.exs
+++ b/test/lasso/core/transport/http/finch_dispatch_test.exs
@@ -1,6 +1,7 @@
 defmodule Lasso.RPC.Transport.HTTP.FinchDispatchTest do
   use ExUnit.Case, async: false
 
+  alias Lasso.Core.Transport.HTTP.DispatchTracker
   alias Lasso.RPC.Transport.HTTP.Client.Finch, as: FinchClient
 
   @finch_name __MODULE__.Client
@@ -13,36 +14,16 @@ defmodule Lasso.RPC.Transport.HTTP.FinchDispatchTest do
     :ok
   end
 
-  test "rejected dispatch authorization prevents TCP connection and request send" do
-    {:ok, listener} =
-      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, ip: {127, 0, 0, 1}])
+  test "adapter source uses only the public Finch request seam" do
+    source = File.read!("lib/lasso/core/transport/http/adapters/finch.ex")
 
-    {:ok, port} = :inet.port(listener)
-    test_pid = self()
-
-    acceptor =
-      spawn(fn ->
-        result = :gen_tcp.accept(listener, 250)
-        send(test_pid, {:accept_result, result})
-      end)
-
-    dead_lifecycle = spawn(fn -> :ok end)
-    dead_monitor = Process.monitor(dead_lifecycle)
-    assert_receive {:DOWN, ^dead_monitor, :process, ^dead_lifecycle, _reason}, 1_000
-
-    assert {:error, {:local_capacity_rejection, :dispatch_cancelled}} =
-             FinchClient.request(
-               %{url: "http://127.0.0.1:#{port}"},
-               "eth_blockNumber",
-               [],
-               timeout: 100,
-               finch_name: @finch_name,
-               attempt_dispatch: {dead_lifecycle, make_ref()}
-             )
-
-    assert_receive {:accept_result, {:error, :timeout}}, 1_000
-    refute Process.alive?(acceptor)
-    :ok = :gen_tcp.close(listener)
+    assert source =~ "Finch.request(request, finch_name"
+    refute source =~ "Finch.HTTP1"
+    refute source =~ "Finch.Pool.Manager"
+    refute source =~ "NimblePool"
+    refute source =~ "Mint."
+    refute source =~ "authorize_dispatch"
+    refute source =~ "confirm_dispatched"
   end
 
   test "request encoding failure aborts before connection and returns a typed client error" do
@@ -81,5 +62,227 @@ defmodule Lasso.RPC.Transport.HTTP.FinchDispatchTest do
                timeout: 100,
                finch_name: @finch_name
              )
+  end
+
+  test "predispatch Finch failure is proven only while the tracker remains authoritative" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+
+    assert {:error, {:network_error, _message}} =
+             FinchClient.request(
+               %{url: "http://example.invalid"},
+               "eth_blockNumber",
+               [],
+               timeout: 100,
+               attempt_dispatch: context,
+               request_fun: fn _request, _name, _options ->
+                 {:error, %Finch.TransportError{reason: :econnrefused}}
+               end
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{kind: :predispatch_failure, reason: :pool_unavailable}}
+  end
+
+  test "send start followed by handler loss and timeout remains indeterminate" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+
+    assert {:error, :timeout} =
+             FinchClient.request(
+               %{url: "http://example.invalid"},
+               "eth_blockNumber",
+               [],
+               timeout: 100,
+               attempt_dispatch: context,
+               request_fun: fn request, _name, _options ->
+                 :telemetry.execute([:finch, :send, :start], %{}, %{request: request})
+                 :ok = :telemetry.detach("lasso-finch-dispatch-tracker")
+                 {:error, %Finch.TransportError{reason: :timeout}}
+               end
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{kind: :transport_failure, certainty: :indeterminate, reason: :timeout}}
+
+    assert :ok = DispatchTracker.audit_now()
+    assert DispatchTracker.ready?()
+  end
+
+  test "missing tracker at the Finch boundary prevents a false not-dispatched claim" do
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+
+    assert {:error, {:network_error, _message}} =
+             FinchClient.request(
+               %{url: "http://example.invalid"},
+               "eth_blockNumber",
+               [],
+               timeout: 100,
+               attempt_dispatch: context,
+               request_fun: fn _request, _name, _options ->
+                 :ok = :telemetry.detach("lasso-finch-dispatch-tracker")
+                 {:error, %Finch.TransportError{reason: :closed}}
+               end
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+
+    assert_receive {:transport_observation, ^attempt_ref,
+                    %{kind: :transport_failure, certainty: :indeterminate, reason: :closed}}
+
+    assert :ok = DispatchTracker.audit_now()
+  end
+
+  test "deadline options preserve one exact remaining budget without clamping" do
+    test_pid = self()
+
+    assert {:error, {:local_capacity_rejection, :pool_unavailable}} =
+             FinchClient.request(
+               %{url: "http://example.invalid"},
+               "eth_blockNumber",
+               [],
+               deadline_us: 10_000,
+               monotonic_now_fun: fn -> 3_001 end,
+               request_fun: fn _request, _name, options ->
+                 send(test_pid, {:request_options, options})
+                 {:error, %Finch.Error{reason: :pool_unavailable}}
+               end
+             )
+
+    assert_receive {:request_options, [pool_timeout: 6, receive_timeout: 6, request_timeout: 6]}
+
+    assert {:error, {:local_capacity_rejection, :deadline}} =
+             FinchClient.request(
+               %{url: "http://example.invalid"},
+               "eth_blockNumber",
+               [],
+               deadline_us: 10_000,
+               monotonic_now_fun: fn -> 9_001 end,
+               request_fun: fn _request, _name, _options ->
+                 send(test_pid, :expired_request_ran)
+                 {:ok, %Finch.Response{status: 200, body: "{}"}}
+               end
+             )
+
+    refute_receive :expired_request_ran
+  end
+
+  test "deadline recheck after receipt prevents entering Finch" do
+    test_pid = self()
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+    counter = :counters.new(1, [])
+
+    monotonic_now = fn ->
+      :counters.add(counter, 1, 1)
+      if :counters.get(counter, 1) == 1, do: 3_001, else: 10_000
+    end
+
+    assert {:error, {:local_capacity_rejection, :deadline}} =
+             FinchClient.request(
+               %{url: "http://example.invalid"},
+               "eth_blockNumber",
+               [],
+               deadline_us: 10_000,
+               attempt_dispatch: context,
+               monotonic_now_fun: monotonic_now,
+               request_fun: fn _request, _name, _options ->
+                 send(test_pid, :deadline_recheck_request_ran)
+                 {:ok, %Finch.Response{status: 200, body: "{}"}}
+               end
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :predispatch_failure}}
+    refute_receive :deadline_recheck_request_ran
+  end
+
+  test "one adapter call performs one physical HTTP send" do
+    {:ok, listener} =
+      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, ip: {127, 0, 0, 1}])
+
+    {:ok, port} = :inet.port(listener)
+    test_pid = self()
+    attempt_ref = make_ref()
+    context = {self(), attempt_ref}
+    response_body = ~s({"jsonrpc":"2.0","id":"physical-one","result":"0x1"})
+
+    server =
+      spawn(fn ->
+        {:ok, socket} = :gen_tcp.accept(listener, 1_000)
+        {:ok, request, remainder} = receive_http_request(socket, "")
+        send(test_pid, {:physical_request, request, remainder})
+
+        response =
+          "HTTP/1.1 200 OK\r\ncontent-length: #{byte_size(response_body)}\r\n" <>
+            "connection: keep-alive\r\n\r\n" <> response_body
+
+        :ok = :gen_tcp.send(socket, response)
+        send(test_pid, {:after_response_bytes, :gen_tcp.recv(socket, 0, 100)})
+        :gen_tcp.close(socket)
+      end)
+
+    server_monitor = Process.monitor(server)
+
+    assert {:ok, {:raw, ^response_body}} =
+             FinchClient.request(
+               %{url: "http://127.0.0.1:#{port}"},
+               "eth_blockNumber",
+               [],
+               request_id: "physical-one",
+               timeout: 1_000,
+               finch_name: @finch_name,
+               attempt_dispatch: context
+             )
+
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: :send_confirmed}}
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :send_started}}
+
+    assert_receive {:physical_request, request, ""}, 1_000
+    assert length(:binary.matches(request, "POST ")) == 1
+    assert_receive {:after_response_bytes, result}, 1_000
+    assert result in [{:error, :timeout}, {:error, :closed}]
+
+    assert_receive {:DOWN, ^server_monitor, :process, ^server, :normal}, 1_000
+    :ok = :gen_tcp.close(listener)
+  end
+
+  defp receive_http_request(socket, acc) do
+    case :binary.match(acc, "\r\n\r\n") do
+      {header_end, 4} ->
+        body_start = header_end + 4
+        headers = binary_part(acc, 0, body_start)
+        content_length = content_length(headers)
+
+        if byte_size(acc) >= body_start + content_length do
+          request_size = body_start + content_length
+          request = binary_part(acc, 0, request_size)
+          remainder = binary_part(acc, request_size, byte_size(acc) - request_size)
+          {:ok, request, remainder}
+        else
+          receive_more(socket, acc)
+        end
+
+      :nomatch ->
+        receive_more(socket, acc)
+    end
+  end
+
+  defp receive_more(socket, acc) do
+    case :gen_tcp.recv(socket, 0, 1_000) do
+      {:ok, bytes} -> receive_http_request(socket, acc <> bytes)
+      error -> error
+    end
+  end
+
+  defp content_length(headers) do
+    [_, value] = Regex.run(~r/content-length:\s*(\d+)/i, headers)
+    String.to_integer(value)
   end
 end

--- a/test/lasso/core/transport/http/http_test.exs
+++ b/test/lasso/core/transport/http/http_test.exs
@@ -2,8 +2,15 @@ defmodule Lasso.RPC.Transports.HTTPTest do
   use ExUnit.Case, async: false
   import Mox
 
+  alias Lasso.Core.Support.ErrorClassifier
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.RPC.Transports.HTTP
+
+  defmodule LocalRawClient do
+    def request(_config, _method, _params, _opts) do
+      {:ok, {:raw, Process.get({__MODULE__, :raw})}}
+    end
+  end
 
   setup :verify_on_exit!
 
@@ -47,6 +54,138 @@ defmodule Lasso.RPC.Transports.HTTPTest do
     assert error.retriable? == true
     assert error.breaker_penalty? == true
     assert error.provider_id == "sepolia_onfinality"
-    assert error.data[:reason] == :no_result_or_error
+    assert error.data[:reason] == :invalid_envelope
+  end
+
+  test "preserves the original large response binary on the same-id HTTP path" do
+    channel = %{
+      provider_id: "large-response-provider",
+      config: %{id: "large-response-provider", url: "https://example.invalid"}
+    }
+
+    request_id = "large-response"
+    result = String.duplicate("a", 4 * 1_024 * 1_024)
+    raw = ~s({"jsonrpc":"2.0","id":"#{request_id}","result":"#{result}"})
+    Application.put_env(:lasso, :http_client, LocalRawClient)
+    Process.put({LocalRawClient, :raw}, raw)
+
+    on_exit(fn -> Process.delete({LocalRawClient, :raw}) end)
+
+    rpc_request = %{
+      "jsonrpc" => "2.0",
+      "method" => "eth_call",
+      "params" => [],
+      "id" => request_id
+    }
+
+    assert {:ok, %Lasso.RPC.Response.Success{} = response, _io_ms} =
+             HTTP.request(channel, rpc_request, 1_000)
+
+    assert response.id == request_id
+    assert response.raw_bytes == raw
+    assert :erts_debug.same(response.raw_bytes, raw)
+  end
+
+  test "rejects a structurally incomplete response without decoding its result" do
+    channel = %{
+      provider_id: "malformed-provider",
+      config: %{id: "malformed-provider", url: "https://example.invalid"}
+    }
+
+    rpc_request = %{
+      "jsonrpc" => "2.0",
+      "method" => "eth_call",
+      "params" => [],
+      "id" => "malformed-response"
+    }
+
+    raw = ~s({"jsonrpc":"2.0","id":"malformed-response","result":[1}})
+
+    expect(Lasso.RPC.HttpClientMock, :request, fn _config, _method, _params, _opts ->
+      {:ok, {:raw, raw}}
+    end)
+
+    assert {:error, %JError{code: -32_700} = error, _io_ms} =
+             HTTP.request(channel, rpc_request, 1_000)
+
+    assert error.data.reason == :invalid_json
+  end
+
+  test "preserves JSON-RPC error data and existing classification semantics" do
+    provider_id = "classified-error-provider"
+
+    channel = %{
+      provider_id: provider_id,
+      config: %{id: provider_id, url: "https://example.invalid"}
+    }
+
+    error_data = %{"retry_after" => 50, "scope" => "provider"}
+
+    rpc_request = %{
+      "jsonrpc" => "2.0",
+      "method" => "eth_call",
+      "params" => [],
+      "id" => "classified-error"
+    }
+
+    raw =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => "classified-error",
+        "error" => %{"code" => -32_005, "message" => "rate limited", "data" => error_data}
+      })
+
+    expect(Lasso.RPC.HttpClientMock, :request, fn _config, _method, _params, _opts ->
+      {:ok, {:raw, raw}}
+    end)
+
+    expected =
+      ErrorClassifier.classify(-32_005, "rate limited",
+        data: error_data,
+        provider_id: provider_id
+      )
+
+    assert {:error, %JError{} = error, _io_ms} = HTTP.request(channel, rpc_request, 1_000)
+    assert error.data == error_data
+    assert error.category == expected.category
+    assert error.retriable? == expected.retriable?
+    assert error.breaker_penalty? == expected.breaker_penalty?
+  end
+
+  test "composes the per-attempt timeout with the shared decision deadline" do
+    channel = %{
+      provider_id: "deadline-provider",
+      config: %{id: "deadline-provider", url: "https://example.invalid"}
+    }
+
+    rpc_request = %{
+      "jsonrpc" => "2.0",
+      "method" => "eth_blockNumber",
+      "params" => [],
+      "id" => "deadline-response"
+    }
+
+    started_before_us = System.monotonic_time(:microsecond)
+    decision_deadline_us = started_before_us + 100_000
+    previous_deadline = Process.put(:lasso_attempt_deadline_us, decision_deadline_us)
+
+    on_exit(fn ->
+      if is_nil(previous_deadline) do
+        Process.delete(:lasso_attempt_deadline_us)
+      else
+        Process.put(:lasso_attempt_deadline_us, previous_deadline)
+      end
+    end)
+
+    expect(Lasso.RPC.HttpClientMock, :request, fn _config, _method, _params, opts ->
+      deadline_us = Keyword.fetch!(opts, :deadline_us)
+      assert deadline_us >= started_before_us + 25_000
+      assert deadline_us < decision_deadline_us
+
+      {:ok, {:raw, ~s({"jsonrpc":"2.0","id":"deadline-response","result":"0x1"})}}
+    end)
+
+    assert {:ok, %Lasso.RPC.Response.Success{}, _io_ms} =
+             HTTP.request(channel, rpc_request, 25)
   end
 end

--- a/test/lasso/core/transport/websocket/transport_protocol_test.exs
+++ b/test/lasso/core/transport/websocket/transport_protocol_test.exs
@@ -1,0 +1,1256 @@
+defmodule Lasso.RPC.Transport.WebSocket.TransportProtocolTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.Support.{CircuitBreaker, ErrorClassifier}
+  alias Lasso.Core.Support.CircuitBreaker.{ControlRing, Snapshot}
+  alias Lasso.Core.Transport.UpstreamResponse
+  alias Lasso.Core.Transport.UpstreamResponse.Validated
+  alias Lasso.JSONRPC.Error, as: JError
+  alias Lasso.Providers.InstanceState
+  alias Lasso.RPC.Response
+  alias Lasso.RPC.Transport.WebSocket.{Connection, Endpoint, Handler}
+  alias Lasso.RPC.Transports.WebSocket
+
+  @config_keys [
+    :protocol_ws_send_mode,
+    :protocol_ws_test_owner,
+    :ws_client_module,
+    :ws_send_cleanup_ms,
+    :ws_startup_jitter_ms,
+    :ws_transport_pending_limit
+  ]
+
+  setup context do
+    saved_config = Map.new(@config_keys, &{&1, Application.fetch_env(:lasso, &1)})
+
+    Application.put_env(:lasso, :protocol_ws_send_mode, context[:send_mode] || :manual)
+    Application.put_env(:lasso, :protocol_ws_test_owner, self())
+    Application.put_env(:lasso, :ws_client_module, TestSupport.ProtocolWSClient)
+    Application.put_env(:lasso, :ws_send_cleanup_ms, context[:send_cleanup_ms] || 10_000)
+    Application.put_env(:lasso, :ws_startup_jitter_ms, 0)
+    Application.put_env(:lasso, :ws_transport_pending_limit, context[:pending_limit] || 256)
+
+    suffix = System.unique_integer([:positive, :monotonic])
+
+    endpoint = %Endpoint{
+      profile: "public",
+      id: "protocol-ws-#{suffix}",
+      name: "Protocol WebSocket #{suffix}",
+      chain_id: suffix,
+      chain_name: "protocol-ws-chain-#{suffix}",
+      ws_url: "ws://protocol.test/#{suffix}",
+      reconnect_interval: 1,
+      heartbeat_interval: 60_000,
+      max_reconnect_attempts: 3,
+      stability_ms: 60_000
+    }
+
+    instance_id = "#{endpoint.chain_id}:#{endpoint.id}"
+    breaker_id = {instance_id, :ws}
+
+    {:ok, breaker_pid} =
+      CircuitBreaker.start_link(
+        {breaker_id, %{failure_threshold: 5, recovery_timeout: 200, success_threshold: 1}}
+      )
+
+    {:ok, connection_pid} = Connection.start_link(endpoint)
+
+    assert_receive {:protocol_ws_connected, ws_pid, generation}
+    assert eventually(fn -> Connection.status(instance_id).connected end)
+
+    on_exit(fn ->
+      stop_if_alive(connection_pid)
+      stop_if_alive(breaker_pid)
+      InstanceState.clear(instance_id)
+
+      Enum.each(saved_config, fn
+        {key, {:ok, value}} -> Application.put_env(:lasso, key, value)
+        {key, :error} -> Application.delete_env(:lasso, key)
+      end)
+    end)
+
+    channel = %{instance_id: instance_id, provider_id: endpoint.id}
+
+    %{
+      channel: channel,
+      breaker_pid: breaker_pid,
+      connection_pid: connection_pid,
+      generation: generation,
+      instance_id: instance_id,
+      ws_pid: ws_pid
+    }
+  end
+
+  @tag send_mode: :auto_success
+  test "registers before an immediate response and replaces duplicate client ids", context do
+    first = request_task(context.channel, "duplicate-client-id", 1_000)
+    second = request_task(context.channel, "duplicate-client-id", 1_000)
+
+    assert_receive {:protocol_ws_send, ws_pid, first_id, _payload}
+    assert_receive {:protocol_ws_send, ^ws_pid, second_id, _payload}
+
+    assert first_id != second_id
+    assert String.starts_with?(first_id, "lasso-")
+    assert String.starts_with?(second_id, "lasso-")
+
+    assert {:ok, %Response.Success{id: "duplicate-client-id"}, _io_ms} = Task.await(first)
+    assert {:ok, %Response.Success{id: "duplicate-client-id"}, _io_ms} = Task.await(second)
+
+    assert %{pending_requests: 0, transport_pending_requests: 0} =
+             Connection.status(context.instance_id)
+  end
+
+  @tag pending_limit: 1
+  test "rejects pending-cap saturation before send while a send is blocked", context do
+    first = request_task(context.channel, 1, 1_000)
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+
+    assert %{connected: true, transport_pending_requests: 1, transport_pending_limit: 1} =
+             Connection.status(context.instance_id)
+
+    assert {:error, %JError{category: :local_capacity_rejection, data: %{reason: :capacity}},
+            _io_ms} = WebSocket.request(context.channel, rpc_request(2), 1_000)
+
+    refute_receive {:protocol_ws_send, ^ws_pid, _id, _payload}, 0
+    assert Connection.status(context.instance_id).connected
+
+    :ok =
+      TestSupport.ProtocolWSClient.acknowledge(
+        ws_pid,
+        transport_id,
+        success_response(transport_id, "0x1")
+      )
+
+    assert {:ok, %Response.Success{id: 1}, _io_ms} = Task.await(first)
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+  end
+
+  test "does not register or send at or after the absolute deadline", context do
+    {:ok, snapshot = {_ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    deadline = System.monotonic_time(:microsecond)
+
+    for {suffix, candidate_deadline} <- [
+          {"at-deadline", deadline},
+          {"after-deadline", deadline - 1}
+        ] do
+      assert {:error, :deadline} =
+               Connection.register_transport(
+                 context.instance_id,
+                 snapshot,
+                 transport_id(generation, suffix),
+                 self(),
+                 candidate_deadline,
+                 1_000
+               )
+    end
+
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+    refute_receive {:protocol_ws_send, _ws_pid, _id, _payload}, 0
+  end
+
+  @tag pending_limit: 1
+  test "an expired queued frame stays bounded and never sends after handler resume", context do
+    :sys.suspend(context.ws_pid)
+    on_exit(fn -> if Process.alive?(context.ws_pid), do: :sys.resume(context.ws_pid) end)
+
+    {task, attempt_ref} = observed_request_task(context.channel)
+
+    assert eventually(fn ->
+             state = :sys.get_state(context.connection_pid)
+
+             match?(
+               [{_id, %{send_state: :queued}}],
+               Map.to_list(state.transport_pending)
+             )
+           end)
+
+    assert_observation(attempt_ref, :send_started)
+    assert {:message_queue_len, queued} = Process.info(context.ws_pid, :message_queue_len)
+    assert queued <= 1
+
+    {transport_id, pending} = only_transport_pending(context.connection_pid)
+    expire_transport(context.connection_pid, transport_id, pending)
+
+    assert {:error, %JError{category: :timeout}, _io_ms} = Task.await(task)
+
+    assert %{transport_pending_requests: 1, transport_tombstones: 1} =
+             Connection.status(context.instance_id)
+
+    send(
+      context.connection_pid,
+      {:transport_timeout, transport_id, pending.generation, pending.token}
+    )
+
+    assert %{connected: true, transport_tombstones: 1} =
+             Connection.status(context.instance_id)
+
+    assert {:error, %JError{category: :local_capacity_rejection}, _io_ms} =
+             WebSocket.request(context.channel, rpc_request("capacity"), 100)
+
+    :sys.resume(context.ws_pid)
+    refute_receive {:protocol_ws_send, _ws_pid, _id, _payload}, 0
+
+    assert eventually(fn ->
+             Connection.status(context.instance_id).transport_pending_requests == 0
+           end)
+  end
+
+  test "does not send when the lifecycle owner is already down", context do
+    owner = spawn(fn -> receive do: (:stop -> :ok) end)
+    owner_monitor = Process.monitor(owner)
+    Process.exit(owner, :kill)
+    assert_receive {:DOWN, ^owner_monitor, :process, ^owner, :killed}
+
+    task =
+      Task.async(fn ->
+        Process.put(:lasso_attempt_dispatch_context, {owner, make_ref()})
+        Process.put(:lasso_attempt_deadline_us, System.monotonic_time(:microsecond) + 1_000_000)
+        WebSocket.request(context.channel, rpc_request("owner-down"), 1_000)
+      end)
+
+    assert {:error, %JError{category: :cancelled, breaker_penalty?: false}, _io_ms} =
+             Task.await(task)
+
+    refute_receive {:protocol_ws_send, _ws_pid, _id, _payload}, 0
+
+    assert eventually(fn ->
+             Connection.status(context.instance_id).transport_pending_requests == 0
+           end)
+  end
+
+  test "uses tokenized timers and preserves a response stamped before the deadline", context do
+    {:ok, snapshot = {ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    before_deadline_id = transport_id(generation, "d-minus-one")
+    initial_deadline = System.monotonic_time(:microsecond) + 5_000_000
+
+    assert {:ok, before_token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               before_deadline_id,
+               self(),
+               initial_deadline,
+               1_000
+             )
+
+    send(
+      context.connection_pid,
+      {:transport_timeout, before_deadline_id, generation, before_token}
+    )
+
+    assert Connection.status(context.instance_id).transport_pending_requests == 1
+
+    before_deadline = replace_deadline(context.connection_pid, before_deadline_id)
+    raw = success_response(before_deadline_id, "0x1")
+
+    send(
+      context.connection_pid,
+      {:transport_timeout, before_deadline_id, generation, before_token}
+    )
+
+    send_parsed_frame(
+      context.connection_pid,
+      ws_pid,
+      generation,
+      raw,
+      before_deadline - 1,
+      before_deadline - 1
+    )
+
+    assert_receive {:ws_transport_response, ^before_token, ^generation, ^ws_pid,
+                    {:ok, %Validated{id: ^before_deadline_id}}, ^raw, received_at, validated_at}
+
+    assert received_at == before_deadline - 1
+    assert validated_at == before_deadline - 1
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+
+    at_deadline_id = transport_id(generation, "at-deadline")
+
+    assert {:ok, at_token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               at_deadline_id,
+               self(),
+               initial_deadline,
+               1_000
+             )
+
+    at_deadline = replace_deadline(context.connection_pid, at_deadline_id)
+    at_raw = success_response(at_deadline_id, "0x2")
+
+    send(context.connection_pid, {:transport_timeout, at_deadline_id, generation, at_token})
+
+    send_parsed_frame(
+      context.connection_pid,
+      ws_pid,
+      generation,
+      at_raw,
+      at_deadline,
+      at_deadline
+    )
+
+    assert_receive {:ws_transport_timeout, ^at_token, ^generation}
+
+    refute_receive {:ws_transport_response, ^at_token, ^generation, _pid, _validation, _raw,
+                    _received, _validated},
+                   0
+
+    status = Connection.status(context.instance_id)
+    assert status.transport_pending_requests == 0
+    assert status.transport_diagnostics.late_or_uncorrelated_response == 1
+
+    after_deadline_id = transport_id(generation, "after-deadline")
+
+    assert {:ok, after_token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               after_deadline_id,
+               self(),
+               initial_deadline,
+               1_000
+             )
+
+    after_deadline = replace_deadline(context.connection_pid, after_deadline_id)
+    after_raw = success_response(after_deadline_id, "0x3")
+
+    send(
+      context.connection_pid,
+      {:transport_timeout, after_deadline_id, generation, after_token}
+    )
+
+    send_parsed_frame(
+      context.connection_pid,
+      ws_pid,
+      generation,
+      after_raw,
+      after_deadline + 1,
+      after_deadline + 1
+    )
+
+    assert_receive {:ws_transport_timeout, ^after_token, ^generation}
+
+    refute_receive {:ws_transport_response, ^after_token, ^generation, _pid, _validation, _raw,
+                    _received, _validated},
+                   0
+
+    status = Connection.status(context.instance_id)
+    assert status.transport_pending_requests == 0
+    assert status.transport_diagnostics.late_or_uncorrelated_response == 2
+  end
+
+  test "settlement drain deterministically accepts only D-1 under mailbox overtaking", context do
+    {:ok, snapshot = {ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    for iteration <- 1..10,
+        {label, offset, expected} <- [
+          {:d_minus_one, -1, :response},
+          {:d, 0, :timeout},
+          {:d_plus_one, 1, :timeout}
+        ] do
+      id = transport_id(generation, "#{label}-#{iteration}")
+      initial_deadline = System.monotonic_time(:microsecond) + 5_000_000
+
+      assert {:ok, token} =
+               Connection.register_transport(
+                 context.instance_id,
+                 snapshot,
+                 id,
+                 self(),
+                 initial_deadline,
+                 1_000
+               )
+
+      decision_deadline_us = System.monotonic_time(:microsecond) - 2_000
+      settlement_deadline_us = System.monotonic_time(:microsecond) - 1
+
+      force_transport_cutoffs(
+        context.connection_pid,
+        id,
+        decision_deadline_us,
+        settlement_deadline_us
+      )
+
+      raw = success_response(id, "0x1")
+      validated_at_us = decision_deadline_us + offset
+
+      :sys.suspend(context.connection_pid)
+
+      send(
+        context.connection_pid,
+        {:transport_timeout, id, generation, token}
+      )
+
+      send_parsed_frame(
+        context.connection_pid,
+        ws_pid,
+        generation,
+        raw,
+        validated_at_us,
+        validated_at_us
+      )
+
+      :sys.resume(context.connection_pid)
+
+      case expected do
+        :response ->
+          assert_receive {:ws_transport_response, ^token, ^generation, ^ws_pid,
+                          {:ok, %Validated{id: ^id}}, ^raw, ^validated_at_us, ^validated_at_us}
+
+          refute_receive {:ws_transport_timeout, ^token, ^generation}, 0
+
+        :timeout ->
+          assert_receive {:ws_transport_timeout, ^token, ^generation}
+
+          refute_receive {:ws_transport_response, ^token, ^generation, _pid, _validation, _raw,
+                          _received, _validated},
+                         0
+      end
+
+      assert Connection.status(context.instance_id).transport_pending_requests == 0
+    end
+  end
+
+  test "ABA-safe cancellation ignores stale timers and late responses", context do
+    {:ok, snapshot = {ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    id = transport_id(generation, "cancelled")
+    deadline = System.monotonic_time(:microsecond) + 5_000_000
+
+    assert {:ok, token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               id,
+               self(),
+               deadline,
+               1_000
+             )
+
+    Connection.cancel_transport(context.instance_id, id, generation, token)
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+
+    send(context.connection_pid, {:transport_timeout, id, generation, token})
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, success_response(id, "late"))
+
+    status = Connection.status(context.instance_id)
+    assert status.transport_pending_requests == 0
+    assert status.transport_diagnostics.late_or_uncorrelated_response == 1
+
+    refute_receive {:ws_transport_response, ^token, ^generation, _pid, _validation, _raw,
+                    _received, _validated},
+                   0
+  end
+
+  test "rejects duplicate registrations and snapshots from an old generation", context do
+    {:ok, snapshot = {ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    id = transport_id(generation, "duplicate-registration")
+    deadline = System.monotonic_time(:microsecond) + 5_000_000
+
+    assert {:ok, token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               id,
+               self(),
+               deadline,
+               1_000
+             )
+
+    assert {:error, :duplicate_transport_id} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               id,
+               self(),
+               deadline,
+               1_000
+             )
+
+    Connection.cancel_transport(context.instance_id, id, generation, token)
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+
+    :ok = TestSupport.ProtocolWSClient.disconnect(ws_pid, :closed)
+    assert_receive {:protocol_ws_connected, new_ws_pid, new_generation}
+    assert new_ws_pid != ws_pid
+    assert new_generation != generation
+
+    assert eventually(fn ->
+             match?(
+               {:ok, {^new_ws_pid, ^new_generation}},
+               Connection.transport_snapshot(context.instance_id, 1_000)
+             )
+           end)
+
+    assert {:error, :stale_connection} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               transport_id(generation, "stale-snapshot"),
+               self(),
+               deadline,
+               1_000
+             )
+  end
+
+  test "owner death removes pending registration without waiting for its deadline", context do
+    {:ok, snapshot = {_ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    owner = spawn(fn -> receive do: (:stop -> :ok) end)
+    id = transport_id(generation, "owner-death")
+    deadline = System.monotonic_time(:microsecond) + 5_000_000
+
+    assert {:ok, _token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               id,
+               owner,
+               deadline,
+               1_000
+             )
+
+    assert Connection.status(context.instance_id).transport_pending_requests == 1
+    Process.exit(owner, :kill)
+
+    assert eventually(fn ->
+             Connection.status(context.instance_id).transport_pending_requests == 0
+           end)
+  end
+
+  test "stale connection generations cannot complete a new pending attempt", context do
+    {:ok, snapshot = {ws_pid, generation}} =
+      Connection.transport_snapshot(context.instance_id, 1_000)
+
+    id = transport_id(generation, "stale-generation")
+    deadline = System.monotonic_time(:microsecond) + 5_000_000
+
+    assert {:ok, token} =
+             Connection.register_transport(
+               context.instance_id,
+               snapshot,
+               id,
+               self(),
+               deadline,
+               1_000
+             )
+
+    raw = success_response(id, "0x1")
+
+    send_parsed_frame(
+      context.connection_pid,
+      self(),
+      generation <> "-stale",
+      raw,
+      System.monotonic_time(:microsecond),
+      System.monotonic_time(:microsecond)
+    )
+
+    status = Connection.status(context.instance_id)
+    assert status.transport_pending_requests == 1
+    assert status.transport_diagnostics.stale_generation == 1
+
+    refute_receive {:ws_transport_response, ^token, ^generation, _pid, _validation, _raw,
+                    _received, _validated},
+                   0
+
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, raw)
+
+    assert_receive {:ws_transport_response, ^token, ^generation, ^ws_pid,
+                    {:ok, %Validated{id: ^id}}, ^raw, _received_at, _validated_at}
+  end
+
+  test "only attributable invalid envelopes terminate a multiplexed attempt", context do
+    task = request_task(context.channel, "client-id", 1_000)
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, "not-json")
+
+    :ok =
+      TestSupport.ProtocolWSClient.emit_raw(
+        ws_pid,
+        success_response(transport_id(context.generation, "unrelated"), "wrong-id")
+      )
+
+    status = Connection.status(context.instance_id)
+    assert status.transport_pending_requests == 1
+    assert status.transport_diagnostics.unattributable_frame == 1
+    assert status.transport_diagnostics.late_or_uncorrelated_response == 1
+    refute Task.yield(task, 0)
+
+    invalid_batch =
+      Jason.encode!([%{"jsonrpc" => "2.0", "id" => transport_id, "result" => "0x1"}])
+
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, invalid_batch)
+    assert Connection.status(context.instance_id).transport_pending_requests == 1
+    refute Task.yield(task, 0)
+
+    nested_id =
+      ~s({"jsonrpc":"2.0","id":"client","result":{"id":"#{transport_id}"}})
+
+    duplicate_id =
+      ~s({"jsonrpc":"2.0","id":"#{transport_id}","id":"#{transport_id}","result":1})
+
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, nested_id)
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, duplicate_id)
+    assert Connection.status(context.instance_id).transport_pending_requests == 1
+
+    attributable_invalid =
+      Jason.encode!(%{"jsonrpc" => "1.0", "id" => transport_id, "result" => "0x1"})
+
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, transport_id, attributable_invalid)
+
+    assert {:error, %JError{data: %{reason: :unsupported_version}}, _io_ms} = Task.await(task)
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+
+    trailing_task = request_task(context.channel, "client-id", 1_000)
+    assert_receive {:protocol_ws_send, ^ws_pid, trailing_id, _payload}
+
+    invalid_trailing = ~s({"jsonrpc":"1.0","id":"#{trailing_id}","result":"0x1"} trailing)
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, trailing_id, invalid_trailing)
+
+    assert {:error, %JError{data: %{reason: :invalid_json}}, _io_ms} =
+             Task.await(trailing_task)
+
+    invalid_vectors = [
+      {:unsupported_version,
+       fn id ->
+         Jason.encode!(%{"jsonrpc" => "1.0", "id" => id, "result" => "0x1"})
+       end},
+      {:unexpected_notification,
+       fn id ->
+         Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "method" => "notice"})
+       end},
+      {:invalid_envelope,
+       fn id ->
+         Jason.encode!(%{
+           "jsonrpc" => "2.0",
+           "id" => id,
+           "result" => "0x1",
+           "error" => %{"code" => -32_000, "message" => "both"}
+         })
+       end}
+    ]
+
+    Enum.each(invalid_vectors, fn {expected_reason, invalid_response} ->
+      vector_task = request_task(context.channel, "client-id", 1_000)
+      assert_receive {:protocol_ws_send, ^ws_pid, vector_id, _payload}
+
+      :ok =
+        TestSupport.ProtocolWSClient.acknowledge(
+          ws_pid,
+          vector_id,
+          invalid_response.(vector_id)
+        )
+
+      assert {:error, %JError{data: %{reason: ^expected_reason}}, _io_ms} =
+               Task.await(vector_task)
+    end)
+
+    error_task = request_task(context.channel, "error-client", 1_000)
+    assert_receive {:protocol_ws_send, ^ws_pid, error_transport_id, _payload}
+    error_data = %{"retry_after" => 75, "scope" => "provider"}
+
+    raw_error =
+      Jason.encode!(%{
+        "jsonrpc" => "2.0",
+        "id" => error_transport_id,
+        "error" => %{"code" => -32_005, "message" => "rate limited", "data" => error_data}
+      })
+
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, error_transport_id, raw_error)
+
+    expected_classification =
+      ErrorClassifier.classify(-32_005, "rate limited",
+        data: error_data,
+        provider_id: context.channel.provider_id
+      )
+
+    assert {:error, %JError{} = classified_error, _io_ms} = Task.await(error_task)
+    assert classified_error.data == error_data
+    assert classified_error.category == expected_classification.category
+    assert classified_error.retriable? == expected_classification.retriable?
+    assert classified_error.breaker_penalty? == expected_classification.breaker_penalty?
+
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+  end
+
+  test "uses validation completion for eligibility and receipt time only for I/O duration",
+       context do
+    {task, attempt_ref} = observed_request_task(context.channel)
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+
+    received_at = System.monotonic_time(:microsecond)
+    raw = success_response(transport_id, "0x1")
+
+    send_parsed_frame(
+      context.connection_pid,
+      ws_pid,
+      context.generation,
+      raw,
+      received_at,
+      System.monotonic_time(:microsecond)
+    )
+
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, transport_id)
+
+    assert_observation(attempt_ref, :send_started)
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :send_confirmed}}, 0
+
+    assert %{event_us: event_us, io_duration_us: io_duration_us} =
+             assert_observation(attempt_ref, :response)
+
+    assert event_us >= received_at
+    assert io_duration_us >= 0
+    assert {:ok, %Response.Success{id: "observed"}, _io_ms} = Task.await(task)
+  end
+
+  test "parses an attributed transport frame exactly once in the WebSockex process", context do
+    mfa = {UpstreamResponse, :parse_ws_frame, 1}
+    :erlang.trace_pattern(mfa, true, [:local])
+    :erlang.trace(context.ws_pid, true, [:call])
+
+    on_exit(fn ->
+      if Process.alive?(context.ws_pid), do: :erlang.trace(context.ws_pid, false, [:call])
+      :erlang.trace_pattern(mfa, false, [:local])
+    end)
+
+    task = request_task(context.channel, "single-parse", 1_000)
+    task_pid = task.pid
+    :erlang.trace(task_pid, true, [:call])
+
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+    raw = success_response(transport_id, %{"payload" => String.duplicate("x", 32_000)})
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, transport_id, raw)
+
+    assert_receive {:trace, ^ws_pid, :call, {UpstreamResponse, :parse_ws_frame, [^raw]}}
+
+    refute_receive {:trace, ^ws_pid, :call, {UpstreamResponse, :parse_ws_frame, [_raw]}}, 0
+    refute_receive {:trace, ^task_pid, :call, {UpstreamResponse, :parse_ws_frame, [_raw]}}, 0
+
+    assert {:ok, %Response.Success{id: "single-parse"}, _io_ms} = Task.await(task)
+  end
+
+  test "uses one bounded Connection authorization call on the unary hot path", context do
+    traced_mfas = [
+      {Connection, :authorize_transport, 7},
+      {Connection, :transport_snapshot, 2},
+      {Connection, :register_transport, 6},
+      {Connection, :queue_transport, 6}
+    ]
+
+    Enum.each(traced_mfas, &:erlang.trace_pattern(&1, true, [:local]))
+
+    on_exit(fn ->
+      Enum.each(traced_mfas, &:erlang.trace_pattern(&1, false, [:local]))
+    end)
+
+    task = request_task(context.channel, "one-authorization", 1_000)
+    task_pid = task.pid
+    :erlang.trace(task_pid, true, [:call])
+
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+
+    :ok =
+      TestSupport.ProtocolWSClient.acknowledge(
+        ws_pid,
+        transport_id,
+        success_response(transport_id, "0x1")
+      )
+
+    assert_receive {:trace, ^task_pid, :call, {Connection, :authorize_transport, _arguments}}
+
+    for function <- [:transport_snapshot, :register_transport, :queue_transport] do
+      refute_receive {:trace, ^task_pid, :call, {Connection, ^function, _arguments}}, 0
+    end
+
+    assert {:ok, %Response.Success{id: "one-authorization"}, _io_ms} = Task.await(task)
+  end
+
+  test "a response validated before the deadline remains eligible after the task resumes",
+       context do
+    owner = self()
+    attempt_ref = make_ref()
+    deadline_us = System.monotonic_time(:microsecond) + 500_000
+
+    task =
+      Task.async(fn ->
+        Process.put(:lasso_attempt_dispatch_context, {owner, attempt_ref})
+        Process.put(:lasso_attempt_deadline_us, deadline_us)
+        WebSocket.request(context.channel, rpc_request("validation-deadline"), 5_000)
+      end)
+
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+    true = :erlang.suspend_process(task.pid)
+    on_exit(fn -> if Process.alive?(task.pid), do: :erlang.resume_process(task.pid) end)
+
+    :ok =
+      TestSupport.ProtocolWSClient.acknowledge(
+        ws_pid,
+        transport_id,
+        success_response(transport_id, "0x1")
+      )
+
+    assert Connection.status(context.instance_id).transport_pending_requests == 0
+    wait_for_monotonic_deadline(deadline_us)
+    true = :erlang.resume_process(task.pid)
+
+    assert_observation(attempt_ref, :send_started)
+
+    assert %{event_us: event_us} = assert_observation(attempt_ref, :response)
+
+    assert event_us < deadline_us
+    refute_receive {:transport_observation, ^attempt_ref, %{kind: :transport_failure}}, 0
+    assert {:ok, %Response.Success{id: "validation-deadline"}, _io_ms} = Task.await(task)
+  end
+
+  test "handler maps live, deadline, cancellation, and generation decisions", context do
+    state = %{
+      parent: self(),
+      connection_generation: context.generation,
+      endpoint: %{id: "test"}
+    }
+
+    live_latch = :atomics.new(1, signed: false)
+    live_key = {:control, make_ref()}
+
+    assert {:reply, :ping, ^state} =
+             Handler.handle_cast(
+               {:send_if_live, context.generation, live_key,
+                System.monotonic_time(:microsecond) + 1_000_000, live_latch, :ping},
+               state
+             )
+
+    assert_receive {:ws_send_decision, _pid, generation, ^live_key, :accepted, _at}
+    assert generation == context.generation
+
+    for {generation, deadline, initial_latch, expected} <- [
+          {context.generation <> "-stale", System.monotonic_time(:microsecond) + 1_000_000, 0,
+           :stale_generation},
+          {context.generation, System.monotonic_time(:microsecond), 0, :deadline},
+          {context.generation, System.monotonic_time(:microsecond) + 1_000_000, 1, :cancelled}
+        ] do
+      latch = :atomics.new(1, signed: false)
+      :atomics.put(latch, 1, initial_latch)
+      key = {:control, make_ref()}
+
+      assert {:ok, ^state} =
+               Handler.handle_cast(
+                 {:send_if_live, generation, key, deadline, latch, :ping},
+                 state
+               )
+
+      assert_receive {:ws_send_decision, _pid, _generation, ^key, {:rejected, ^expected}, _at}
+    end
+  end
+
+  test "task death during a blocked send releases the pending slot", context do
+    task = request_task(context.channel, "caller-died", 5_000)
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+    assert Connection.status(context.instance_id).transport_pending_requests == 1
+
+    Process.unlink(task.pid)
+    task_monitor = Process.monitor(task.pid)
+    Process.exit(task.pid, :kill)
+    assert_receive {:DOWN, ^task_monitor, :process, _pid, :killed}
+
+    assert eventually(fn ->
+             Connection.status(context.instance_id).transport_pending_requests == 0
+           end)
+
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, transport_id)
+  end
+
+  @tag pending_limit: 1
+  test "queued cancellation expiry kills only its stuck connection generation",
+       context do
+    :sys.suspend(context.ws_pid)
+    on_exit(fn -> if Process.alive?(context.ws_pid), do: :sys.resume(context.ws_pid) end)
+
+    task = request_task(context.channel, "cancelled-owner", 5_000)
+
+    assert eventually(fn ->
+             state = :sys.get_state(context.connection_pid)
+
+             match?(
+               [{_id, %{send_state: :queued}}],
+               Map.to_list(state.transport_pending)
+             )
+           end)
+
+    Process.unlink(task.pid)
+    monitor = Process.monitor(task.pid)
+    Process.exit(task.pid, :kill)
+    assert_receive {:DOWN, ^monitor, :process, _pid, :killed}
+
+    assert eventually(fn ->
+             match?(
+               %{transport_pending_requests: 1, transport_tombstones: 1},
+               Connection.status(context.instance_id)
+             )
+           end)
+
+    assert {:error, %JError{category: :local_capacity_rejection}, _io_ms} =
+             WebSocket.request(context.channel, rpc_request("capacity"), 100)
+
+    assert {:message_queue_len, queued} = Process.info(context.ws_pid, :message_queue_len)
+    assert queued <= 1
+
+    send(context.connection_pid, {:heartbeat})
+
+    assert %{pending_requests: 1, queued_control_sends: 0} =
+             Connection.status(context.instance_id)
+
+    {transport_id, pending} = only_transport_pending(context.connection_pid)
+    cleanup_expiry_us = expire_send_cleanup(context.connection_pid, transport_id, pending)
+    ws_monitor = Process.monitor(context.ws_pid)
+
+    send(
+      context.connection_pid,
+      {:send_cleanup_expired, pending.connection, pending.generation, {:transport, transport_id},
+       pending.token, cleanup_expiry_us}
+    )
+
+    assert_receive {:DOWN, ^ws_monitor, :process, ws_pid, :killed}
+    assert ws_pid == context.ws_pid
+    refute_receive {:protocol_ws_send, _ws_pid, _id, _payload}, 0
+
+    assert_receive {:protocol_ws_connected, new_ws_pid, new_generation}
+    assert new_ws_pid != context.ws_pid
+    assert new_generation != context.generation
+
+    assert eventually(fn ->
+             match?(
+               %{transport_pending_requests: 0, pending_requests: 0},
+               Connection.status(context.instance_id)
+             )
+           end)
+  end
+
+  @tag pending_limit: 2
+  test "a blocked subscription send cannot head-of-line block unary registration", context do
+    :sys.suspend(context.ws_pid)
+    on_exit(fn -> if Process.alive?(context.ws_pid), do: :sys.resume(context.ws_pid) end)
+
+    subscription =
+      Task.async(fn ->
+        Connection.request(
+          context.instance_id,
+          "eth_subscribe",
+          ["newHeads"],
+          5_000,
+          "subscription-client"
+        )
+      end)
+
+    assert eventually(fn ->
+             Connection.status(context.instance_id).legacy_pending_requests == 1
+           end)
+
+    unary = request_task(context.channel, "unary-client", 5_000)
+
+    assert eventually(fn ->
+             match?(
+               %{legacy_pending_requests: 1, transport_pending_requests: 1},
+               Connection.status(context.instance_id)
+             )
+           end)
+
+    assert {:message_queue_len, queued} = Process.info(context.ws_pid, :message_queue_len)
+    assert queued <= 2
+
+    :sys.resume(context.ws_pid)
+
+    assert_receive {:protocol_ws_send, ws_pid, first_id, _payload}
+    assert_receive {:protocol_ws_send, ^ws_pid, second_id, _payload}
+
+    for id <- [first_id, second_id] do
+      :ok =
+        TestSupport.ProtocolWSClient.acknowledge(
+          ws_pid,
+          id,
+          success_response(id, "0x1")
+        )
+    end
+
+    assert {:ok, %Response.Success{id: "subscription-client"}} = Task.await(subscription)
+    assert {:ok, %Response.Success{id: "unary-client"}, _io_ms} = Task.await(unary)
+  end
+
+  test "WebSockex death during send remains indeterminate and reconnects", context do
+    {task, attempt_ref} = observed_request_task(context.channel)
+    assert_receive {:protocol_ws_send, ws_pid, _transport_id, _payload}
+
+    Process.exit(ws_pid, :kill)
+    assert_observation(attempt_ref, :send_started)
+
+    assert %{certainty: :indeterminate} =
+             assert_observation(attempt_ref, :transport_failure)
+
+    assert {:error, %JError{}, _io_ms} = Task.await(task)
+
+    assert eventually(fn ->
+             Connection.status(context.instance_id).transport_pending_requests == 0
+           end)
+
+    assert_receive {:protocol_ws_connected, new_ws_pid, new_generation}
+    assert new_ws_pid != ws_pid
+    assert new_generation != context.generation
+  end
+
+  test "a disconnect between registration and send completion cannot be replayed safely",
+       context do
+    {task, attempt_ref} = observed_request_task(context.channel)
+    assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+
+    :ok = TestSupport.ProtocolWSClient.disconnect(ws_pid, :closed)
+    :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, transport_id)
+
+    assert_observation(attempt_ref, :send_started)
+
+    assert %{certainty: :indeterminate} =
+             assert_observation(attempt_ref, :transport_failure)
+
+    assert {:error, %JError{}, _io_ms} = Task.await(task)
+
+    assert_receive {:protocol_ws_connected, new_ws_pid, new_generation}
+    assert new_ws_pid != ws_pid
+    assert new_generation != context.generation
+
+    :ok = TestSupport.ProtocolWSClient.emit_raw(ws_pid, success_response(transport_id, "late"))
+
+    status = Connection.status(context.instance_id)
+    assert status.transport_pending_requests == 0
+    assert status.transport_diagnostics.stale_generation == 1
+  end
+
+  test "a saturated suspended breaker cannot block disconnect handling", context do
+    :sys.suspend(context.breaker_pid)
+
+    on_exit(fn ->
+      if Process.alive?(context.breaker_pid), do: :sys.resume(context.breaker_pid)
+    end)
+
+    %{capacity: capacity} = ControlRing.stats({context.instance_id, :ws})
+
+    for _index <- 1..capacity do
+      assert :ok =
+               CircuitBreaker.report_external_bounded(
+                 {context.instance_id, :ws},
+                 {:error, :disconnect_flood}
+               )
+    end
+
+    assert {:error, :saturated} =
+             CircuitBreaker.report_external_bounded(
+               {context.instance_id, :ws},
+               {:error, :disconnect_flood}
+             )
+
+    disconnect = Task.async(fn -> TestSupport.ProtocolWSClient.disconnect(context.ws_pid) end)
+    assert :ok = Task.await(disconnect, 1_000)
+
+    assert %{connected: false} = Connection.status(context.instance_id)
+    assert {:message_queue_len, queued} = Process.info(context.breaker_pid, :message_queue_len)
+    assert queued <= 1
+
+    assert {:ok, %Snapshot{control_health: :degraded}} =
+             Snapshot.lookup({context.instance_id, :ws})
+
+    :sys.resume(context.breaker_pid)
+  end
+
+  defp request_task(channel, client_id, timeout) do
+    Task.async(fn -> WebSocket.request(channel, rpc_request(client_id), timeout) end)
+  end
+
+  defp observed_request_task(channel) do
+    owner = self()
+    attempt_ref = make_ref()
+
+    task =
+      Task.async(fn ->
+        Process.put(:lasso_attempt_dispatch_context, {owner, attempt_ref})
+        Process.put(:lasso_attempt_deadline_us, System.monotonic_time(:microsecond) + 5_000_000)
+        WebSocket.request(channel, rpc_request("observed"), 5_000)
+      end)
+
+    {task, attempt_ref}
+  end
+
+  defp assert_observation(attempt_ref, kind) do
+    assert_receive {:transport_observation, ^attempt_ref, %{kind: ^kind} = observation}
+    observation
+  end
+
+  defp rpc_request(id) do
+    %{"jsonrpc" => "2.0", "id" => id, "method" => "eth_blockNumber", "params" => []}
+  end
+
+  defp success_response(transport_id, result) do
+    Jason.encode!(%{"jsonrpc" => "2.0", "id" => transport_id, "result" => result})
+  end
+
+  defp transport_id(generation, suffix), do: "lasso-#{generation}-#{suffix}"
+
+  defp send_parsed_frame(
+         connection_pid,
+         ws_pid,
+         generation,
+         raw_bytes,
+         received_at,
+         validated_at
+       ) do
+    parsed = UpstreamResponse.parse_ws_frame(raw_bytes)
+
+    send(
+      connection_pid,
+      {:ws_message, ws_pid, generation, parsed, raw_bytes, received_at, validated_at}
+    )
+  end
+
+  defp replace_deadline(connection_pid, transport_id) do
+    deadline = System.monotonic_time(:microsecond)
+
+    :sys.replace_state(connection_pid, fn state ->
+      pending = Map.fetch!(state.transport_pending, transport_id)
+      Process.cancel_timer(pending.timer)
+
+      put_in(
+        state,
+        [:transport_pending, transport_id],
+        %{
+          pending
+          | deadline_us: deadline,
+            decision_deadline_us: deadline,
+            settlement_deadline_us: deadline,
+            timer: make_ref()
+        }
+      )
+    end)
+
+    deadline
+  end
+
+  defp only_transport_pending(connection_pid) do
+    connection_pid
+    |> :sys.get_state()
+    |> Map.fetch!(:transport_pending)
+    |> Map.to_list()
+    |> then(fn [pending] -> pending end)
+  end
+
+  defp expire_transport(connection_pid, transport_id, pending) do
+    deadline = System.monotonic_time(:microsecond)
+    Process.cancel_timer(pending.timer)
+
+    :sys.replace_state(connection_pid, fn state ->
+      put_in(
+        state,
+        [:transport_pending, transport_id],
+        %{
+          pending
+          | deadline_us: deadline,
+            decision_deadline_us: deadline,
+            settlement_deadline_us: deadline,
+            timer: make_ref()
+        }
+      )
+    end)
+
+    send(
+      connection_pid,
+      {:transport_timeout, transport_id, pending.generation, pending.token}
+    )
+  end
+
+  defp force_transport_cutoffs(
+         connection_pid,
+         transport_id,
+         decision_deadline_us,
+         settlement_deadline_us
+       ) do
+    :sys.replace_state(connection_pid, fn state ->
+      pending = Map.fetch!(state.transport_pending, transport_id)
+      Process.cancel_timer(pending.timer)
+
+      put_in(
+        state,
+        [:transport_pending, transport_id],
+        %{
+          pending
+          | deadline_us: decision_deadline_us,
+            decision_deadline_us: decision_deadline_us,
+            settlement_deadline_us: settlement_deadline_us,
+            timer: make_ref()
+        }
+      )
+    end)
+  end
+
+  defp expire_send_cleanup(connection_pid, transport_id, pending) do
+    cleanup_expiry_us = System.monotonic_time(:microsecond)
+    Process.cancel_timer(pending.timer)
+
+    :sys.replace_state(connection_pid, fn state ->
+      put_in(
+        state,
+        [:transport_pending, transport_id],
+        %{pending | cleanup_expiry_us: cleanup_expiry_us, timer: make_ref()}
+      )
+    end)
+
+    cleanup_expiry_us
+  end
+
+  defp eventually(fun, deadline_us \\ System.monotonic_time(:microsecond) + 1_000_000) do
+    if fun.() do
+      true
+    else
+      if System.monotonic_time(:microsecond) >= deadline_us do
+        false
+      else
+        receive do
+        after
+          0 -> eventually(fun, deadline_us)
+        end
+      end
+    end
+  end
+
+  defp wait_for_monotonic_deadline(deadline_us) do
+    remaining_us = deadline_us - System.monotonic_time(:microsecond)
+
+    if remaining_us > 0 do
+      marker = make_ref()
+      Process.send_after(self(), {:deadline_marker, marker}, div(remaining_us + 999, 1_000))
+
+      receive do
+        {:deadline_marker, ^marker} -> :ok
+      after
+        1_000 -> flunk("monotonic deadline marker was not delivered")
+      end
+
+      wait_for_monotonic_deadline(deadline_us)
+    end
+  end
+
+  defp stop_if_alive(pid) do
+    if Process.alive?(pid), do: GenServer.stop(pid, :normal)
+  catch
+    :exit, _reason -> :ok
+  end
+end

--- a/test/lasso/rpc/circuit_breaker_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_admission_test.exs
@@ -114,12 +114,13 @@ defmodule Lasso.RPC.CircuitBreakerAdmissionTest do
                fn -> send(test_pid, :transport_ran) end,
                100,
                nil,
-               nil,
+               fn _dispatched_at_us -> send(test_pid, :dispatch_receipt) end,
                :immediate,
                deadline_us
              )
 
     refute_receive :transport_ran, 20
+    refute_receive :dispatch_receipt, 20
   end
 
   defp run_after_admission(id, deadline_us, fun) do

--- a/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
+++ b/test/lasso/rpc/circuit_breaker_attempt_lifecycle_test.exs
@@ -3,6 +3,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
 
   alias Lasso.Core.Support.{AttemptLifecycle, CircuitBreaker}
   alias Lasso.Core.Support.CircuitBreaker.Snapshot
+  alias Lasso.Core.Transport.AttemptProtocol
   alias Lasso.JSONRPC.Error, as: JError
 
   setup_all do
@@ -10,7 +11,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     :ok
   end
 
-  test "caller death after dispatch finalizes cancellation once and releases half-open admission" do
+  test "caller death after dispatch publishes no terminal fact and releases half-open admission" do
     id = start_half_open_breaker()
     test_pid = self()
 
@@ -35,13 +36,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
 
     Process.exit(caller_pid, :kill)
 
-    assert_receive {:terminal,
-                    {:error, %JError{category: :cancelled, breaker_penalty?: false}, result_ms},
-                    callback_ms},
-                   1_000
-
-    assert result_ms == callback_ms
-    assert result_ms >= 0
+    refute_receive {:terminal, _, _}, 100
 
     eventually(fn ->
       state = :sys.get_state(breaker_pid)
@@ -81,7 +76,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     refute_receive :attempt_dispatched, 100
   end
 
-  test "dispatch receipt survives lifecycle death after deferred confirmation" do
+  test "dispatch receipt survives transport death after deferred confirmation" do
     id = start_half_open_breaker()
     test_pid = self()
 
@@ -90,17 +85,17 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
         id,
         fn ->
           :ok = AttemptLifecycle.mark_dispatched(AttemptLifecycle.dispatch_context())
-          Process.sleep(:infinity)
+          Process.exit(self(), :kill)
         end,
         1_000,
         dispatch: :deferred,
         on_dispatch: fn dispatched_at_us ->
-          send(test_pid, {:dispatch_receipt, dispatched_at_us})
-          Process.exit(self(), :kill)
+          send(test_pid, {:dispatch_receipt, self(), dispatched_at_us})
         end
       )
 
-    assert_receive {:dispatch_receipt, dispatched_at_us}, 1_000
+    assert_receive {:dispatch_receipt, callback_pid, dispatched_at_us}, 1_000
+    assert callback_pid == self()
     assert is_integer(dispatched_at_us)
     assert {:executed, {:exception, {:exit, :killed, []}}} = result
   end
@@ -108,6 +103,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
   test "repeated deferred confirmation emits one dispatch receipt" do
     id = start_half_open_breaker()
     test_pid = self()
+    callback_key = {__MODULE__, make_ref()}
 
     assert {:executed, :ok} =
              CircuitBreaker.call(
@@ -120,12 +116,465 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
                1_000,
                dispatch: :deferred,
                on_dispatch: fn dispatched_at_us ->
-                 send(test_pid, {:dispatch_receipt, dispatched_at_us})
+                 Process.put(callback_key, Process.get(callback_key, 0) + 1)
+                 send(test_pid, {:dispatch_receipt, self(), dispatched_at_us})
                end
              )
 
-    assert_receive {:dispatch_receipt, _dispatched_at_us}, 1_000
-    refute_receive {:dispatch_receipt, _dispatched_at_us}, 100
+    assert_receive {:dispatch_receipt, callback_pid, _dispatched_at_us}, 1_000
+    assert callback_pid == self()
+    assert Process.get(callback_key) == 1
+    refute_receive {:dispatch_receipt, _, _dispatched_at_us}, 100
+    Process.delete(callback_key)
+  end
+
+  test "task death after send start commits dispatch once and terminalizes once" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    assert {:executed, {:exception, {:exit, :killed, []}}} =
+             CircuitBreaker.call(
+               id,
+               fn ->
+                 context = AttemptLifecycle.dispatch_context()
+                 :ok = AttemptProtocol.send_started(context)
+                 :ok = AttemptProtocol.send_started(context)
+                 Process.exit(self(), :kill)
+               end,
+               1_000,
+               dispatch: :deferred,
+               on_dispatch: fn started_at_us ->
+                 send(test_pid, {:dispatch_receipt, started_at_us})
+               end,
+               on_terminal: fn result, elapsed_ms ->
+                 send(test_pid, {:terminal, result, elapsed_ms})
+               end
+             )
+
+    assert_receive {:dispatch_receipt, started_at_us}, 1_000
+    assert is_integer(started_at_us)
+    refute_receive {:dispatch_receipt, _}, 100
+
+    assert_receive {:terminal, {:exception, {:exit, :killed, []}}, elapsed_ms}, 1_000
+    assert elapsed_ms >= 0
+    refute_receive {:terminal, _, _}, 100
+
+    breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))
+
+    eventually(fn ->
+      state = :sys.get_state(breaker_pid)
+      state.inflight_count == 0 and state.inflight_attempts == %{}
+    end)
+  end
+
+  test "caller publishes the latched receipt when the lifecycle owner dies" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    caller_pid =
+      spawn(fn ->
+        dispatch_ref = make_ref()
+        caller = self()
+
+        result =
+          CircuitBreaker.call(
+            id,
+            fn ->
+              {lifecycle_pid, _attempt_ref} = context = AttemptLifecycle.dispatch_context()
+              send(test_pid, {:owner_death_ready, lifecycle_pid, self()})
+
+              receive do
+                :cross_send ->
+                  :ok = AttemptProtocol.send_started(context)
+                  send(test_pid, :owner_death_send_crossed)
+                  Process.sleep(:infinity)
+              end
+            end,
+            1_000,
+            dispatch: :deferred,
+            on_dispatch: fn started_at_us ->
+              send(caller, {:pipeline_dispatch_receipt, dispatch_ref, started_at_us})
+            end
+          )
+
+        send(
+          test_pid,
+          {:owner_death_result, result, drain_dispatch_receipts(dispatch_ref, [])}
+        )
+      end)
+
+    caller_monitor = Process.monitor(caller_pid)
+    assert_receive {:owner_death_ready, lifecycle_pid, task_pid}, 1_000
+    send(task_pid, :cross_send)
+    assert_receive :owner_death_send_crossed, 1_000
+
+    Process.exit(lifecycle_pid, :kill)
+
+    assert_receive {:owner_death_result, {:executed, {:exception, {:exit, :killed, []}}},
+                    [started_at_us]},
+                   1_000
+
+    assert is_integer(started_at_us)
+    assert_receive {:DOWN, ^caller_monitor, :process, ^caller_pid, reason}, 1_000
+    assert reason in [:normal, :noproc]
+  end
+
+  test "caller closes a suspended lifecycle without authorizing a late callback" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    caller_pid =
+      spawn(fn ->
+        dispatch_ref = make_ref()
+        caller = self()
+
+        result =
+          CircuitBreaker.call(
+            id,
+            fn ->
+              {lifecycle_pid, _attempt_ref} = context = AttemptLifecycle.dispatch_context()
+              send(test_pid, {:ready_to_cross_send, lifecycle_pid, self()})
+
+              receive do
+                :cross_send ->
+                  :ok = AttemptProtocol.send_started(context)
+                  Process.sleep(:infinity)
+              end
+            end,
+            100,
+            dispatch: :deferred,
+            on_dispatch: fn started_at_us ->
+              Process.put({:pipeline_dispatch_receipt, dispatch_ref}, started_at_us)
+              send(caller, {:pipeline_dispatch_receipt, dispatch_ref, started_at_us})
+            end,
+            on_terminal: fn result, elapsed_ms ->
+              send(test_pid, {:suspended_owner_terminal, result, elapsed_ms})
+            end
+          )
+
+        receipts = drain_dispatch_receipts(dispatch_ref, [])
+
+        send(
+          test_pid,
+          {:suspended_owner_result, result, receipts,
+           Process.get({:pipeline_dispatch_receipt, dispatch_ref})}
+        )
+      end)
+
+    caller_monitor = Process.monitor(caller_pid)
+
+    assert_receive {:ready_to_cross_send, lifecycle_pid, task_pid}, 1_000
+    :erlang.suspend_process(lifecycle_pid)
+    send(task_pid, :cross_send)
+
+    assert_receive {:suspended_owner_result,
+                    {:executed, {:error, %JError{category: :timeout, retriable?: true}, 100}},
+                    [started_at_us], callback_started_at_us},
+                   1_000
+
+    assert is_integer(started_at_us)
+    assert callback_started_at_us == started_at_us
+
+    assert_receive {:DOWN, ^caller_monitor, :process, ^caller_pid, reason}, 1_000
+    assert reason in [:normal, :noproc]
+
+    refute_receive {:suspended_owner_terminal, _, _}, 100
+
+    breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))
+
+    eventually(fn ->
+      state = :sys.get_state(breaker_pid)
+      state.inflight_count == 0 and state.inflight_attempts == %{}
+    end)
+  end
+
+  test "suspended lifecycle accepts D-1 and rejects D and D+1 terminal observations" do
+    Enum.each([-1, 0, 1], fn offset_us ->
+      id = start_half_open_breaker()
+      test_pid = self()
+      terminal_ref = make_ref()
+      client_deadline_us = System.monotonic_time(:microsecond) + 500_000
+
+      transport_error =
+        JError.new(-32_008, "local transport result",
+          category: :local_capacity_rejection,
+          retriable?: true,
+          breaker_penalty?: false
+        )
+
+      caller_pid =
+        spawn(fn ->
+          result =
+            CircuitBreaker.call(
+              id,
+              fn ->
+                {lifecycle_pid, _attempt_ref} = context = AttemptLifecycle.dispatch_context()
+                attempt_deadline_us = AttemptProtocol.deadline_us()
+
+                send(
+                  test_pid,
+                  {:decision_ready, terminal_ref, lifecycle_pid, self(), attempt_deadline_us}
+                )
+
+                receive do
+                  {:emit, ^offset_us} ->
+                    :ok =
+                      AttemptProtocol.terminal_at(
+                        context,
+                        :response,
+                        %{response_kind: :success, io_duration_us: 0},
+                        attempt_deadline_us + offset_us
+                      )
+
+                    {:error, transport_error, 0}
+                end
+              end,
+              25,
+              deadline_us: client_deadline_us,
+              dispatch: :deferred,
+              on_terminal: fn result, elapsed_ms ->
+                send(test_pid, {:decision_terminal, terminal_ref, result, elapsed_ms})
+              end
+            )
+
+          send(test_pid, {:decision_result, terminal_ref, result})
+        end)
+
+      assert_receive {:decision_ready, ^terminal_ref, lifecycle_pid, task_pid,
+                      attempt_deadline_us},
+                     1_000
+
+      :erlang.suspend_process(lifecycle_pid)
+      task_monitor = Process.monitor(task_pid)
+      send(task_pid, {:emit, offset_us})
+      assert_receive {:DOWN, ^task_monitor, :process, ^task_pid, :normal}, 1_000
+      wait_until_monotonic(attempt_deadline_us)
+      :erlang.resume_process(lifecycle_pid)
+
+      assert_receive {:decision_result, ^terminal_ref,
+                      {:executed, {:error, ^transport_error, 0}}},
+                     1_000
+
+      if offset_us == -1 do
+        assert_receive {:decision_terminal, ^terminal_ref, {:error, ^transport_error, 0},
+                        elapsed_ms},
+                       1_000
+
+        assert elapsed_ms >= 0
+      else
+        refute_receive {:decision_terminal, ^terminal_ref, _, _}, 50
+      end
+
+      caller_monitor = Process.monitor(caller_pid)
+      assert_receive {:DOWN, ^caller_monitor, :process, ^caller_pid, reason}, 1_000
+      assert reason in [:normal, :noproc]
+    end)
+  end
+
+  test "transport task exposes immutable eligibility and settlement deadlines" do
+    id = start_half_open_breaker()
+    test_pid = self()
+    client_deadline_us = System.monotonic_time(:microsecond) + 500_000
+
+    transport_error =
+      JError.new(-32_008, "local transport result",
+        category: :local_capacity_rejection,
+        retriable?: true,
+        breaker_penalty?: false
+      )
+
+    assert {:executed, {:error, ^transport_error, 0}} =
+             CircuitBreaker.call(
+               id,
+               fn ->
+                 attempt_deadline_us = AttemptProtocol.deadline_us()
+                 settlement_deadline_us = AttemptProtocol.settlement_deadline_us()
+
+                 send(
+                   test_pid,
+                   {:attempt_deadlines, attempt_deadline_us, settlement_deadline_us}
+                 )
+
+                 :ok = AttemptProtocol.predispatch_failure(AttemptProtocol.context(), :local)
+                 {:error, transport_error, 0}
+               end,
+               25,
+               deadline_us: client_deadline_us,
+               dispatch: :deferred
+             )
+
+    assert_receive {:attempt_deadlines, attempt_deadline_us, settlement_deadline_us}, 1_000
+    assert settlement_deadline_us == min(client_deadline_us, attempt_deadline_us + 1_000)
+  end
+
+  test "short attempt settles D-1 after its cutoff and rejects D and D+1" do
+    Enum.each([-1, 0, 1], fn offset_us ->
+      id = start_half_open_breaker()
+      test_pid = self()
+      result_ref = make_ref()
+      client_deadline_us = System.monotonic_time(:microsecond) + 500_000
+
+      transport_error =
+        JError.new(-32_008, "local transport result",
+          category: :local_capacity_rejection,
+          retriable?: true,
+          breaker_penalty?: false
+        )
+
+      spawn(fn ->
+        result =
+          CircuitBreaker.call(
+            id,
+            fn ->
+              {lifecycle_pid, _attempt_ref} = context = AttemptProtocol.context()
+              attempt_deadline_us = AttemptProtocol.deadline_us()
+
+              :ok =
+                AttemptProtocol.terminal_at(
+                  context,
+                  :response,
+                  %{response_kind: :success, io_duration_us: 0},
+                  attempt_deadline_us + offset_us
+                )
+
+              send(
+                test_pid,
+                {:short_attempt_ready, result_ref, lifecycle_pid, self(), attempt_deadline_us}
+              )
+
+              receive do
+                :finish_after_cutoff ->
+                  yield_until_monotonic(attempt_deadline_us + 1)
+                  send(test_pid, {:short_attempt_finished, result_ref})
+                  {:error, transport_error, 0}
+              end
+            end,
+            100,
+            deadline_us: client_deadline_us,
+            dispatch: :deferred
+          )
+
+        send(test_pid, {:short_attempt_result, result_ref, result})
+      end)
+
+      assert_receive {:short_attempt_ready, ^result_ref, lifecycle_pid, task_pid,
+                      attempt_deadline_us},
+                     1_000
+
+      eventually(fn ->
+        match?({:message_queue_len, 0}, Process.info(lifecycle_pid, :message_queue_len))
+      end)
+
+      send(task_pid, :finish_after_cutoff)
+      assert_receive {:short_attempt_finished, ^result_ref}, 1_000
+      assert System.monotonic_time(:microsecond) >= attempt_deadline_us
+
+      if offset_us == -1 do
+        assert_receive {:short_attempt_result, ^result_ref,
+                        {:executed, {:error, ^transport_error, 0}}},
+                       1_000
+      else
+        assert_receive {:short_attempt_result, ^result_ref, {:rejected, :admission_timeout}},
+                       1_000
+      end
+    end)
+  end
+
+  test "caller timeout closes publication before a suspended lifecycle can report late" do
+    id = start_half_open_breaker()
+    test_pid = self()
+    terminal_ref = make_ref()
+
+    caller_pid =
+      spawn(fn ->
+        result =
+          CircuitBreaker.call(
+            id,
+            fn ->
+              {lifecycle_pid, _attempt_ref} = context = AttemptLifecycle.dispatch_context()
+              send(test_pid, {:timeout_close_ready, lifecycle_pid, self()})
+
+              receive do
+                :cross_send ->
+                  :ok = AttemptProtocol.send_started(context)
+                  send(test_pid, :timeout_close_send_started)
+                  Process.sleep(:infinity)
+              end
+            end,
+            50,
+            dispatch: :deferred,
+            on_terminal: fn result, elapsed_ms ->
+              send(test_pid, {:timeout_close_terminal, terminal_ref, result, elapsed_ms})
+            end
+          )
+
+        send(test_pid, {:timeout_close_result, terminal_ref, result})
+      end)
+
+    assert_receive {:timeout_close_ready, lifecycle_pid, task_pid}, 1_000
+    :erlang.suspend_process(lifecycle_pid)
+    send(task_pid, :cross_send)
+    assert_receive :timeout_close_send_started, 1_000
+
+    assert_receive {:timeout_close_result, ^terminal_ref,
+                    {:executed, {:error, %JError{category: :timeout}, 50}}},
+                   1_000
+
+    refute Process.alive?(lifecycle_pid)
+    refute Process.alive?(task_pid)
+    refute_receive {:timeout_close_terminal, ^terminal_ref, _, _}, 100
+
+    caller_monitor = Process.monitor(caller_pid)
+    assert_receive {:DOWN, ^caller_monitor, :process, ^caller_pid, reason}, 1_000
+    assert reason in [:normal, :noproc]
+  end
+
+  test "not-dispatched transport failure releases an open send reservation" do
+    id = start_half_open_breaker()
+    test_pid = self()
+
+    transport_error =
+      JError.new(-32_008, "pool unavailable",
+        category: :local_capacity_rejection,
+        retriable?: true,
+        breaker_penalty?: false
+      )
+
+    assert {:executed, {:error, ^transport_error, 2}} =
+             CircuitBreaker.call(
+               id,
+               fn ->
+                 context = AttemptLifecycle.dispatch_context()
+                 :ok = AttemptProtocol.send_started(context)
+
+                 :ok =
+                   AttemptProtocol.terminal(context, :transport_failure, %{
+                     reason: :network_error,
+                     certainty: :not_dispatched,
+                     elapsed_us: 0
+                   })
+
+                 {:error, transport_error, 2}
+               end,
+               1_000,
+               dispatch: :deferred,
+               on_dispatch: fn started_at_us ->
+                 send(test_pid, {:dispatch_receipt, started_at_us})
+               end,
+               on_terminal: fn result, elapsed_ms ->
+                 send(test_pid, {:terminal, result, elapsed_ms})
+               end
+             )
+
+    refute_receive {:dispatch_receipt, _}, 100
+    refute_receive {:terminal, _, _}, 100
+
+    breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))
+    state = :sys.get_state(breaker_pid)
+    assert state.state == :half_open
+    assert state.failure_count == 0
+    assert state.inflight_count == 0
+    assert state.inflight_attempts == %{}
   end
 
   test "immediate dispatch receipt is emitted before the worker becomes runnable" do
@@ -136,18 +585,22 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
              CircuitBreaker.call(
                id,
                fn ->
-                 send(test_pid, :worker_ran)
+                 send(test_pid, {:immediate_order, :worker_ran})
                  :ok
                end,
                1_000,
-               on_dispatch: fn _dispatched_at_us -> send(test_pid, :dispatch_receipt) end
+               on_dispatch: fn _dispatched_at_us ->
+                 send(test_pid, {:immediate_order, :dispatch_receipt})
+               end
              )
 
-    assert_receive :dispatch_receipt, 1_000
-    assert_receive :worker_ran, 1_000
+    assert_receive {:immediate_order, first_event}, 1_000
+    assert first_event == :dispatch_receipt
+    assert_receive {:immediate_order, second_event}, 1_000
+    assert second_event == :worker_ran
   end
 
-  test "a completed operation wins over caller death" do
+  test "a completed operation is not published after its caller dies" do
     id = start_half_open_breaker()
     test_pid = self()
 
@@ -157,8 +610,11 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
           id,
           fn ->
             {lifecycle_pid, _dispatch_ref} = AttemptLifecycle.dispatch_context()
-            send(test_pid, {:operation_completed, lifecycle_pid})
-            :ok
+            send(test_pid, {:operation_ready, lifecycle_pid, self()})
+
+            receive do
+              :complete_operation -> :ok
+            end
           end,
           5_000,
           on_terminal: fn result, elapsed_ms ->
@@ -167,18 +623,18 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
         )
       end)
 
-    assert_receive {:operation_completed, lifecycle_pid}, 1_000
+    assert_receive {:operation_ready, lifecycle_pid, task_pid}, 1_000
     :erlang.suspend_process(lifecycle_pid)
-    Process.sleep(20)
+    task_monitor = Process.monitor(task_pid)
+    send(task_pid, :complete_operation)
+    assert_receive {:DOWN, ^task_monitor, :process, ^task_pid, :normal}, 1_000
     Process.exit(caller_pid, :kill)
-    :erlang.resume_process(lifecycle_pid)
+    if Process.alive?(lifecycle_pid), do: :erlang.resume_process(lifecycle_pid)
 
-    assert_receive {:terminal, :ok, elapsed_ms}, 1_000
-    assert elapsed_ms >= 0
     refute_receive {:terminal, _, _}, 100
   end
 
-  test "slow terminal work does not block the breaker or fail the completed call" do
+  test "a blocked compatibility terminal callback cannot delay the attempt result" do
     id = {"slow_terminal_#{System.unique_integer([:positive])}", :http}
     test_pid = self()
 
@@ -187,18 +643,30 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
         {id, %{failure_threshold: 2, recovery_timeout: 60_000, success_threshold: 1}}
       )
 
-    assert {:executed, :ok} =
-             CircuitBreaker.call(id, fn -> :ok end, 1_000,
-               on_terminal: fn _result, _elapsed_ms ->
-                 send(test_pid, :callback_started)
-                 Process.sleep(250)
-                 send(test_pid, :callback_finished)
-               end
-             )
+    caller_pid =
+      spawn(fn ->
+        result =
+          CircuitBreaker.call(id, fn -> :ok end, 1_000,
+            on_terminal: fn _result, _elapsed_ms ->
+              send(test_pid, {:callback_started, self()})
 
-    assert_receive :callback_started, 1_000
-    assert {:executed, :ok} = CircuitBreaker.call(id, fn -> :ok end, 1_000)
+              receive do
+                :release_callback -> send(test_pid, :callback_finished)
+              end
+            end
+          )
+
+        send(test_pid, {:attempt_result, result})
+      end)
+
+    assert_receive {:attempt_result, {:executed, :ok}}, 1_000
+    assert_receive {:callback_started, callback_pid}, 1_000
+    refute callback_pid == caller_pid
+    refute_receive :callback_finished, 100
+
+    send(callback_pid, :release_callback)
     assert_receive :callback_finished, 1_000
+    refute_receive :callback_finished, 100
   end
 
   test "unsupported preflight and local capacity rejection do not mutate breaker health" do
@@ -363,10 +831,10 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
 
     assert {:executed, :ok} = CircuitBreaker.call(id, fn -> :ok end)
 
-    state = :sys.get_state(breaker_pid)
-    assert state.state == :closed
-    assert state.inflight_count == 0
-    assert state.inflight_attempts == %{}
+    eventually(fn ->
+      state = :sys.get_state(breaker_pid)
+      state.state == :closed and state.inflight_count == 0 and state.inflight_attempts == %{}
+    end)
   end
 
   test "deferred local queue timeout is admission, not a terminal attempt" do
@@ -496,57 +964,16 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     refute_receive {:terminal, _, _}, 100
   end
 
-  test "dispatch authorization rejects a dead caller even when its message arrives first" do
-    id = start_half_open_breaker()
-    test_pid = self()
+  test "dispatch authorization performs no lifecycle request reply" do
+    lifecycle_pid = spawn(fn -> Process.sleep(:infinity) end)
+    context = {lifecycle_pid, make_ref()}
+    {:message_queue_len, before_count} = Process.info(lifecycle_pid, :message_queue_len)
 
-    caller_pid =
-      spawn(fn ->
-        CircuitBreaker.call(
-          id,
-          fn ->
-            {lifecycle_pid, _dispatch_ref} = context = AttemptLifecycle.dispatch_context()
-            send(test_pid, {:ready_to_authorize, lifecycle_pid, context, self()})
+    assert :ok = AttemptLifecycle.authorize_dispatch(context)
+    {:message_queue_len, after_count} = Process.info(lifecycle_pid, :message_queue_len)
+    assert after_count == before_count
 
-            receive do
-              :authorize -> :ok
-            end
-
-            case AttemptLifecycle.mark_dispatched(context) do
-              :ok ->
-                send(test_pid, {:authorization, :ok})
-                send(test_pid, :ghost_dispatch)
-
-              rejection ->
-                send(test_pid, {:authorization, rejection})
-                rejection
-            end
-          end,
-          1_000,
-          dispatch: :deferred,
-          on_terminal: fn result, elapsed_ms ->
-            send(test_pid, {:terminal, result, elapsed_ms})
-          end
-        )
-      end)
-
-    assert_receive {:ready_to_authorize, lifecycle_pid, _context, worker_pid}, 1_000
-    :erlang.suspend_process(lifecycle_pid)
-    send(worker_pid, :authorize)
-    Process.sleep(20)
-    Process.exit(caller_pid, :kill)
-    :erlang.resume_process(lifecycle_pid)
-
-    assert_receive {:authorization, {:error, :cancelled}}, 1_000
-    refute_receive :ghost_dispatch, 100
-    refute_receive {:terminal, _, _}, 100
-
-    breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))
-
-    eventually(fn ->
-      state = :sys.get_state(breaker_pid)
-      state.inflight_count == 0 and state.inflight_attempts == %{}
-    end)
+    Process.exit(lifecycle_pid, :kill)
   end
 
   test "an explicitly aborted transport dispatch remains admission evidence" do
@@ -586,57 +1013,15 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     assert state.inflight_attempts == %{}
   end
 
-  test "timed-out dispatch authorization cancels its queued grant" do
-    id = start_half_open_breaker()
-    test_pid = self()
-
-    caller_pid =
-      spawn(fn ->
-        result =
-          CircuitBreaker.call(
-            id,
-            fn ->
-              {lifecycle_pid, _dispatch_ref} = context = AttemptLifecycle.dispatch_context()
-              send(test_pid, {:authorization_ready, lifecycle_pid, self()})
-
-              receive do
-                :authorize -> :ok
-              end
-
-              authorization = AttemptLifecycle.mark_dispatched(context)
-              send(test_pid, {:authorization_result, authorization})
-
-              {:error,
-               JError.new(-32_008, "cancelled locally",
-                 category: :local_capacity_rejection,
-                 retriable?: true,
-                 breaker_penalty?: false
-               ), 1_000}
-            end,
-            1_500,
-            dispatch: :deferred,
-            on_terminal: fn result, elapsed_ms ->
-              send(test_pid, {:terminal, result, elapsed_ms})
-            end
-          )
-
-        send(test_pid, {:caller_result, result})
-      end)
-
-    assert_receive {:authorization_ready, lifecycle_pid, worker_pid}, 1_000
+  test "dispatch confirmation is one-way while the lifecycle owner is suspended" do
+    lifecycle_pid = spawn(fn -> Process.sleep(:infinity) end)
+    context = {lifecycle_pid, make_ref()}
     :erlang.suspend_process(lifecycle_pid)
-    send(worker_pid, :authorize)
-    Process.sleep(1_100)
-    :erlang.resume_process(lifecycle_pid)
 
-    assert_receive {:authorization_result, {:error, :cancelled}}, 500
+    assert :ok = AttemptLifecycle.mark_dispatched(context)
+    assert {:message_queue_len, 2} = Process.info(lifecycle_pid, :message_queue_len)
 
-    assert_receive {:caller_result,
-                    {:executed, {:error, %JError{category: :local_capacity_rejection}, 1_000}}},
-                   500
-
-    refute_receive {:terminal, _, _}, 100
-    refute Process.alive?(caller_pid)
+    Process.exit(lifecycle_pid, :kill)
   end
 
   test "local connection loss after confirmed dispatch invokes one terminal callback" do
@@ -722,7 +1107,7 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     assert_receive {:authorized_for_late_confirm, _context, worker_pid}, 1_000
     Process.exit(caller_pid, :kill)
     send(worker_pid, :confirm)
-    assert_receive {:late_confirmation, {:error, :cancelled}}, 1_000
+    refute_receive {:late_confirmation, _}, 100
     refute_receive {:terminal, _, _}, 100
   end
 
@@ -748,13 +1133,34 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
                end
              )
 
-    assert_receive {:late_deadline_confirmation, {:error, :cancelled}}, 1_000
+    refute_receive {:late_deadline_confirmation, _}, 100
     refute_receive {:terminal, _, _}, 100
 
     breaker_pid = GenServer.whereis(CircuitBreaker.via_name(id))
     state = :sys.get_state(breaker_pid)
     assert state.inflight_count == 0
     assert state.inflight_attempts == %{}
+  end
+
+  test "attempt timeout stops blocking transport before the shared client deadline" do
+    id = start_half_open_breaker()
+    started_at_ms = System.monotonic_time(:millisecond)
+    client_deadline_us = System.monotonic_time(:microsecond) + 500_000
+
+    assert {:executed, {:error, %JError{category: :timeout, retriable?: true}, 25}} =
+             CircuitBreaker.call(
+               id,
+               fn ->
+                 :ok = AttemptProtocol.send_started(AttemptProtocol.context())
+                 Process.sleep(:infinity)
+               end,
+               25,
+               deadline_us: client_deadline_us,
+               dispatch: :deferred
+             )
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at_ms
+    assert elapsed_ms < 250
   end
 
   test "expired queued admission does not create a token for a live caller" do
@@ -834,6 +1240,33 @@ defmodule Lasso.RPC.CircuitBreakerAttemptLifecycleTest do
     })
 
     id
+  end
+
+  defp drain_dispatch_receipts(dispatch_ref, receipts) do
+    receive do
+      {:pipeline_dispatch_receipt, ^dispatch_ref, started_at_us} ->
+        drain_dispatch_receipts(dispatch_ref, [started_at_us | receipts])
+    after
+      0 -> Enum.reverse(receipts)
+    end
+  end
+
+  defp wait_until_monotonic(deadline_us) do
+    remaining_us = deadline_us - System.monotonic_time(:microsecond)
+
+    if remaining_us > 0 do
+      timer_ref = make_ref()
+      Process.send_after(self(), {:monotonic_deadline, timer_ref}, div(remaining_us + 999, 1_000))
+      assert_receive {:monotonic_deadline, ^timer_ref}, 1_000
+      wait_until_monotonic(deadline_us)
+    end
+  end
+
+  defp yield_until_monotonic(deadline_us) do
+    if System.monotonic_time(:microsecond) < deadline_us do
+      :erlang.yield()
+      yield_until_monotonic(deadline_us)
+    end
   end
 
   defp eventually(fun, attempts \\ 50)

--- a/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
+++ b/test/lasso/rpc/circuit_breaker_half_open_admission_test.exs
@@ -1,7 +1,7 @@
 defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
   use ExUnit.Case, async: false
 
-  alias Lasso.Core.Support.CircuitBreaker
+  alias Lasso.Core.Support.{AttemptLifecycle, CircuitBreaker}
   alias Lasso.Core.Support.CircuitBreaker.{AdmissionReceipt, ControlRing, Snapshot, Storage}
 
   test "concurrent recovery candidates produce one bounded lease" do
@@ -90,18 +90,29 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
     assert token == receipt.token
   end
 
-  test "the attempt lifecycle owns and releases the half-open lease when it dies" do
+  test "the caller retains half-open lease ownership when the lifecycle dies" do
     {id, breaker_pid} = start_half_open_breaker()
     parent = self()
 
     caller =
       spawn(fn ->
-        result = CircuitBreaker.call(id, fn -> Process.sleep(:infinity) end, 5_000)
+        result =
+          CircuitBreaker.call(
+            id,
+            fn ->
+              {lifecycle_pid, _attempt_ref} = AttemptLifecycle.dispatch_context()
+              send(parent, {:attempt_started, lifecycle_pid})
+              Process.sleep(:infinity)
+            end,
+            5_000
+          )
+
         send(parent, {:call_result, result})
         receive do: (:stop -> :ok)
       end)
 
-    lifecycle_pid = await_lease_owner(id, caller)
+    assert_receive {:attempt_started, lifecycle_pid}, 1_000
+    assert [{^id, %{owner_pid: ^caller, claimed?: true}}] = :ets.lookup(Storage.lease_table(), id)
     assert Process.alive?(caller)
     Process.exit(lifecycle_pid, :kill)
 
@@ -191,20 +202,6 @@ defmodule Lasso.RPC.CircuitBreakerHalfOpenAdmissionTest do
     {:ok, restarted_pid} = CircuitBreaker.start_link({id, %{success_threshold: 1}})
     on_exit(fn -> if Process.alive?(restarted_pid), do: GenServer.stop(restarted_pid) end)
     assert %{inflight_count: 0} = :sys.get_state(restarted_pid)
-  end
-
-  defp await_lease_owner(id, excluded_pid, attempts \\ 100)
-  defp await_lease_owner(_id, _excluded_pid, 0), do: flunk("lease ownership was not transferred")
-
-  defp await_lease_owner(id, excluded_pid, attempts) do
-    case :ets.lookup(Storage.lease_table(), id) do
-      [{^id, %{owner_pid: owner_pid}}] when owner_pid != excluded_pid ->
-        owner_pid
-
-      _ ->
-        Process.sleep(5)
-        await_lease_owner(id, excluded_pid, attempts - 1)
-    end
   end
 
   defp await_snapshot_state(id, state, attempts \\ 100)

--- a/test/support/failing_ws_client.ex
+++ b/test/support/failing_ws_client.ex
@@ -15,4 +15,6 @@ defmodule TestSupport.FailingWSClient do
   def send_frame(_pid, _frame) do
     {:error, :not_connected}
   end
+
+  def cast(_pid, _message), do: :ok
 end

--- a/test/support/lasso/testing/behavior_http_client.ex
+++ b/test/support/lasso/testing/behavior_http_client.ex
@@ -87,7 +87,7 @@ defmodule Lasso.Testing.BehaviorHttpClient do
       end
     else
       # Return a mock response as raw bytes to prevent hanging
-      {:ok, {:raw, Jason.encode!(%{"jsonrpc" => "2.0", "id" => 1, "result" => "0x1"})}}
+      {:ok, {:raw, Jason.encode!(%{"jsonrpc" => "2.0", "id" => request_id, "result" => "0x1"})}}
     end
   end
 

--- a/test/support/mock_http_client.ex
+++ b/test/support/mock_http_client.ex
@@ -10,21 +10,26 @@ defmodule MockHttpClient do
 
   def request(_config, "eth_chainId", _params, opts) do
     AttemptLifecycle.mark_dispatched(Keyword.get(opts, :attempt_dispatch))
-    {:ok, {:raw, ~s({"jsonrpc":"2.0","id":1,"result":"0x1"})}}
+    response(opts, "0x1")
   end
 
   def request(_config, "eth_blockNumber", _params, opts) do
     AttemptLifecycle.mark_dispatched(Keyword.get(opts, :attempt_dispatch))
-    {:ok, {:raw, ~s({"jsonrpc":"2.0","id":1,"result":"0x12345"})}}
+    response(opts, "0x12345")
   end
 
   def request(_config, "eth_getBalance", _params, opts) do
     AttemptLifecycle.mark_dispatched(Keyword.get(opts, :attempt_dispatch))
-    {:ok, {:raw, ~s({"jsonrpc":"2.0","id":1,"result":"0x1234567890abcdef"})}}
+    response(opts, "0x1234567890abcdef")
   end
 
   def request(_config, _method, _params, opts) do
     AttemptLifecycle.mark_dispatched(Keyword.get(opts, :attempt_dispatch))
-    {:ok, {:raw, ~s({"jsonrpc":"2.0","id":1,"result":"0x0"})}}
+    response(opts, "0x0")
+  end
+
+  defp response(opts, result) do
+    id = Keyword.get(opts, :request_id, 1)
+    {:ok, {:raw, Jason.encode!(%{"jsonrpc" => "2.0", "id" => id, "result" => result})}}
   end
 end

--- a/test/support/mock_ws_client.ex
+++ b/test/support/mock_ws_client.ex
@@ -13,6 +13,10 @@ defmodule TestSupport.MockWSClient do
     GenServer.call(pid, {:send_frame, frame})
   end
 
+  def cast(pid, message) do
+    GenServer.cast(pid, {:websockex_cast, message})
+  end
+
   # Test helpers for simulating various WebSocket behaviors
   def emit_message(pid, json_map) when is_map(json_map) do
     GenServer.cast(pid, {:emit_message, json_map})
@@ -279,6 +283,20 @@ defmodule TestSupport.MockWSClient do
   end
 
   @impl true
+  def handle_cast(
+        {:websockex_cast, message},
+        %{handler: handler, state: handler_state} = state
+      ) do
+    case handler.handle_cast(message, handler_state) do
+      {:reply, frame, handler_state} ->
+        state = %{state | state: handler_state}
+        {:noreply, dispatch_cast_frame(frame, state)}
+
+      {:ok, handler_state} ->
+        {:noreply, %{state | state: handler_state}}
+    end
+  end
+
   def handle_cast({:emit_message, json_map}, %{handler: handler, state: st, connected: true} = s) do
     {:ok, new_state} = handler.handle_frame({:text, Jason.encode!(json_map)}, st)
     {:noreply, %{s | state: new_state}}
@@ -343,5 +361,67 @@ defmodule TestSupport.MockWSClient do
   def handle_cast({:emit_subscription, _subscription_id, _result}, %{connected: false} = s) do
     # Ignore subscription notifications when not connected
     {:noreply, s}
+  end
+
+  defp dispatch_cast_frame({:text, _payload}, %{failure_mode: :fail_sends} = state),
+    do: state
+
+  defp dispatch_cast_frame(
+         {:text, payload},
+         %{
+           handler: handler,
+           state: handler_state,
+           connected: true,
+           response_delay: delay,
+           response_mode: mode
+         } = state
+       ) do
+    response_payload = response_payload(payload, mode)
+
+    if delay > 0 do
+      Process.send_after(self(), {:delayed_response, response_payload}, delay)
+      state
+    else
+      case handler.handle_frame({:text, response_payload}, handler_state) do
+        {:ok, new_handler_state} -> %{state | state: new_handler_state}
+        other -> %{state | state: elem(other, 1)}
+      end
+    end
+  end
+
+  defp dispatch_cast_frame(:ping, %{failure_mode: :fail_pings} = state), do: state
+
+  defp dispatch_cast_frame(:ping, %{handler: handler, state: handler_state} = state) do
+    {:ok, new_handler_state} = handler.handle_frame({:pong, ""}, handler_state)
+    %{state | state: new_handler_state}
+  end
+
+  defp dispatch_cast_frame(_frame, state), do: state
+
+  defp response_payload(payload, mode) do
+    case Jason.decode(payload) do
+      {:ok, %{"id" => id, "method" => "eth_subscribe", "params" => _params}} ->
+        subscription_id = "0x" <> Base.encode16(:crypto.strong_rand_bytes(16), case: :lower)
+
+        case mode do
+          :result ->
+            ~s({"jsonrpc":"2.0","id":#{Jason.encode!(id)},"result":#{Jason.encode!(subscription_id)}})
+
+          :error ->
+            ~s({"jsonrpc":"2.0","id":#{Jason.encode!(id)},"error":{"code":-32_601,"message":"Subscription not supported"}})
+        end
+
+      {:ok, %{"id" => id, "method" => method, "params" => params}} ->
+        case mode do
+          :result ->
+            ~s({"jsonrpc":"2.0","id":#{Jason.encode!(id)},"result":{"rpc_method":#{Jason.encode!(method)},"params":#{Jason.encode!(params)},"mock_response":true}})
+
+          :error ->
+            get_error_for_method(method, id)
+        end
+
+      _other ->
+        payload
+    end
   end
 end

--- a/test/support/protocol_ws_client.ex
+++ b/test/support/protocol_ws_client.ex
@@ -1,0 +1,148 @@
+defmodule TestSupport.ProtocolWSClient do
+  @moduledoc false
+
+  use GenServer
+
+  def start_link(url, handler, handler_state, opts \\ []) do
+    GenServer.start_link(__MODULE__, {url, handler, handler_state, opts})
+  end
+
+  def send_frame(pid, frame), do: GenServer.call(pid, {:send_frame, frame}, :infinity)
+  def cast(pid, message), do: GenServer.cast(pid, {:websockex_cast, message})
+
+  def acknowledge(pid, transport_id, raw_response \\ nil) do
+    GenServer.call(pid, {:acknowledge, transport_id, raw_response})
+  end
+
+  def fail(pid, transport_id, reason) do
+    GenServer.call(pid, {:fail, transport_id, reason})
+  end
+
+  def emit_raw(pid, raw_response), do: GenServer.call(pid, {:emit_raw, raw_response})
+
+  def disconnect(pid, reason \\ :closed), do: GenServer.call(pid, {:disconnect, reason})
+
+  @impl true
+  def init({_url, handler, handler_state, _opts}) do
+    controller = Application.fetch_env!(:lasso, :protocol_ws_test_owner)
+    mode = Application.get_env(:lasso, :protocol_ws_send_mode, :manual)
+    {:ok, connected_state} = handler.handle_connect(%{}, handler_state)
+    send(controller, {:protocol_ws_connected, self(), connected_state.connection_generation})
+
+    {:ok,
+     %{
+       controller: controller,
+       handler: handler,
+       handler_state: connected_state,
+       mode: mode,
+       sends: %{}
+     }}
+  end
+
+  @impl true
+  def handle_cast({:websockex_cast, message}, state) do
+    case state.handler.handle_cast(message, state.handler_state) do
+      {:reply, frame, handler_state} ->
+        state = %{state | handler_state: handler_state}
+        {:noreply, record_outbound_frame(frame, state)}
+
+      {:ok, handler_state} ->
+        {:noreply, %{state | handler_state: handler_state}}
+    end
+  end
+
+  @impl true
+  def handle_call({:send_frame, {:text, payload}}, from, state) do
+    %{"id" => transport_id} = Jason.decode!(payload)
+    send(state.controller, {:protocol_ws_send, self(), transport_id, payload})
+
+    case state.mode do
+      :manual ->
+        {:noreply, %{state | sends: Map.put(state.sends, transport_id, from)}}
+
+      :auto_success ->
+        raw_response =
+          Jason.encode!(%{"jsonrpc" => "2.0", "id" => transport_id, "result" => "0x1"})
+
+        {:ok, handler_state} =
+          state.handler.handle_frame({:text, raw_response}, state.handler_state)
+
+        sync_connection(handler_state)
+        {:reply, :ok, %{state | handler_state: handler_state}}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:send_frame, _frame}, _from, state), do: {:reply, :ok, state}
+
+  def handle_call({:acknowledge, transport_id, raw_response}, _from, state) do
+    {send_entry, sends} = Map.pop(state.sends, transport_id)
+    true = not is_nil(send_entry)
+
+    if is_tuple(send_entry), do: GenServer.reply(send_entry, :ok)
+
+    state = %{state | sends: sends}
+
+    case raw_response do
+      nil ->
+        {:reply, :ok, state}
+
+      raw_response ->
+        {:ok, handler_state} =
+          state.handler.handle_frame({:text, raw_response}, state.handler_state)
+
+        sync_connection(handler_state)
+        {:reply, :ok, %{state | handler_state: handler_state}}
+    end
+  end
+
+  def handle_call({:fail, transport_id, reason}, _from, state) do
+    {send_entry, sends} = Map.pop(state.sends, transport_id)
+    true = not is_nil(send_entry)
+    if is_tuple(send_entry), do: GenServer.reply(send_entry, {:error, reason})
+    {:reply, :ok, %{state | sends: sends}}
+  end
+
+  def handle_call({:emit_raw, raw_response}, _from, state) do
+    {:ok, handler_state} = state.handler.handle_frame({:text, raw_response}, state.handler_state)
+    sync_connection(handler_state)
+    {:reply, :ok, %{state | handler_state: handler_state}}
+  end
+
+  def handle_call({:disconnect, reason}, _from, state) do
+    {:ok, handler_state} = state.handler.handle_disconnect(%{reason: reason}, state.handler_state)
+    sync_connection(handler_state)
+    {:reply, :ok, %{state | handler_state: handler_state}}
+  end
+
+  defp sync_connection(handler_state) do
+    GenServer.call(handler_state.parent, :status)
+  end
+
+  defp record_outbound_frame({:text, payload}, state) do
+    %{"id" => transport_id} = Jason.decode!(payload)
+    send(state.controller, {:protocol_ws_send, self(), transport_id, payload})
+    state = %{state | sends: Map.put(state.sends, transport_id, payload)}
+
+    case state.mode do
+      :auto_success ->
+        raw_response =
+          Jason.encode!(%{"jsonrpc" => "2.0", "id" => transport_id, "result" => "0x1"})
+
+        {:ok, handler_state} =
+          state.handler.handle_frame({:text, raw_response}, state.handler_state)
+
+        %{state | handler_state: handler_state}
+
+      _other ->
+        state
+    end
+  end
+
+  defp record_outbound_frame(frame, state) do
+    send(state.controller, {:protocol_ws_control_send, self(), frame})
+    state
+  end
+end


### PR DESCRIPTION
## Stack

Depends on #56, which contains the independently reviewed strict response validator. Review this PR
as the atomic runtime cutover across lifecycle, Finch, and WebSocket transport behavior.

## Summary

Replaces synchronous transport authorization/confirmation handshakes with stamped one-way attempt
observations governed by immutable decision and settlement deadlines.

The compatibility lifecycle now conservatively tracks exactly one dispatch receipt and terminal
decision in the request caller. HTTP uses supported public Finch APIs plus boot-critical send
tracking. WebSocket unary requests use generation-safe internal IDs, bounded pending ownership, and
deadline/cancellation-aware physical sends.

## Runtime behavior

### Attempt protocol and deadlines

- `send_started`, positive proof, pre-send proof, and terminal observations carry authoritative
  monotonic stamps.
- Strict eligibility remains `event_us < decision_deadline_us`; equality is expired.
- A capped settlement deadline gives already-eligible events time to reach the lifecycle without
  making late validation eligible.
- The effective per-attempt cutoff remains the minimum of the shared request decision deadline and
  the attempt slice, preserving sequential fallback time.
- Unknown send state is `indeterminate` and cannot authorize unsafe replay.
- Dispatch receipts and terminal callbacks are linearized by the request caller, including
  lifecycle death and scheduling-overtake races.
- Timeout/closure cannot publish late compatibility evidence or revise breaker/routing state.

### HTTP

- Pins Finch 0.23 and uses public `Finch.request/3`; private Finch pool/Mint ownership is removed.
- A supervised telemetry tracker supplies attempt-local positive send proof and repairs stale or
  replaced handlers conservatively.
- A deadline is rechecked after opening dispatch ambiguity and before entering Finch.
- Strict response validation preserves the exact raw binary for normal same-ID responses.

### WebSocket

- Generates unique internal upstream IDs and restores client IDs only at the response boundary.
- Keys pending attempts by internal ID and immutable connection generation, with owner monitors,
  tokenized timers/cancellation, bounded pending capacity, and capped expiry tombstones.
- Rejects stale-generation frames, duplicate/cross-correlated IDs, malformed/trailing/batch frames,
  and validation-complete events at or after the strict cutoff.
- Performs one bounded Connection authorization call per unary attempt; the Handler parses each
  unary response once and the request task does not reparse it.
- Subscription sends no longer block unary registration/correlation in the Connection owner.
- Breaker disconnect reporting is bounded and asynchronous rather than a five-second synchronous
  call in the shared connection owner.

## Named WebSocket deviation

`WebSockex.send_frame/2` is intentionally not called from the attempt task because its queued
`GenServer.call` cannot be retracted when the task dies or its deadline expires. The connection
owner instead performs one generation-bound, deadline-checked cast guarded by a cancellation latch.
Cast acceptance is `indeterminate`; only a correctly correlated response proves `dispatched`. This
may conservatively under-confirm sends, but it never makes an unsafe retry eligible.

## Verification

- Full integration-enabled suite: 1,223 tests, 0 failures.
- Focused lifecycle/protocol/transport suites repeatedly exercised under multiple seeds.
- Deterministic coverage for D-1/D/D+1 boundaries, short attempt slices, lifecycle suspension/death,
  receipt overtaking, one physical HTTP send, tracker repair/restart, duplicate WS client IDs,
  generation rollover, cancellation, late response, blocked send, owner death, tombstone recovery,
  and malformed/cross-correlated frames.
- `mix format --check-formatted`.
- warnings-as-errors compilation.
- Credo strict.
- Dialyzer.
- dependency audit (only documented cowlib exceptions).
- clean production Docker build; boot/health check is repeated in hosted CI.
- Multiple independent BEAM/OTP and distributed-systems review rounds drove the race corrections.

## Review and rollback boundary

Please review in three passes:

1. lifecycle/reducer/breaker ownership and deadlines;
2. Finch/HTTP/tracker behavior;
3. WebSocket correlation, cancellation, send expiry, and pending bounds.

Do not partially revert the WebSocket files while the new lifecycle protocol remains active. For a
WebSocket-specific incident, remove WebSocket candidates/use HTTP-only routing while rolling forward
or reverting this complete runtime PR.

## Deliberate follow-up

The extra `AttemptLifecycle` process remains only as a compatibility owner in this slice. The next
#500 PR moves its state machine into the existing request-execution owner, deletes the extra process,
and wires bounded projection handoff. This PR establishes transport truth; it does not claim an
end-to-end performance win over eRPC.
