### PR TITLE
Add request-owned attempt runtime

### DIFF
--- a/bench/routing_kernel/lib/routing_kernel_diagnostic.ex
+++ b/bench/routing_kernel/lib/routing_kernel_diagnostic.ex
@@ -370,6 +370,18 @@ defmodule Lasso.Bench.RoutingKernel.ClosedBreakerSuccess do
     %{accepted: :atomics.get(state.handoffs, 1), dropped: :atomics.get(state.handoffs, 2)}
   end
 
+  @doc false
+  @spec await_projection_handoffs!(map(), map(), non_neg_integer(), String.t()) :: :ok
+  def await_projection_handoffs!(state, before, expected, label) do
+    await_projection_handoffs!(
+      state,
+      before,
+      expected,
+      label,
+      System.monotonic_time(:millisecond) + @projection_drain_timeout_ms
+    )
+  end
+
   def await_projection_idle!(state) do
     await_projection_idle!(
       state,
@@ -448,6 +460,25 @@ defmodule Lasso.Bench.RoutingKernel.ClosedBreakerSuccess do
         else
           raise "projection lane did not drain: #{inspect(stats)}"
         end
+    end
+  end
+
+  defp await_projection_handoffs!(state, before, expected, label, deadline_ms) do
+    after_handoffs = projection_handoffs(state)
+
+    observed =
+      after_handoffs.accepted - before.accepted + after_handoffs.dropped - before.dropped
+
+    cond do
+      observed >= expected ->
+        :ok
+
+      System.monotonic_time(:millisecond) < deadline_ms ->
+        Process.sleep(1)
+        await_projection_handoffs!(state, before, expected, label, deadline_ms)
+
+      true ->
+        raise "#{label} projection handoff timed out: #{observed}/#{expected}"
     end
   end
 
@@ -655,8 +686,8 @@ defmodule Lasso.Bench.RoutingKernel.Runner do
   defp structural_pass(state, iterations, warmup) do
     tracer = StructuralTrace.start()
 
-    worker =
-      spawn(fn ->
+    {worker, worker_monitor} =
+      spawn_monitor(fn ->
         receive do
           {:warm_structural, caller} ->
             warm_worker!(state, :structural, warmup, "structural warmup")
@@ -677,7 +708,11 @@ defmodule Lasso.Bench.RoutingKernel.Runner do
       send(worker, {:warm_structural, self()})
 
       receive do
-        {:structural_warm, ^worker} -> :ok
+        {:structural_warm, ^worker} ->
+          :ok
+
+        {:DOWN, ^worker_monitor, :process, ^worker, reason} ->
+          raise "structural diagnostic worker exited during warmup: #{inspect(reason)}"
       after
         @structural_timeout_ms -> raise "structural diagnostic warmup timed out"
       end
@@ -698,10 +733,21 @@ defmodule Lasso.Bench.RoutingKernel.Runner do
       send(worker, {:run_structural, self()})
 
       receive do
-        {:structural_complete, ^worker} -> :ok
+        {:structural_complete, ^worker} ->
+          :ok
+
+        {:DOWN, ^worker_monitor, :process, ^worker, reason} ->
+          raise "structural diagnostic worker exited: #{inspect(reason)}"
       after
         @structural_timeout_ms -> raise "structural diagnostic timed out"
       end
+
+      ClosedBreakerSuccess.await_projection_handoffs!(
+        state,
+        projection_before.handoffs,
+        iterations,
+        "structural"
+      )
 
       await_trace_delivery!()
       raw = StructuralTrace.snapshot(tracer)
@@ -739,6 +785,7 @@ defmodule Lasso.Bench.RoutingKernel.Runner do
         }
       }
     after
+      Process.demonitor(worker_monitor, [:flush])
       if Process.alive?(worker), do: :erlang.trace(worker, false, [:all])
       :erlang.trace_pattern({:ets, :_, :_}, false, [:local])
       if Process.alive?(worker), do: Process.exit(worker, :kill)
@@ -900,6 +947,13 @@ defmodule Lasso.Bench.RoutingKernel.Runner do
   end
 
   defp finish_projection_window!(state, before, expected, label) do
+    ClosedBreakerSuccess.await_projection_handoffs!(
+      state,
+      before.handoffs,
+      expected,
+      label
+    )
+
     after_handoffs = ClosedBreakerSuccess.projection_handoffs(state)
 
     handoffs = %{

--- a/lib/lasso/core/request/execution_reducer.ex
+++ b/lib/lasso/core/request/execution_reducer.ex
@@ -41,7 +41,8 @@ defmodule Lasso.RPC.ExecutionReducer do
   @type event :: %{
           required(:id) => term(),
           required(:kind) => atom(),
-          required(:event_us) => integer()
+          required(:event_us) => integer(),
+          optional(atom()) => term()
         }
 
   @spec new(AttemptIdentity.t(), integer(), integer()) :: t()
@@ -51,27 +52,21 @@ defmodule Lasso.RPC.ExecutionReducer do
   end
 
   @spec observe(t(), event()) :: t()
-  def observe(%__MODULE__{} = state, %{id: _id, kind: kind, event_us: event_us} = event)
-      when kind in @observation_kinds and is_integer(event_us) do
-    normalized = normalize(event)
+  def observe(%__MODULE__{} = state, event), do: observe_many(state, [event])
 
-    cond do
-      existing_event(state, normalized.id) ->
-        diagnose_reused_id(state, normalized)
+  @doc "Reduces a bounded observation batch with one normalization/sort pass."
+  @spec observe_many(t(), [event()]) :: t()
+  def observe_many(%__MODULE__{} = state, events) when is_list(events) do
+    {state, recompute?} =
+      Enum.reduce(events, {state, false}, fn event, {acc, dirty?} ->
+        case stage_observation(acc, event) do
+          {:accepted, next} -> {next, true}
+          {:unchanged, next} -> {next, dirty?}
+        end
+      end)
 
-      state.committed ->
-        late(state, event)
-
-      event_us >= state.deadline_us ->
-        late(state, event)
-
-      true ->
-        state |> put_seen(normalized) |> add_observation(normalized) |> recompute()
-    end
+    if recompute?, do: recompute(state), else: state
   end
-
-  def observe(%__MODULE__{}, event),
-    do: raise(ArgumentError, "invalid observation: #{inspect(event)}")
 
   @spec close_deadline(t()) :: t()
   def close_deadline(%__MODULE__{terminal: nil} = state) do
@@ -84,6 +79,14 @@ defmodule Lasso.RPC.ExecutionReducer do
   end
 
   def close_deadline(state), do: commit(state)
+
+  @spec close_deadline(t(), :not_dispatched | :indeterminate | :dispatched) :: t()
+  def close_deadline(%__MODULE__{terminal: nil} = state, certainty) do
+    state = promote(state, certainty)
+    %{state | terminal: :deadline, terminal_at_us: state.deadline_us, committed: true}
+  end
+
+  def close_deadline(state, _certainty), do: commit(state)
 
   @spec commit(t()) :: t()
   def commit(%__MODULE__{terminal: nil}),
@@ -122,17 +125,19 @@ defmodule Lasso.RPC.ExecutionReducer do
   def terminal_fact(%__MODULE__{
         terminal: :transport_failure,
         terminal_event: %{kind: :task_exit},
-        identity: identity
+        identity: identity,
+        dispatch_certainty: certainty
       }),
-      do: AttemptTerminal.TransportFailure.new(identity, :unknown, :indeterminate)
+      do: AttemptTerminal.TransportFailure.new(identity, :unknown, certainty)
 
   def terminal_fact(%__MODULE__{
         terminal: :transport_failure,
         terminal_event: event,
-        identity: identity
+        identity: identity,
+        dispatch_certainty: certainty
       }) do
     opts = maybe_option([], :io_duration_us, event)
-    AttemptTerminal.TransportFailure.new(identity, event.reason, event.certainty, opts)
+    AttemptTerminal.TransportFailure.new(identity, event.reason, certainty, opts)
   end
 
   def terminal_fact(%__MODULE__{terminal: :cancelled, terminal_event: event, identity: identity}),
@@ -208,13 +213,15 @@ defmodule Lasso.RPC.ExecutionReducer do
 
   defp fold(state, %{kind: kind, event_us: event_us, certainty: certainty} = event)
        when kind in [:transport_failure, :cancelled] do
+    original_event = event
     {certainty, event} = resolve_terminal_certainty(state, event, certainty)
+    regression? = @certainty_rank[certainty] < @certainty_rank[state.dispatch_certainty]
+    certainty = if regression?, do: state.dispatch_certainty, else: certainty
+    event = normalize_terminal_censor(state, %{event | certainty: certainty})
 
-    if @certainty_rank[certainty] < @certainty_rank[state.dispatch_certainty] do
-      violation(state, event, :certainty_regression)
-    else
-      state |> promote(certainty) |> terminal(kind, event_us, event)
-    end
+    state = state |> promote(certainty) |> terminal(kind, event_us, event)
+
+    if regression?, do: violation(state, original_event, :certainty_regression), else: state
   end
 
   defp fold(state, %{kind: :task_exit, event_us: event_us} = event) do
@@ -285,6 +292,31 @@ defmodule Lasso.RPC.ExecutionReducer do
 
     validate_observation!(normalized)
   end
+
+  defp stage_observation(
+         %__MODULE__{} = state,
+         %{id: _id, kind: kind, event_us: event_us} = event
+       )
+       when kind in @observation_kinds and is_integer(event_us) do
+    normalized = normalize(event)
+
+    cond do
+      existing_event(state, normalized.id) ->
+        {:unchanged, diagnose_reused_id(state, normalized)}
+
+      state.committed ->
+        {:unchanged, late(state, event)}
+
+      event_us >= state.deadline_us ->
+        {:unchanged, late(state, event)}
+
+      true ->
+        {:accepted, state |> put_seen(normalized) |> add_observation(normalized)}
+    end
+  end
+
+  defp stage_observation(%__MODULE__{}, event),
+    do: raise(ArgumentError, "invalid observation: #{inspect(event)}")
 
   defp bounded_id(id) when is_integer(id), do: bounded_integer(id, :id)
   defp bounded_id(id) when is_binary(id), do: Lasso.RPC.BoundedIdentifier.encode(id)
@@ -437,13 +469,28 @@ defmodule Lasso.RPC.ExecutionReducer do
 
   defp resolve_terminal_certainty(state, %{kind: :cancelled} = event, :not_dispatched) do
     if unresolved_send?(state, event.event_us) do
-      {:indeterminate, %{event | certainty: :indeterminate}}
+      {:indeterminate,
+       %{
+         event
+         | certainty: :indeterminate,
+           censoring_boundary_us: max(event.event_us - state.started_us, 1)
+       }}
     else
       {:not_dispatched, event}
     end
   end
 
   defp resolve_terminal_certainty(_state, event, certainty), do: {certainty, event}
+
+  defp normalize_terminal_censor(
+         state,
+         %{kind: :cancelled, certainty: certainty} = event
+       )
+       when certainty in [:indeterminate, :dispatched] do
+    %{event | censoring_boundary_us: max(event.event_us - state.started_us, 1)}
+  end
+
+  defp normalize_terminal_censor(_state, event), do: event
 
   defp unresolved_send?(state, boundary_us) do
     case Map.fetch(state.observations, :send_started) do

--- a/lib/lasso/core/request/request_owner.ex
+++ b/lib/lasso/core/request/request_owner.ex
@@ -1,0 +1,611 @@
+defmodule Lasso.Core.Request.RequestOwner do
+  @moduledoc false
+
+  alias Lasso.Core.Transport.AttemptProtocol
+  alias Lasso.RPC.{AttemptIdentity, ExecutionProjector, ExecutionReducer}
+
+  defmodule AttemptCompletion do
+    @moduledoc false
+
+    @enforce_keys [:result, :terminal_candidate, :completed_at_us]
+    defstruct @enforce_keys
+  end
+
+  defmodule Outcome do
+    @moduledoc false
+
+    @enforce_keys [:result, :fact, :projection, :committed?]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{
+            result: term(),
+            fact: struct(),
+            projection: ExecutionProjector.t(),
+            committed?: true
+          }
+  end
+
+  @type option :: {:caller_pid, pid()} | {:test_before_restore, (-> term())}
+
+  @spec execute(AttemptIdentity.t(), integer(), (-> term()), [option()]) :: Outcome.t()
+  def execute(%AttemptIdentity{} = identity, deadline_us, fun, opts \\ [])
+      when is_integer(deadline_us) and is_function(fun, 0) do
+    started_us = System.monotonic_time(:microsecond)
+
+    if started_us >= deadline_us do
+      deadline_outcome(ExecutionReducer.new(identity, started_us, started_us))
+    else
+      previous_trap_exit = Process.flag(:trap_exit, true)
+
+      try do
+        outcome = do_execute(identity, started_us, deadline_us, fun, opts, previous_trap_exit)
+        invoke_test_before_restore(Keyword.get(opts, :test_before_restore))
+        outcome
+      after
+        Process.flag(:trap_exit, previous_trap_exit)
+        propagate_pending_exits(previous_trap_exit)
+      end
+    end
+  end
+
+  defp do_execute(identity, started_us, deadline_us, fun, opts, previous_trap_exit) do
+    attempt_ref = make_ref()
+    context = AttemptProtocol.new_context(self(), attempt_ref, deadline_us)
+    caller_state = monitor_caller(Keyword.get(opts, :caller_pid))
+    reducer = ExecutionReducer.new(identity, started_us, deadline_us)
+
+    if caller_state.status == :down do
+      cleanup_monitor(caller_state.monitor)
+
+      context
+      |> preflight_cancellation(reducer, started_us)
+      |> build_outcome()
+    else
+      cutoff_token = make_ref()
+      cutoff_timer = start_cutoff_timer(attempt_ref, cutoff_token, deadline_us)
+
+      if now_us() >= deadline_us do
+        cancel_cutoff(cutoff_timer, attempt_ref, cutoff_token)
+        cleanup_monitor(caller_state.monitor)
+        AttemptProtocol.close(context)
+        deadline_outcome(reducer)
+      else
+        task = start_transport_task(context, fun)
+
+        %{
+          attempt_ref: attempt_ref,
+          caller_monitor: caller_state.monitor,
+          context: context,
+          cutoff_timer: cutoff_timer,
+          cutoff_token: cutoff_token,
+          gate_snapshot: nil,
+          previous_trap_exit: previous_trap_exit,
+          reducer: reducer,
+          task: task
+        }
+        |> await_terminal()
+        |> finish()
+      end
+    end
+  end
+
+  defp start_transport_task(context, fun) do
+    Task.async(fn ->
+      :ok = AttemptProtocol.install_context(context)
+
+      try do
+        result = fun.()
+
+        %AttemptCompletion{
+          result: result,
+          terminal_candidate: AttemptProtocol.take_terminal_candidate(context),
+          completed_at_us: System.monotonic_time(:microsecond)
+        }
+      after
+        AttemptProtocol.clear_context()
+      end
+    end)
+  end
+
+  defp await_terminal(state) do
+    task_ref = state.task.ref
+    task_pid = state.task.pid
+
+    receive do
+      {^task_ref, %AttemptCompletion{} = completion} ->
+        handle_completion(state, completion)
+
+      {:request_owner_cutoff, attempt_ref, cutoff_token}
+      when attempt_ref == state.attempt_ref and cutoff_token == state.cutoff_token ->
+        close_deadline(state)
+
+      {:EXIT, ^task_pid, :normal} ->
+        await_terminal(state)
+
+      {:DOWN, ^task_ref, :process, ^task_pid, :normal} ->
+        protocol_failure(state, :missing_completion, System.monotonic_time(:microsecond))
+
+      {:EXIT, ^task_pid, reason} ->
+        handle_task_down(state, reason)
+
+      {:DOWN, ^task_ref, :process, ^task_pid, reason} ->
+        handle_task_down(state, reason)
+
+      {:DOWN, caller_ref, :process, _caller_pid, _reason}
+      when caller_ref == state.caller_monitor ->
+        handle_caller_down(state)
+
+      {:EXIT, _pid, :normal} when state.previous_trap_exit == false ->
+        await_terminal(state)
+
+      {:EXIT, _pid, reason} when state.previous_trap_exit == false ->
+        exit(reason)
+    end
+  end
+
+  defp handle_completion(state, %AttemptCompletion{completed_at_us: completed_at_us} = completion) do
+    case completion.terminal_candidate do
+      {:ok, %{event_us: event_us} = terminal} when event_us >= state.reducer.deadline_us ->
+        close_deadline(state, terminal)
+
+      _candidate ->
+        if ExecutionReducer.eligible?(state.reducer, completed_at_us) do
+          case validate_completion(completion) do
+            {:ok, terminal} ->
+              safely_commit_terminal(state, completion.result, completed_at_us, terminal)
+
+            {:error, reason} ->
+              protocol_failure(state, reason, completed_at_us)
+          end
+        else
+          close_deadline(state)
+        end
+    end
+  end
+
+  defp validate_completion(%AttemptCompletion{
+         result: result,
+         terminal_candidate: {:ok, terminal},
+         completed_at_us: completed_at_us
+       }) do
+    cond do
+      terminal.event_us > completed_at_us -> {:error, :terminal_after_completion}
+      not result_matches_terminal?(result, terminal) -> {:error, :terminal_result_mismatch}
+      true -> {:ok, terminal}
+    end
+  end
+
+  defp validate_completion(%AttemptCompletion{terminal_candidate: :missing}),
+    do: {:error, :missing_terminal}
+
+  defp validate_completion(%AttemptCompletion{terminal_candidate: {:conflict, _terminal}}),
+    do: {:error, :conflicting_terminal}
+
+  defp commit_terminal(state, result, completed_at_us, terminal) do
+    if ExecutionReducer.eligible?(state.reducer, terminal.event_us) do
+      state
+      |> commit(result, completed_at_us, [terminal])
+    else
+      close_deadline(state)
+    end
+  end
+
+  defp safely_commit_terminal(state, result, completed_at_us, terminal) do
+    commit_terminal(state, result, completed_at_us, terminal)
+  rescue
+    ArgumentError -> protocol_failure(state, :invalid_terminal, completed_at_us)
+  end
+
+  defp protocol_failure(state, reason, event_us) do
+    if ExecutionReducer.eligible?(state.reducer, event_us) do
+      commit(
+        state,
+        {:error, {:attempt_protocol, bounded_protocol_reason(reason)}},
+        event_us,
+        [%{id: -3, kind: :task_exit, event_us: event_us}]
+      )
+    else
+      close_deadline(state)
+    end
+  end
+
+  defp handle_task_down(state, reason) do
+    event_us = System.monotonic_time(:microsecond)
+
+    if ExecutionReducer.eligible?(state.reducer, event_us) do
+      commit(
+        state,
+        {:error, {:transport_task_exit, normalize_exit_reason(reason)}},
+        event_us,
+        [%{id: -4, kind: :task_exit, event_us: event_us}]
+      )
+    else
+      close_deadline(state)
+    end
+  end
+
+  defp handle_caller_down(state) do
+    marker = make_ref()
+    send(self(), {:request_owner_drain, state.attempt_ref, marker})
+    state = close_authorization(state)
+    state = drain_until_marker(state, marker)
+
+    case Map.fetch(state, :committed) do
+      {:ok, _committed} ->
+        state
+
+      :error ->
+        event_us = System.monotonic_time(:microsecond)
+
+        if ExecutionReducer.eligible?(state.reducer, event_us) do
+          censoring_boundary_us =
+            if state.gate_snapshot.certainty == :not_dispatched,
+              do: 0,
+              else: max(event_us - state.reducer.started_us, 1)
+
+          commit(
+            state,
+            {:error, :caller_abandoned},
+            event_us,
+            [
+              %{
+                id: -5,
+                kind: :cancelled,
+                event_us: event_us,
+                reason: :caller_abandoned,
+                certainty: state.gate_snapshot.certainty,
+                censoring_boundary_us: censoring_boundary_us
+              }
+            ]
+          )
+        else
+          close_deadline(state)
+        end
+    end
+  end
+
+  defp drain_until_marker(state, marker) do
+    task_ref = state.task.ref
+    task_pid = state.task.pid
+
+    receive do
+      {:request_owner_drain, attempt_ref, ^marker} when attempt_ref == state.attempt_ref ->
+        state
+
+      {^task_ref, %AttemptCompletion{} = completion} ->
+        case handle_completion(state, completion) do
+          %{committed: _committed} = committed ->
+            drain_committed_until_marker(committed, marker)
+
+          next ->
+            drain_until_marker(next, marker)
+        end
+
+      {:EXIT, ^task_pid, :normal} ->
+        drain_until_marker(state, marker)
+
+      {:DOWN, ^task_ref, :process, ^task_pid, :normal} ->
+        state
+        |> protocol_failure(:missing_completion, now_us())
+        |> drain_committed_until_marker(marker)
+
+      {:EXIT, ^task_pid, reason} ->
+        state
+        |> handle_task_down(reason)
+        |> drain_committed_until_marker(marker)
+
+      {:DOWN, ^task_ref, :process, ^task_pid, reason} ->
+        state
+        |> handle_task_down(reason)
+        |> drain_committed_until_marker(marker)
+
+      {:EXIT, _pid, :normal} when state.previous_trap_exit == false ->
+        drain_until_marker(state, marker)
+
+      {:EXIT, _pid, reason} when state.previous_trap_exit == false ->
+        exit(reason)
+    end
+  end
+
+  defp drain_committed_until_marker(state, marker) do
+    task_ref = state.task.ref
+    task_pid = state.task.pid
+
+    receive do
+      {:request_owner_drain, attempt_ref, ^marker} when attempt_ref == state.attempt_ref ->
+        state
+
+      {^task_ref, _reply} ->
+        drain_committed_until_marker(state, marker)
+
+      {:EXIT, ^task_pid, _reason} ->
+        drain_committed_until_marker(state, marker)
+
+      {:DOWN, ^task_ref, :process, ^task_pid, _reason} ->
+        drain_committed_until_marker(state, marker)
+    end
+  end
+
+  defp close_deadline(state, terminal_candidate \\ nil) do
+    state = close_authorization(state)
+    certainty = deadline_certainty(state.gate_snapshot.certainty, terminal_candidate)
+    reducer = ExecutionReducer.close_deadline(state.reducer, certainty)
+
+    fact = ExecutionReducer.terminal_fact(reducer)
+
+    Map.merge(state, %{
+      committed: true,
+      completed_at_us: state.reducer.deadline_us,
+      fact: fact,
+      result: {:error, :deadline_expired},
+      reducer: reducer
+    })
+  end
+
+  defp commit(state, result, completed_at_us, terminal_events) do
+    state = close_authorization(state)
+
+    observations = terminal_observations(terminal_events, state.gate_snapshot)
+
+    reducer =
+      state.reducer
+      |> ExecutionReducer.observe_many(observations)
+      |> ensure_terminal(completed_at_us)
+      |> ExecutionReducer.commit()
+
+    fact = ExecutionReducer.terminal_fact(reducer)
+
+    Map.merge(state, %{
+      committed: true,
+      completed_at_us: completed_at_us,
+      fact: fact,
+      result: result,
+      reducer: reducer
+    })
+  end
+
+  defp ensure_terminal(%ExecutionReducer{terminal: nil} = reducer, event_us) do
+    ExecutionReducer.observe(reducer, %{id: -6, kind: :task_exit, event_us: event_us})
+  end
+
+  defp ensure_terminal(reducer, _event_us), do: reducer
+
+  defp deadline_certainty(snapshot_certainty, terminal_candidate) do
+    case terminal_dispatch_certainty(terminal_candidate) do
+      :dispatched -> :dispatched
+      :indeterminate when snapshot_certainty == :not_dispatched -> :indeterminate
+      _certainty -> snapshot_certainty
+    end
+  end
+
+  defp terminal_dispatch_certainty(%{kind: kind})
+       when kind in [:response, :invalid_response],
+       do: :dispatched
+
+  defp terminal_dispatch_certainty(%{kind: :transport_failure, certainty: certainty})
+       when certainty in [:indeterminate, :dispatched],
+       do: certainty
+
+  defp terminal_dispatch_certainty(_terminal), do: nil
+
+  defp terminal_observations([%{kind: kind} = terminal], _gate_snapshot)
+       when kind in [:response, :invalid_response],
+       do: [terminal]
+
+  defp terminal_observations(
+         [%{kind: :predispatch_failure} = terminal],
+         %{certainty: :not_dispatched}
+       ),
+       do: [terminal]
+
+  defp terminal_observations(
+         [%{kind: :predispatch_failure, event_us: event_us}],
+         %{certainty: certainty}
+       )
+       when certainty in [:indeterminate, :dispatched] do
+    [
+      %{
+        id: -13,
+        kind: :transport_failure,
+        event_us: event_us,
+        reason: :unknown,
+        certainty: certainty
+      }
+    ]
+  end
+
+  defp terminal_observations(terminal_events, gate_snapshot),
+    do: AttemptProtocol.gate_observations(terminal_events, gate_snapshot)
+
+  defp preflight_cancellation(context, reducer, event_us) do
+    snapshot = AttemptProtocol.close(context)
+
+    reducer =
+      reducer
+      |> ExecutionReducer.observe_many([
+        %{
+          id: -7,
+          kind: :cancelled,
+          event_us: event_us,
+          reason: :caller_abandoned,
+          certainty: snapshot.certainty,
+          censoring_boundary_us: 0
+        }
+      ])
+      |> ExecutionReducer.commit()
+
+    %{
+      fact: ExecutionReducer.terminal_fact(reducer),
+      result: {:error, :caller_abandoned},
+      reducer: reducer
+    }
+  end
+
+  defp close_authorization(%{gate_snapshot: nil} = state),
+    do: %{state | gate_snapshot: AttemptProtocol.close(state.context)}
+
+  defp close_authorization(state), do: state
+
+  defp finish(state) do
+    cancel_cutoff(state)
+    cleanup_task(state.task)
+    cleanup_monitor(state.caller_monitor)
+    drain_retired_attempt(state)
+    build_outcome(state)
+  end
+
+  defp build_outcome(%{
+         fact: fact,
+         result: result,
+         reducer: %ExecutionReducer{committed: true}
+       }) do
+    %Outcome{
+      result: result,
+      fact: fact,
+      projection: ExecutionProjector.project(fact),
+      committed?: true
+    }
+  end
+
+  defp deadline_outcome(reducer) do
+    reducer = ExecutionReducer.close_deadline(reducer)
+
+    build_outcome(%{
+      fact: ExecutionReducer.terminal_fact(reducer),
+      result: {:error, :deadline_expired},
+      reducer: reducer
+    })
+  end
+
+  defp result_matches_terminal?(result, %{kind: :response, response_kind: :success}),
+    do: result_kind(result) == :success
+
+  defp result_matches_terminal?(result, %{kind: :response, response_kind: :application_error}),
+    do: result_kind(result) == :error
+
+  defp result_matches_terminal?(result, %{kind: kind})
+       when kind in [:predispatch_failure, :invalid_response, :transport_failure],
+       do: result_kind(result) == :error
+
+  defp result_matches_terminal?(_result, _terminal), do: false
+
+  defp result_kind({:ok, _value}), do: :success
+  defp result_kind({:ok, _value, _elapsed}), do: :success
+  defp result_kind({:error, _reason}), do: :error
+  defp result_kind({:error, _reason, _elapsed}), do: :error
+  defp result_kind(_result), do: :unknown
+
+  defp bounded_protocol_reason(reason)
+       when reason in [
+              :conflicting_terminal,
+              :missing_completion,
+              :missing_terminal,
+              :invalid_terminal,
+              :terminal_after_completion,
+              :terminal_result_mismatch
+            ],
+       do: reason
+
+  defp bounded_protocol_reason(_reason), do: :invalid_completion
+
+  defp normalize_exit_reason(reason)
+       when reason in [:killed, :normal, :noproc, :shutdown],
+       do: reason
+
+  defp normalize_exit_reason({:shutdown, _detail}), do: :shutdown
+  defp normalize_exit_reason(_reason), do: :transport_crashed
+
+  defp start_cutoff_timer(attempt_ref, cutoff_token, deadline_us) do
+    deadline_ms = -Integer.floor_div(-deadline_us, 1_000)
+
+    Process.send_after(
+      self(),
+      {:request_owner_cutoff, attempt_ref, cutoff_token},
+      deadline_ms,
+      abs: true
+    )
+  end
+
+  defp cancel_cutoff(state),
+    do: cancel_cutoff(state.cutoff_timer, state.attempt_ref, state.cutoff_token)
+
+  defp cancel_cutoff(timer, attempt_ref, cutoff_token) do
+    Process.cancel_timer(timer)
+
+    receive do
+      {:request_owner_cutoff, ^attempt_ref, ^cutoff_token} ->
+        :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  defp cleanup_task(task) do
+    task_pid = task.pid
+    Process.unlink(task.pid)
+    Process.demonitor(task.ref, [:flush])
+    if Process.alive?(task.pid), do: Process.exit(task.pid, :kill)
+
+    receive do
+      {:EXIT, ^task_pid, _reason} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  defp drain_retired_attempt(state) do
+    task_ref = state.task.ref
+    task_pid = state.task.pid
+
+    receive do
+      {^task_ref, _reply} ->
+        drain_retired_attempt(state)
+
+      {:DOWN, ^task_ref, :process, ^task_pid, _reason} ->
+        drain_retired_attempt(state)
+
+      {:EXIT, ^task_pid, _reason} ->
+        drain_retired_attempt(state)
+    after
+      0 -> :ok
+    end
+  end
+
+  defp monitor_caller(nil), do: %{monitor: nil, status: :alive}
+
+  defp monitor_caller(caller_pid) when is_pid(caller_pid) do
+    if Process.alive?(caller_pid) do
+      monitor = Process.monitor(caller_pid)
+
+      status =
+        receive do
+          {:DOWN, ^monitor, :process, ^caller_pid, _reason} -> :down
+        after
+          0 -> if(Process.alive?(caller_pid), do: :alive, else: :down)
+        end
+
+      %{monitor: monitor, status: status}
+    else
+      %{monitor: nil, status: :down}
+    end
+  end
+
+  defp cleanup_monitor(nil), do: :ok
+  defp cleanup_monitor(reference), do: Process.demonitor(reference, [:flush])
+
+  defp propagate_pending_exits(true), do: :ok
+
+  defp propagate_pending_exits(false) do
+    receive do
+      {:EXIT, _pid, :normal} -> propagate_pending_exits(false)
+      {:EXIT, _pid, reason} -> exit(reason)
+    after
+      0 -> :ok
+    end
+  end
+
+  defp invoke_test_before_restore(nil), do: :ok
+  defp invoke_test_before_restore(hook) when is_function(hook, 0), do: hook.()
+
+  defp now_us, do: System.monotonic_time(:microsecond)
+end

--- a/lib/lasso/core/transport/attempt_protocol.ex
+++ b/lib/lasso/core/transport/attempt_protocol.ex
@@ -1,22 +1,122 @@
 defmodule Lasso.Core.Transport.AttemptProtocol do
   @moduledoc false
 
-  alias Lasso.Core.Support.AttemptLifecycle
+  alias Lasso.Core.Support.{AttemptLifecycle, ErrorClassification}
 
-  @type context :: {pid(), reference()}
+  @dispatch_context_key :lasso_attempt_dispatch_context
+  @deadline_key :lasso_attempt_deadline_us
+  @terminal_candidate_key :lasso_attempt_terminal_candidate
+
+  @open_not_started 0
+  @open_started 1
+  @open_confirmed 2
+  @closed_not_started 3
+  @closed_started 4
+  @closed_confirmed 5
+  @timestamp_unset -9_223_372_036_854_775_808
+
+  defmodule Context do
+    @moduledoc false
+
+    @enforce_keys [:owner, :attempt_ref, :deadline_us, :gate]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{
+            owner: pid(),
+            attempt_ref: reference(),
+            deadline_us: integer(),
+            gate: :atomics.atomics_ref()
+          }
+  end
+
+  @type legacy_context :: {pid(), reference()}
+  @type context :: legacy_context() | Context.t()
   @type certainty :: :not_dispatched | :indeterminate | :dispatched
   @type send_start_error :: :deadline_expired | :owner_down
+  @type terminal_candidate ::
+          {:ok, map()} | {:conflict, map()} | :missing
 
   @terminal_kinds [:predispatch_failure, :response, :invalid_response, :transport_failure]
 
+  @doc false
+  @spec new_context(pid(), reference(), integer()) :: Context.t()
+  def new_context(owner, attempt_ref, deadline_us)
+      when is_pid(owner) and is_reference(attempt_ref) and is_integer(deadline_us) do
+    gate = :atomics.new(3, signed: true)
+    :atomics.put(gate, 1, @open_not_started)
+    :atomics.put(gate, 2, @timestamp_unset)
+    :atomics.put(gate, 3, @timestamp_unset)
+
+    %Context{owner: owner, attempt_ref: attempt_ref, deadline_us: deadline_us, gate: gate}
+  end
+
+  @doc false
+  @spec install_context(context()) :: :ok
+  def install_context(context) do
+    Process.put(@dispatch_context_key, context)
+    Process.put(@deadline_key, context_deadline(context))
+    Process.delete(@terminal_candidate_key)
+    :ok
+  end
+
+  @doc false
+  @spec clear_context() :: :ok
+  def clear_context do
+    Process.delete(@dispatch_context_key)
+    Process.delete(@deadline_key)
+    Process.delete(@terminal_candidate_key)
+    :ok
+  end
+
+  @doc false
+  @spec take_terminal_candidate(Context.t()) :: terminal_candidate()
+  def take_terminal_candidate(%Context{}) do
+    case Process.delete(@terminal_candidate_key) do
+      {:candidate, candidate} -> {:ok, candidate}
+      {:conflict, candidate} -> {:conflict, candidate}
+      nil -> :missing
+    end
+  end
+
+  @doc false
+  @spec close(Context.t()) :: map()
+  def close(%Context{gate: gate}) do
+    state = close_gate(gate)
+    gate_snapshot(gate, state)
+  end
+
+  @doc false
+  @spec gate_observations([map()], map()) :: [map()]
+  def gate_observations(observations, snapshot) do
+    observations =
+      if snapshot.certainty in [:indeterminate, :dispatched] and
+           is_integer(snapshot.started_at_us) and
+           not Enum.any?(observations, &(&1.kind == :send_started)) do
+        [%{id: -1, kind: :send_started, event_us: snapshot.started_at_us} | observations]
+      else
+        observations
+      end
+
+    if snapshot.certainty == :dispatched and is_integer(snapshot.confirmed_at_us) and
+         not Enum.any?(observations, &(&1.kind == :send_confirmed)) do
+      [%{id: -2, kind: :send_confirmed, event_us: snapshot.confirmed_at_us} | observations]
+    else
+      observations
+    end
+  end
+
   @spec context() :: context() | nil
-  def context, do: AttemptLifecycle.dispatch_context()
+  def context, do: Process.get(@dispatch_context_key)
 
   @spec deadline_us() :: integer() | nil
-  def deadline_us, do: AttemptLifecycle.deadline_us()
+  def deadline_us, do: Process.get(@deadline_key)
 
   @spec authorized?(context() | nil, integer() | nil) :: boolean()
   def authorized?(nil, deadline_us), do: before_deadline?(deadline_us)
+
+  def authorized?(%Context{owner: owner, gate: gate}, deadline_us),
+    do: Process.alive?(owner) and gate_open?(gate) and before_deadline?(deadline_us)
+
   def authorized?(_context, deadline_us), do: before_deadline?(deadline_us)
 
   @spec send_started(context() | nil) :: :ok | {:error, send_start_error()}
@@ -28,7 +128,7 @@ defmodule Lasso.Core.Transport.AttemptProtocol do
   @spec send_started_at(context() | nil, integer()) :: :ok | {:error, send_start_error()}
   def send_started_at(context, event_us) when is_integer(event_us) do
     with :ok <- validate_send_start(context, event_us),
-         :ok <- AttemptLifecycle.record_dispatch_state(:ambiguous, event_us) do
+         :ok <- record_dispatch_state(context, :ambiguous, event_us) do
       deliver_observation(context, :send_started, event_us, %{})
     end
   end
@@ -75,20 +175,20 @@ defmodule Lasso.Core.Transport.AttemptProtocol do
     do: send_started_at(context, event_us)
 
   def observe_at(context, :send_confirmed, event_us, fields) do
-    _result = AttemptLifecycle.record_dispatch_state(:dispatched, event_us)
+    _result = record_dispatch_state(context, :dispatched, event_us)
     deliver_observation(context, :send_confirmed, event_us, fields)
     :ok
   end
 
   def observe_at(context, :predispatch_failure, event_us, fields) do
-    _result = AttemptLifecycle.record_dispatch_state(:not_dispatched, event_us)
-    deliver_observation(context, :predispatch_failure, event_us, fields)
+    _result = record_dispatch_state(context, :not_dispatched, event_us)
+    deliver_terminal(context, :predispatch_failure, event_us, fields)
   end
 
   def observe_at(context, kind, event_us, fields)
       when kind in [:response, :invalid_response] do
-    _result = AttemptLifecycle.record_dispatch_state(:dispatched, event_us)
-    deliver_observation(context, kind, event_us, fields)
+    _result = record_dispatch_state(context, :dispatched, event_us)
+    deliver_terminal(context, kind, event_us, fields)
   end
 
   def observe_at(context, :transport_failure, event_us, %{certainty: certainty} = fields) do
@@ -99,42 +199,82 @@ defmodule Lasso.Core.Transport.AttemptProtocol do
         :indeterminate -> :ambiguous
       end
 
-    _result = AttemptLifecycle.record_dispatch_state(shared_certainty, event_us)
-    deliver_observation(context, :transport_failure, event_us, fields)
+    _result = record_dispatch_state(context, shared_certainty, event_us)
+    deliver_terminal(context, :transport_failure, event_us, fields)
   end
 
   def observe_at(context, kind, event_us, fields),
     do: deliver_observation(context, kind, event_us, fields)
 
+  defp deliver_terminal(%Context{}, kind, event_us, fields) do
+    candidate = build_context_observation(kind, event_us, fields)
+
+    case Process.get(@terminal_candidate_key) do
+      nil -> Process.put(@terminal_candidate_key, {:candidate, candidate})
+      {:candidate, ^candidate} -> :ok
+      {:candidate, first} -> Process.put(@terminal_candidate_key, {:conflict, first})
+      {:conflict, _first} -> :ok
+    end
+
+    :ok
+  end
+
+  defp deliver_terminal(context, kind, event_us, fields),
+    do: deliver_observation(context, kind, event_us, fields)
+
   defp deliver_observation(nil, _kind, _event_us, _fields), do: :ok
+
+  defp deliver_observation(%Context{}, _kind, _event_us, _fields), do: :ok
 
   defp deliver_observation({owner, attempt_ref}, kind, event_us, fields)
        when is_pid(owner) and is_reference(attempt_ref) and is_atom(kind) and is_integer(event_us) and
               is_map(fields) do
-    observation =
-      fields
-      |> Map.take([
-        :certainty,
-        :reason,
-        :response_kind,
-        :error_code,
-        :error_category,
-        :retry_after_ms,
-        :io_duration_us,
-        :elapsed_us,
-        :censoring_boundary_us
-      ])
-      |> Map.merge(%{
-        id: System.unique_integer([:positive, :monotonic]),
-        kind: kind,
-        event_us: event_us
-      })
-
-    send(owner, {:transport_observation, attempt_ref, observation})
+    send(owner, {:transport_observation, attempt_ref, build_observation(kind, event_us, fields)})
     :ok
   end
 
+  defp build_observation(kind, event_us, fields) do
+    build_observation(System.unique_integer([:positive, :monotonic]), kind, event_us, fields)
+  end
+
+  defp build_context_observation(kind, event_us, fields) do
+    build_observation(context_observation_id(kind), kind, event_us, fields)
+  end
+
+  defp build_observation(id, kind, event_us, fields) do
+    fields
+    |> Map.take([
+      :certainty,
+      :reason,
+      :response_kind,
+      :error_code,
+      :error_category,
+      :retry_after_ms,
+      :io_duration_us,
+      :elapsed_us,
+      :censoring_boundary_us
+    ])
+    |> Map.merge(%{
+      id: id,
+      kind: kind,
+      event_us: event_us
+    })
+  end
+
+  defp context_observation_id(:predispatch_failure), do: -10
+  defp context_observation_id(:response), do: -11
+  defp context_observation_id(:invalid_response), do: -12
+  defp context_observation_id(:transport_failure), do: -13
+
   defp validate_send_start(nil, _event_us), do: :ok
+
+  defp validate_send_start(%Context{owner: owner, deadline_us: deadline_us}, event_us) do
+    cond do
+      not Process.alive?(owner) -> {:error, :owner_down}
+      event_us >= deadline_us -> {:error, :deadline_expired}
+      true -> :ok
+    end
+  end
 
   defp validate_send_start({owner, _attempt_ref}, event_us) do
     cond do
@@ -152,14 +292,171 @@ defmodule Lasso.Core.Transport.AttemptProtocol do
     end
   end
 
-  defp normalize_terminal(:response, %{response_kind: :error} = fields),
-    do: %{fields | response_kind: :application_error}
+  defp record_dispatch_state(%Context{gate: gate, deadline_us: deadline_us}, certainty, event_us)
+       when event_us < deadline_us do
+    if System.monotonic_time(:microsecond) < deadline_us do
+      transition_gate(gate, certainty, event_us)
+    else
+      late_dispatch_state_result(certainty)
+    end
+  end
+
+  defp record_dispatch_state(%Context{}, _certainty, _event_us), do: :ok
+
+  defp record_dispatch_state(_context, certainty, event_us),
+    do: AttemptLifecycle.record_dispatch_state(certainty, event_us)
+
+  defp late_dispatch_state_result(:ambiguous), do: {:error, :deadline_expired}
+  defp late_dispatch_state_result(_certainty), do: :ok
+
+  defp transition_gate(gate, :ambiguous, event_us) do
+    case :atomics.get(gate, 1) do
+      @open_not_started ->
+        put_timestamp_once(gate, 2, event_us)
+
+        retry_gate(gate, @open_not_started, @open_started, fn gate ->
+          transition_gate(gate, :ambiguous, event_us)
+        end)
+
+      state when state in [@open_started, @open_confirmed] ->
+        :ok
+
+      _closed ->
+        {:error, :owner_down}
+    end
+  end
+
+  defp transition_gate(gate, :dispatched, event_us) do
+    if gate_open?(gate) do
+      put_timestamp_once(gate, 3, event_us)
+      promote_confirmed(gate)
+    end
+
+    :ok
+  end
+
+  defp transition_gate(gate, :not_dispatched, _event_us) do
+    prove_not_dispatched(gate)
+    :ok
+  end
+
+  defp promote_confirmed(gate) do
+    case :atomics.get(gate, 1) do
+      @open_confirmed ->
+        :ok
+
+      @open_not_started ->
+        retry_gate(gate, @open_not_started, @open_confirmed, &promote_confirmed/1)
+
+      @open_started ->
+        retry_gate(gate, @open_started, @open_confirmed, &promote_confirmed/1)
+
+      state when state in [@closed_not_started, @closed_started, @closed_confirmed] ->
+        :ok
+    end
+  end
+
+  defp prove_not_dispatched(gate) do
+    case :atomics.get(gate, 1) do
+      @open_started ->
+        retry_gate(gate, @open_started, @open_not_started, &prove_not_dispatched/1)
+
+      _state ->
+        :ok
+    end
+  end
+
+  defp close_gate(gate) do
+    case :atomics.get(gate, 1) do
+      state when state in [@closed_not_started, @closed_started, @closed_confirmed] ->
+        state
+
+      state ->
+        case cas_gate(gate, state, state + 3) do
+          :ok -> state + 3
+          _raced -> close_gate(gate)
+        end
+    end
+  end
+
+  defp retry_gate(gate, expected, desired, retry) do
+    case cas_gate(gate, expected, desired) do
+      :ok -> :ok
+      _raced -> retry.(gate)
+    end
+  end
+
+  defp cas_gate(gate, expected, desired),
+    do: :atomics.compare_exchange(gate, 1, expected, desired)
+
+  defp put_timestamp_once(gate, index, event_us) do
+    case :atomics.compare_exchange(gate, index, @timestamp_unset, event_us) do
+      :ok -> :ok
+      _existing -> :ok
+    end
+  end
+
+  defp gate_open?(gate), do: :atomics.get(gate, 1) in [0, 1, 2]
+
+  defp gate_snapshot(_gate, @closed_not_started),
+    do: %{certainty: :not_dispatched, confirmed_at_us: nil, started_at_us: nil}
+
+  defp gate_snapshot(gate, @closed_started),
+    do: %{certainty: :indeterminate, confirmed_at_us: nil, started_at_us: gate_value(gate, 2)}
+
+  defp gate_snapshot(gate, @closed_confirmed) do
+    %{
+      certainty: :dispatched,
+      confirmed_at_us: gate_value(gate, 3),
+      started_at_us: gate_value(gate, 2)
+    }
+  end
+
+  defp gate_value(gate, index) do
+    case :atomics.get(gate, index) do
+      @timestamp_unset -> nil
+      timestamp -> timestamp
+    end
+  end
+
+  defp context_deadline(%Context{deadline_us: deadline_us}), do: deadline_us
+  defp context_deadline(_legacy_context), do: Process.get(@deadline_key)
+
+  defp normalize_terminal(:response, %{response_kind: :error} = fields) do
+    fields
+    |> Map.put(:response_kind, :application_error)
+    |> maybe_normalize_application_error_category()
+  end
 
   defp normalize_terminal(:transport_failure, fields) do
     Map.update!(fields, :reason, &transport_reason/1)
   end
 
   defp normalize_terminal(_kind, fields), do: fields
+
+  defp maybe_normalize_application_error_category(fields) do
+    case Map.fetch(fields, :error_category) do
+      {:ok, category} ->
+        Map.put(fields, :error_category, canonical_application_error_category(category))
+
+      :error ->
+        fields
+    end
+  end
+
+  defp canonical_application_error_category(:rate_limit), do: :quota
+
+  defp canonical_application_error_category(category)
+       when category in [:deterministic, :quota, :capability, :provider_failure],
+       do: category
+
+  defp canonical_application_error_category(category) do
+    cond do
+      ErrorClassification.breaker_penalty?(category) -> :provider_failure
+      ErrorClassification.retriable_for_category?(category) -> :capability
+      true -> :deterministic
+    end
+  end
 
   defp predispatch_reason(reason)
        when reason in [:pool_unavailable, :not_connected, :invalid_frame],

--- a/test/lasso/core/request/execution_reducer_test.exs
+++ b/test/lasso/core/request/execution_reducer_test.exs
@@ -66,6 +66,15 @@ defmodule Lasso.RPC.ExecutionReducerTest do
              ExecutionReducer.terminal_fact(reduced)
   end
 
+  test "deadline closure retains an authoritative external dispatch snapshot" do
+    reduced = ExecutionReducer.close_deadline(state(), :dispatched)
+
+    assert reduced.dispatch_certainty == :dispatched
+
+    assert %Lasso.RPC.AttemptTerminal.Deadline{dispatch_certainty: :dispatched} =
+             ExecutionReducer.terminal_fact(reduced)
+  end
+
   test "certainty only increases" do
     reduced =
       state()
@@ -248,6 +257,71 @@ defmodule Lasso.RPC.ExecutionReducerTest do
              ExecutionReducer.terminal_fact(reduced)
   end
 
+  test "task loss preserves prior positive dispatch proof" do
+    reduced =
+      state()
+      |> ExecutionReducer.observe(%{id: 1, kind: :send_confirmed, event_us: 40})
+      |> ExecutionReducer.observe(%{id: 2, kind: :task_exit, event_us: 50})
+
+    assert reduced.terminal == :transport_failure
+    assert reduced.dispatch_certainty == :dispatched
+
+    assert %Lasso.RPC.AttemptTerminal.TransportFailure{
+             reason: :unknown,
+             dispatch_certainty: :dispatched
+           } = ExecutionReducer.terminal_fact(reduced)
+  end
+
+  test "a weaker terminal failure materializes the strongest dispatch proof in either order" do
+    failure = %{
+      id: 2,
+      kind: :transport_failure,
+      event_us: 50,
+      reason: :closed,
+      certainty: :indeterminate
+    }
+
+    for events <- [
+          [%{id: 1, kind: :send_confirmed, event_us: 40}, failure],
+          [failure, %{id: 1, kind: :send_confirmed, event_us: 40}]
+        ] do
+      reduced = ExecutionReducer.observe_many(state(), events)
+
+      assert reduced.terminal == :transport_failure
+      assert reduced.dispatch_certainty == :dispatched
+
+      assert %Lasso.RPC.AttemptTerminal.TransportFailure{
+               dispatch_certainty: :dispatched
+             } = ExecutionReducer.terminal_fact(reduced)
+
+      assert Enum.any?(reduced.protocol_violations, &(&1.reason == :certainty_regression))
+    end
+  end
+
+  test "bounded batch reduction agrees with sequential logical reduction" do
+    events = [
+      %{id: 1, kind: :send_started, event_us: 10},
+      %{id: 2, kind: :send_confirmed, event_us: 20},
+      %{
+        id: 3,
+        kind: :transport_failure,
+        event_us: 30,
+        reason: :closed,
+        certainty: :dispatched,
+        io_duration_us: 20
+      }
+    ]
+
+    batched = ExecutionReducer.observe_many(state(), events)
+    sequential = Enum.reduce(events, state(), &ExecutionReducer.observe(&2, &1))
+
+    assert batched.dispatch_certainty == sequential.dispatch_certainty
+    assert batched.terminal == sequential.terminal
+    assert batched.terminal_event == sequential.terminal_event
+    assert batched.protocol_violations == sequential.protocol_violations
+    assert ExecutionReducer.terminal_fact(batched) == ExecutionReducer.terminal_fact(sequential)
+  end
+
   test "cancellation during unresolved send is indeterminate" do
     reduced =
       state()
@@ -264,8 +338,30 @@ defmodule Lasso.RPC.ExecutionReducerTest do
     assert reduced.terminal == :cancelled
     assert reduced.dispatch_certainty == :indeterminate
 
-    assert %Lasso.RPC.AttemptTerminal.Cancelled{dispatch_certainty: :indeterminate} =
+    assert %Lasso.RPC.AttemptTerminal.Cancelled{
+             dispatch_certainty: :indeterminate,
+             censoring_boundary_us: 20
+           } =
              ExecutionReducer.terminal_fact(reduced)
+  end
+
+  test "cancellation upgraded by positive dispatch proof receives a positive censor" do
+    reduced =
+      state()
+      |> ExecutionReducer.observe(%{id: 1, kind: :send_confirmed, event_us: 10})
+      |> ExecutionReducer.observe(%{
+        id: 2,
+        kind: :cancelled,
+        event_us: 20,
+        reason: :caller_abandoned,
+        certainty: :not_dispatched,
+        censoring_boundary_us: 0
+      })
+
+    assert %Lasso.RPC.AttemptTerminal.Cancelled{
+             dispatch_certainty: :dispatched,
+             censoring_boundary_us: 20
+           } = ExecutionReducer.terminal_fact(reduced)
   end
 
   test "authoritative not-dispatched proof closes ambiguity before cancellation" do

--- a/test/lasso/core/request/request_owner_test.exs
+++ b/test/lasso/core/request/request_owner_test.exs
@@ -1,0 +1,711 @@
+defmodule Lasso.Core.Request.RequestOwnerTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Core.Request.RequestOwner
+  alias Lasso.Core.Transport.AttemptProtocol
+  alias Lasso.RPC.AttemptIdentity
+  alias Lasso.RPC.AttemptTerminal
+
+  defp identity(execution_safety \\ :replay_safe) do
+    AttemptIdentity.new(
+      request_id: "request",
+      attempt_id: "attempt",
+      profile: "public",
+      chain_id: 1,
+      upstream_instance_id: "instance",
+      transport: :http,
+      route_generation: 1,
+      circuit_scope: :broad,
+      circuit_epoch: 1,
+      execution_safety: execution_safety,
+      routing_intent: "default",
+      workload_key: "eth_blockNumber",
+      request_budget_ms: 100,
+      candidate_admission_count: 1,
+      dispatch_count: 1
+    )
+  end
+
+  defp deadline_after(ms),
+    do: System.monotonic_time(:microsecond) + ms * 1_000
+
+  defp success_terminal(context, io_duration_us \\ 1) do
+    AttemptProtocol.terminal(context, :response, %{
+      response_kind: :success,
+      io_duration_us: io_duration_us
+    })
+  end
+
+  defp await_down(pid) do
+    monitor = Process.monitor(pid)
+    assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}, 1_000
+  end
+
+  defp wait_past(deadline_us) do
+    if System.monotonic_time(:microsecond) <= deadline_us do
+      receive do
+      after
+        1 -> wait_past(deadline_us)
+      end
+    end
+  end
+
+  defp await_mailbox(pid, predicate, timeout_ms \\ 1_000) do
+    deadline_ms = System.monotonic_time(:millisecond) + timeout_ms
+    do_await_mailbox(pid, predicate, deadline_ms)
+  end
+
+  defp do_await_mailbox(pid, predicate, deadline_ms) do
+    messages =
+      case Process.info(pid, :messages) do
+        {:messages, messages} -> messages
+        nil -> flunk("process exited before the expected mailbox state")
+      end
+
+    if predicate.(messages) do
+      messages
+    else
+      if System.monotonic_time(:millisecond) >= deadline_ms do
+        flunk("expected mailbox state did not arrive")
+      else
+        receive do
+        after
+          1 -> do_await_mailbox(pid, predicate, deadline_ms)
+        end
+      end
+    end
+  end
+
+  test "the current process owns one linked and monitored transport task" do
+    owner = self()
+
+    outcome =
+      RequestOwner.execute(identity(), deadline_after(100), fn ->
+        task = self()
+
+        send(
+          owner,
+          {:topology, task, Process.info(task, :links), Process.info(task, :monitored_by)}
+        )
+
+        success_terminal(AttemptProtocol.context())
+        {:ok, :response}
+      end)
+
+    assert_receive {:topology, task, {:links, links}, {:monitored_by, monitored_by}}
+    assert self() in links
+    assert self() in monitored_by
+    refute task == self()
+
+    assert outcome.result == {:ok, :response}
+    assert outcome.committed?
+    assert %AttemptTerminal.Response{} = outcome.fact
+    assert outcome.projection.recommended_action == :return_response
+  end
+
+  test "the task result and terminal fact settle as one completion" do
+    outcome =
+      RequestOwner.execute(identity(), deadline_after(100), fn ->
+        success_terminal(AttemptProtocol.context(), 7)
+        {:ok, :deferred}
+      end)
+
+    assert outcome.result == {:ok, :deferred}
+    assert %AttemptTerminal.Response{io_duration_us: 7} = outcome.fact
+  end
+
+  test "authoritative response facts are unchanged by redundant gate proof" do
+    without_gate =
+      RequestOwner.execute(identity(), deadline_after(100), fn ->
+        success_terminal(AttemptProtocol.context(), 7)
+        {:ok, :response}
+      end)
+
+    with_gate =
+      RequestOwner.execute(identity(), deadline_after(100), fn ->
+        context = AttemptProtocol.context()
+        assert :ok = AttemptProtocol.send_started(context)
+        assert :ok = AttemptProtocol.send_confirmed(context)
+        success_terminal(context, 7)
+        {:ok, :response}
+      end)
+
+    assert with_gate.fact == without_gate.fact
+    assert with_gate.projection == without_gate.projection
+  end
+
+  test "missing, conflicting, mismatched, and malformed terminals fail conservatively" do
+    cases = [
+      {:missing,
+       fn ->
+         {:ok, :missing}
+       end},
+      {:conflicting,
+       fn ->
+         context = AttemptProtocol.context()
+         success_terminal(context)
+
+         AttemptProtocol.terminal(context, :transport_failure, %{
+           reason: :closed,
+           certainty: :dispatched,
+           io_duration_us: 2
+         })
+
+         {:ok, :conflicting}
+       end},
+      {:mismatched,
+       fn ->
+         success_terminal(AttemptProtocol.context())
+         {:error, :contradictory_return}
+       end},
+      {:predispatch_mismatched,
+       fn ->
+         AttemptProtocol.predispatch_failure(AttemptProtocol.context(), :not_connected)
+         {:ok, :contradictory_return}
+       end},
+      {:failure_mismatched,
+       fn ->
+         AttemptProtocol.terminal(AttemptProtocol.context(), :transport_failure, %{
+           reason: :closed,
+           certainty: :indeterminate
+         })
+
+         {:ok, :contradictory_return}
+       end},
+      {:malformed,
+       fn ->
+         AttemptProtocol.terminal(AttemptProtocol.context(), :response, %{
+           response_kind: :application_error,
+           io_duration_us: 1
+         })
+
+         {:error, :upstream_error}
+       end}
+    ]
+
+    for {_name, fun} <- cases do
+      started_us = System.monotonic_time(:microsecond)
+      outcome = RequestOwner.execute(identity(), deadline_after(1_000), fun)
+
+      assert %AttemptTerminal.TransportFailure{
+               reason: :unknown,
+               dispatch_certainty: certainty
+             } = outcome.fact
+
+      assert certainty in [:indeterminate, :dispatched]
+      assert match?({:error, {:attempt_protocol, _bounded_reason}}, outcome.result)
+      assert System.monotonic_time(:microsecond) - started_us < 250_000
+      assert outcome.committed?
+    end
+  end
+
+  test "missing terminal proof is unsafe for unknown work" do
+    outcome =
+      RequestOwner.execute(identity(:unknown), deadline_after(100), fn ->
+        {:ok, :missing}
+      end)
+
+    assert %AttemptTerminal.TransportFailure{dispatch_certainty: :indeterminate} = outcome.fact
+    refute outcome.projection.fallback_eligible
+    assert outcome.projection.recommended_action == :finish_unsafe_indeterminate
+  end
+
+  test "a response candidate cannot survive task death" do
+    outcome =
+      RequestOwner.execute(identity(), deadline_after(100), fn ->
+        success_terminal(AttemptProtocol.context())
+        exit({:secret, String.duplicate("credential", 10_000)})
+      end)
+
+    assert outcome.result == {:error, {:transport_task_exit, :transport_crashed}}
+
+    assert %AttemptTerminal.TransportFailure{
+             reason: :unknown,
+             dispatch_certainty: :dispatched
+           } = outcome.fact
+
+    refute inspect(outcome) =~ "credential"
+  end
+
+  test "authoritative pre-send proof releases tentative send ambiguity" do
+    outcome =
+      RequestOwner.execute(identity(), deadline_after(100), fn ->
+        context = AttemptProtocol.context()
+        assert :ok = AttemptProtocol.send_started(context)
+        assert :ok = AttemptProtocol.predispatch_failure(context, :not_connected)
+        {:error, :not_connected}
+      end)
+
+    assert outcome.result == {:error, :not_connected}
+
+    assert %AttemptTerminal.PredispatchFailure{
+             reason: :not_connected,
+             elapsed_us: 0
+           } = outcome.fact
+
+    assert outcome.projection.recommended_action == :try_next_candidate
+  end
+
+  test "predispatch proof cannot erase a confirmed send" do
+    outcome =
+      RequestOwner.execute(identity(:unknown), deadline_after(100), fn ->
+        context = AttemptProtocol.context()
+        assert :ok = AttemptProtocol.send_started(context)
+        assert :ok = AttemptProtocol.send_confirmed(context)
+        assert :ok = AttemptProtocol.predispatch_failure(context, :not_connected)
+        {:error, :not_connected}
+      end)
+
+    assert %AttemptTerminal.TransportFailure{dispatch_certainty: :dispatched} = outcome.fact
+    assert outcome.projection.breaker_effect == :failure
+    refute outcome.projection.fallback_eligible
+  end
+
+  test "positive proof after a predispatch candidate prevents unsafe fallback" do
+    for _iteration <- 1..100 do
+      outcome =
+        RequestOwner.execute(identity(:unknown), deadline_after(100), fn ->
+          context = AttemptProtocol.context()
+          transport_task = self()
+
+          confirmer =
+            spawn(fn ->
+              receive do
+                :confirm ->
+                  AttemptProtocol.send_confirmed(context)
+                  send(transport_task, :confirmed)
+              end
+            end)
+
+          send(confirmer, :confirm)
+          assert :ok = AttemptProtocol.predispatch_failure(context, :not_connected)
+          assert_receive :confirmed
+          {:error, :not_connected}
+        end)
+
+      assert %AttemptTerminal.TransportFailure{dispatch_certainty: :dispatched} = outcome.fact
+      refute outcome.projection.fallback_eligible
+      refute match?(%AttemptTerminal.PredispatchFailure{}, outcome.fact)
+    end
+  end
+
+  test "D and D+1 terminal stamps are expired" do
+    for offset <- [0, 1] do
+      deadline_us = deadline_after(100)
+
+      outcome =
+        RequestOwner.execute(identity(), deadline_us, fn ->
+          assert :ok = AttemptProtocol.send_started(AttemptProtocol.context())
+          assert :ok = AttemptProtocol.send_confirmed(AttemptProtocol.context())
+
+          AttemptProtocol.terminal_at(
+            AttemptProtocol.context(),
+            :response,
+            %{response_kind: :success, io_duration_us: 1},
+            deadline_us + offset
+          )
+
+          {:ok, offset}
+        end)
+
+      assert %AttemptTerminal.Deadline{dispatch_certainty: :dispatched} = outcome.fact
+      assert outcome.result == {:error, :deadline_expired}
+    end
+  end
+
+  test "a response at D is ineligible but still proves dispatch" do
+    deadline_us = deadline_after(100)
+
+    outcome =
+      RequestOwner.execute(identity(:unknown), deadline_us, fn ->
+        AttemptProtocol.terminal_at(
+          AttemptProtocol.context(),
+          :response,
+          %{response_kind: :success, io_duration_us: 1},
+          deadline_us
+        )
+
+        {:ok, :too_late}
+      end)
+
+    assert outcome.result == {:error, :deadline_expired}
+    assert %AttemptTerminal.Deadline{dispatch_certainty: :dispatched} = outcome.fact
+    refute outcome.projection.fallback_eligible
+  end
+
+  test "a negative proof after D cannot erase D-1 ambiguity" do
+    test_pid = self()
+    deadline_us = deadline_after(50)
+
+    owner =
+      spawn(fn ->
+        outcome =
+          RequestOwner.execute(identity(:unknown), deadline_us, fn ->
+            context = AttemptProtocol.context()
+            assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 1)
+            send(test_pid, {:negative_transport_ready, self()})
+            assert_receive :report_late_negative
+
+            assert :ok =
+                     AttemptProtocol.observe_at(
+                       context,
+                       :predispatch_failure,
+                       deadline_us + 1,
+                       %{reason: :not_connected, elapsed_us: 0}
+                     )
+
+            {:error, :not_connected}
+          end)
+
+        send(test_pid, {:negative_owner_outcome, outcome})
+      end)
+
+    assert_receive {:negative_transport_ready, task}
+    assert :erlang.suspend_process(owner)
+    wait_past(deadline_us)
+
+    await_mailbox(owner, fn messages ->
+      Enum.any?(messages, &match?({:request_owner_cutoff, _, _}, &1))
+    end)
+
+    send(task, :report_late_negative)
+    assert :erlang.resume_process(owner)
+
+    assert_receive {:negative_owner_outcome, outcome}, 1_000
+    assert outcome.result == {:error, :deadline_expired}
+    assert %AttemptTerminal.Deadline{dispatch_certainty: :indeterminate} = outcome.fact
+    refute outcome.projection.fallback_eligible
+  end
+
+  test "runtime error categories map to the four canonical application classes" do
+    cases = [
+      {:invalid_params, :deterministic, :return_response, :none},
+      {:rate_limit, :quota, :try_next_candidate, :none},
+      {:method_not_found, :capability, :try_next_candidate, :none},
+      {:server_error, :provider_failure, :try_next_candidate, :failure}
+    ]
+
+    for {runtime_category, canonical_category, action, breaker_effect} <- cases do
+      outcome =
+        RequestOwner.execute(identity(), deadline_after(100), fn ->
+          AttemptProtocol.terminal(AttemptProtocol.context(), :response, %{
+            response_kind: :error,
+            error_code: -32_000,
+            error_category: runtime_category,
+            io_duration_us: 1
+          })
+
+          {:error, :application_error}
+        end)
+
+      assert %AttemptTerminal.Response{
+               kind: :application_error,
+               error_category: ^canonical_category
+             } = outcome.fact
+
+      assert outcome.projection.recommended_action == action
+      assert outcome.projection.breaker_effect == breaker_effect
+    end
+  end
+
+  test "a completion already queued before the cutoff marker remains eligible" do
+    for _iteration <- 1..20 do
+      test_pid = self()
+      deadline_us = deadline_after(50)
+
+      owner =
+        spawn(fn ->
+          outcome =
+            RequestOwner.execute(identity(), deadline_us, fn ->
+              send(test_pid, {:transport_ready, self()})
+              assert_receive :complete
+              success_terminal(AttemptProtocol.context())
+              {:ok, :timely}
+            end)
+
+          send(test_pid, {:owner_outcome, outcome})
+        end)
+
+      assert_receive {:transport_ready, task}
+      assert :erlang.suspend_process(owner)
+      send(task, :complete)
+
+      await_mailbox(owner, fn messages ->
+        Enum.any?(messages, &match?({_task_ref, %RequestOwner.AttemptCompletion{}}, &1))
+      end)
+
+      wait_past(deadline_us)
+
+      await_mailbox(owner, fn messages ->
+        Enum.any?(messages, &match?({:request_owner_cutoff, _, _}, &1))
+      end)
+
+      assert :erlang.resume_process(owner)
+
+      assert_receive {:owner_outcome, outcome}, 1_000
+      assert outcome.result == {:ok, :timely}
+      assert %AttemptTerminal.Response{} = outcome.fact
+    end
+  end
+
+  test "a D-1 stamp delivered after the prearmed cutoff marker is late" do
+    for _iteration <- 1..20 do
+      test_pid = self()
+      deadline_us = deadline_after(25)
+
+      owner =
+        spawn(fn ->
+          outcome =
+            RequestOwner.execute(identity(), deadline_us, fn ->
+              send(test_pid, {:transport_waiting, self()})
+              assert_receive :complete_after_cutoff
+
+              AttemptProtocol.terminal_at(
+                AttemptProtocol.context(),
+                :response,
+                %{response_kind: :success, io_duration_us: 1},
+                deadline_us - 1
+              )
+
+              {:ok, :too_late}
+            end)
+
+          send(test_pid, {:owner_outcome, outcome})
+        end)
+
+      assert_receive {:transport_waiting, task}
+      assert :erlang.suspend_process(owner)
+      wait_past(deadline_us)
+
+      await_mailbox(owner, fn messages ->
+        Enum.any?(messages, &match?({:request_owner_cutoff, _, _}, &1))
+      end)
+
+      send(task, :complete_after_cutoff)
+
+      await_mailbox(owner, fn messages ->
+        Enum.any?(messages, &match?({_task_ref, %RequestOwner.AttemptCompletion{}}, &1))
+      end)
+
+      assert :erlang.resume_process(owner)
+
+      assert_receive {:owner_outcome, outcome}, 1_000
+      assert outcome.result == {:error, :deadline_expired}
+      assert %AttemptTerminal.Deadline{} = outcome.fact
+    end
+  end
+
+  test "a caller already down prevents transport task creation" do
+    test_pid = self()
+    caller = spawn(fn -> :ok end)
+    await_down(caller)
+
+    outcome =
+      RequestOwner.execute(
+        identity(),
+        deadline_after(100),
+        fn ->
+          send(test_pid, :transport_should_not_run)
+          {:ok, :impossible}
+        end,
+        caller_pid: caller
+      )
+
+    refute_receive :transport_should_not_run
+    assert outcome.result == {:error, :caller_abandoned}
+
+    assert %AttemptTerminal.Cancelled{
+             dispatch_certainty: :not_dispatched,
+             censoring_boundary_us: 0
+           } = outcome.fact
+  end
+
+  test "caller death uses the strongest dispatch certainty and a truthful censor" do
+    phases = [
+      {fn _context -> :ok end, :not_dispatched, 0},
+      {fn context -> assert :ok = AttemptProtocol.send_started(context) end, :indeterminate,
+       :positive},
+      {fn context ->
+         assert :ok = AttemptProtocol.send_started(context)
+         assert :ok = AttemptProtocol.send_confirmed(context)
+       end, :dispatched, :positive}
+    ]
+
+    for {prepare, certainty, expected_boundary} <- phases do
+      test_pid = self()
+      caller = spawn(fn -> Process.sleep(:infinity) end)
+
+      killer =
+        spawn(fn ->
+          receive do
+            {:task_ready, task_pid} ->
+              monitor = Process.monitor(task_pid)
+              Process.exit(caller, :kill)
+
+              receive do
+                {:DOWN, ^monitor, :process, ^task_pid, reason} ->
+                  send(test_pid, {:transport_stopped, reason})
+              end
+          end
+        end)
+
+      outcome =
+        RequestOwner.execute(
+          identity(),
+          deadline_after(100),
+          fn ->
+            prepare.(AttemptProtocol.context())
+            send(killer, {:task_ready, self()})
+            Process.sleep(:infinity)
+          end,
+          caller_pid: caller
+        )
+
+      assert_receive {:transport_stopped, :killed}
+
+      assert %AttemptTerminal.Cancelled{
+               reason: :caller_abandoned,
+               dispatch_certainty: ^certainty,
+               censoring_boundary_us: boundary
+             } = outcome.fact
+
+      if expected_boundary == :positive, do: assert(boundary > 0), else: assert(boundary == 0)
+      assert outcome.result == {:error, :caller_abandoned}
+      assert outcome.committed?
+    end
+  end
+
+  test "caller abandonment overrides an unpaired response candidate" do
+    caller = spawn(fn -> Process.sleep(:infinity) end)
+
+    killer =
+      spawn(fn ->
+        receive do
+          {:candidate_ready, task_pid} ->
+            Process.exit(caller, :kill)
+            send(task_pid, :hold)
+        end
+      end)
+
+    outcome =
+      RequestOwner.execute(
+        identity(),
+        deadline_after(100),
+        fn ->
+          success_terminal(AttemptProtocol.context())
+          send(killer, {:candidate_ready, self()})
+          assert_receive :hold
+          Process.sleep(:infinity)
+        end,
+        caller_pid: caller
+      )
+
+    assert outcome.result == {:error, :caller_abandoned}
+    assert %AttemptTerminal.Cancelled{dispatch_certainty: :dispatched} = outcome.fact
+  end
+
+  test "task death is conservative before send, during send, and after dispatch proof" do
+    phases = [
+      {fn _context -> :ok end, :indeterminate},
+      {fn context -> assert :ok = AttemptProtocol.send_started(context) end, :indeterminate},
+      {fn context ->
+         assert :ok = AttemptProtocol.send_started(context)
+         assert :ok = AttemptProtocol.send_confirmed(context)
+       end, :dispatched}
+    ]
+
+    for {prepare, certainty} <- phases do
+      outcome =
+        RequestOwner.execute(identity(), deadline_after(100), fn ->
+          prepare.(AttemptProtocol.context())
+          exit(:transport_crashed)
+        end)
+
+      assert %AttemptTerminal.TransportFailure{
+               reason: :unknown,
+               dispatch_certainty: ^certainty
+             } = outcome.fact
+
+      assert outcome.result == {:error, {:transport_task_exit, :transport_crashed}}
+      assert outcome.committed?
+    end
+  end
+
+  test "restoring trap_exit preserves the caller's unrelated exit semantics" do
+    parent = self()
+
+    for {prior, reason, expected} <- [
+          {false, :normal, :survives},
+          {false, :unrelated_failure, :dies},
+          {true, :normal, :traps},
+          {true, :unrelated_failure, :traps}
+        ] do
+      helper =
+        spawn(fn ->
+          Process.flag(:trap_exit, prior)
+
+          outcome =
+            RequestOwner.execute(
+              identity(),
+              deadline_after(100),
+              fn ->
+                success_terminal(AttemptProtocol.context())
+                {:ok, :done}
+              end,
+              test_before_restore: fn ->
+                linked = spawn_link(fn -> exit(reason) end)
+
+                await_mailbox(self(), fn messages ->
+                  Enum.any?(messages, &match?({:EXIT, ^linked, ^reason}, &1))
+                end)
+              end
+            )
+
+          pending_exit =
+            receive do
+              {:EXIT, _pid, pending_reason} -> pending_reason
+            after
+              0 -> nil
+            end
+
+          send(parent, {:helper_survived, self(), outcome, pending_exit})
+        end)
+
+      monitor = Process.monitor(helper)
+
+      case expected do
+        :dies ->
+          assert_receive {:DOWN, ^monitor, :process, ^helper, :unrelated_failure}
+          refute_receive {:helper_survived, ^helper, _outcome, _pending}
+
+        :survives ->
+          assert_receive {:helper_survived, ^helper, outcome, nil}
+          assert outcome.committed?
+
+        :traps ->
+          assert_receive {:helper_survived, ^helper, outcome, ^reason}
+          assert outcome.committed?
+      end
+    end
+  end
+
+  test "deadline wakeup p95 stays within the bounded runtime tolerance" do
+    overshoots =
+      for _iteration <- 1..30 do
+        deadline_us = deadline_after(5)
+
+        outcome =
+          RequestOwner.execute(identity(), deadline_us, fn ->
+            Process.sleep(:infinity)
+          end)
+
+        assert outcome.result == {:error, :deadline_expired}
+        max(System.monotonic_time(:microsecond) - deadline_us, 0)
+      end
+
+    p95 = overshoots |> Enum.sort() |> Enum.at(28)
+
+    assert p95 <= 25_000,
+           "deadline wakeup p95 exceeded 25ms: p95=#{p95}us max=#{Enum.max(overshoots)}us"
+  end
+end

--- a/test/lasso/core/request/request_owner_test.exs
+++ b/test/lasso/core/request/request_owner_test.exs
@@ -616,7 +616,7 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
 
     for {prepare, certainty} <- phases do
       outcome =
-        RequestOwner.execute(identity(), deadline_after(100), fn ->
+        RequestOwner.execute(identity(), deadline_after(5_000), fn ->
           prepare.(AttemptProtocol.context())
           exit(:transport_crashed)
         end)

--- a/test/lasso/core/transport/attempt_protocol_test.exs
+++ b/test/lasso/core/transport/attempt_protocol_test.exs
@@ -66,4 +66,217 @@ defmodule Lasso.Core.Transport.AttemptProtocolTest do
     assert {:error, :owner_down} =
              AttemptProtocol.send_started({lifecycle_pid, make_ref()})
   end
+
+  test "a backdated send start cannot authorize work after the actual deadline" do
+    deadline_us = System.monotonic_time(:microsecond) + 1_000
+    context = AttemptProtocol.new_context(self(), make_ref(), deadline_us)
+
+    receive do
+    after
+      2 -> :ok
+    end
+
+    assert System.monotonic_time(:microsecond) >= deadline_us
+
+    assert {:error, :deadline_expired} =
+             AttemptProtocol.send_started_at(context, deadline_us - 1)
+
+    assert %{certainty: :not_dispatched} = AttemptProtocol.close(context)
+  end
+
+  test "the request owner closes dispatch authorization atomically" do
+    context =
+      AttemptProtocol.new_context(
+        self(),
+        make_ref(),
+        System.monotonic_time(:microsecond) + 1_000_000
+      )
+
+    assert %{certainty: :not_dispatched} = AttemptProtocol.close(context)
+    assert {:error, :owner_down} = AttemptProtocol.send_started(context)
+    assert %{certainty: :not_dispatched} = AttemptProtocol.close(context)
+  end
+
+  test "a send-start CAS that wins before closure is conservatively indeterminate" do
+    context =
+      AttemptProtocol.new_context(
+        self(),
+        make_ref(),
+        System.monotonic_time(:microsecond) + 1_000_000
+      )
+
+    event_us = System.monotonic_time(:microsecond)
+
+    assert :ok = AttemptProtocol.send_started_at(context, event_us)
+
+    assert %{
+             certainty: :indeterminate,
+             started_at_us: ^event_us,
+             confirmed_at_us: nil
+           } = AttemptProtocol.close(context)
+  end
+
+  test "closure and send authorization have no unsafe split-brain result" do
+    for _iteration <- 1..500 do
+      context =
+        AttemptProtocol.new_context(
+          self(),
+          make_ref(),
+          System.monotonic_time(:microsecond) + 1_000_000
+        )
+
+      task = Task.async(fn -> AttemptProtocol.send_started(context) end)
+      snapshot = AttemptProtocol.close(context)
+      result = Task.await(task)
+
+      assert {result, snapshot.certainty} in [
+               {{:error, :owner_down}, :not_dispatched},
+               {:ok, :indeterminate}
+             ]
+    end
+  end
+
+  test "positive send proof is retained in the immutable closure snapshot" do
+    context =
+      AttemptProtocol.new_context(
+        self(),
+        make_ref(),
+        System.monotonic_time(:microsecond) + 1_000_000
+      )
+
+    :ok = AttemptProtocol.install_context(context)
+
+    on_exit(fn -> AttemptProtocol.clear_context() end)
+
+    assert :ok = AttemptProtocol.send_started(context)
+    assert :ok = AttemptProtocol.send_confirmed(context)
+
+    assert %{certainty: :dispatched, confirmed_at_us: confirmed_at_us} =
+             AttemptProtocol.close(context)
+
+    assert is_integer(confirmed_at_us)
+  end
+
+  test "late dispatch proof cannot revise the deadline gate" do
+    deadline_us = System.monotonic_time(:microsecond) + 1_000_000
+    context = AttemptProtocol.new_context(self(), make_ref(), deadline_us)
+
+    assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 1)
+    assert :ok = AttemptProtocol.observe_at(context, :send_confirmed, deadline_us + 1, %{})
+
+    observations = AttemptProtocol.gate_observations([], AttemptProtocol.close(context))
+    assert Enum.any?(observations, &(&1.kind == :send_started and &1.event_us == deadline_us - 1))
+    refute Enum.any?(observations, &(&1.kind == :send_confirmed))
+  end
+
+  test "late negative proof cannot erase timely send ambiguity" do
+    for offset <- [0, 1] do
+      deadline_us = System.monotonic_time(:microsecond) + 1_000_000
+      context = AttemptProtocol.new_context(self(), make_ref(), deadline_us)
+
+      assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 1)
+
+      assert :ok =
+               AttemptProtocol.observe_at(
+                 context,
+                 :predispatch_failure,
+                 deadline_us + offset,
+                 %{reason: :not_connected, elapsed_us: 0}
+               )
+
+      assert %{certainty: :indeterminate, started_at_us: started_at_us} =
+               AttemptProtocol.close(context)
+
+      assert started_at_us == deadline_us - 1
+    end
+  end
+
+  test "a closed dispatch gate is immutable" do
+    deadline_us = System.monotonic_time(:microsecond) + 1_000_000
+    context = AttemptProtocol.new_context(self(), make_ref(), deadline_us)
+
+    assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 10)
+    assert %{certainty: :indeterminate} = snapshot = AttemptProtocol.close(context)
+
+    assert :ok = AttemptProtocol.observe_at(context, :send_confirmed, deadline_us - 9, %{})
+
+    assert :ok =
+             AttemptProtocol.observe_at(context, :predispatch_failure, deadline_us - 8, %{
+               reason: :not_connected,
+               elapsed_us: 0
+             })
+
+    assert AttemptProtocol.close(context) == snapshot
+  end
+
+  test "negative proof racing closure has one immutable result" do
+    for _iteration <- 1..500 do
+      deadline_us = System.monotonic_time(:microsecond) + 1_000_000
+      context = AttemptProtocol.new_context(self(), make_ref(), deadline_us)
+      assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 10)
+
+      task =
+        Task.async(fn ->
+          AttemptProtocol.observe_at(context, :predispatch_failure, deadline_us - 9, %{
+            reason: :not_connected,
+            elapsed_us: 0
+          })
+        end)
+
+      snapshot = AttemptProtocol.close(context)
+      assert :ok = Task.await(task)
+      assert snapshot.certainty in [:not_dispatched, :indeterminate]
+      assert AttemptProtocol.close(context) == snapshot
+    end
+  end
+
+  test "positive proof racing closure has one immutable result" do
+    for _iteration <- 1..500 do
+      deadline_us = System.monotonic_time(:microsecond) + 1_000_000
+      context = AttemptProtocol.new_context(self(), make_ref(), deadline_us)
+      assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 10)
+
+      task =
+        Task.async(fn ->
+          AttemptProtocol.observe_at(context, :send_confirmed, deadline_us - 9, %{})
+        end)
+
+      snapshot = AttemptProtocol.close(context)
+      assert :ok = Task.await(task)
+      assert snapshot.certainty in [:indeterminate, :dispatched]
+      assert AttemptProtocol.close(context) == snapshot
+    end
+  end
+
+  test "terminal candidates are task-local, exactly one, and bounded" do
+    context =
+      AttemptProtocol.new_context(
+        self(),
+        make_ref(),
+        System.monotonic_time(:microsecond) + 1_000_000
+      )
+
+    :ok = AttemptProtocol.install_context(context)
+
+    on_exit(fn -> AttemptProtocol.clear_context() end)
+
+    assert :ok =
+             AttemptProtocol.terminal(context, :response, %{
+               response_kind: :success,
+               io_duration_us: 3,
+               ignored_body: String.duplicate("secret", 1_000)
+             })
+
+    assert :ok =
+             AttemptProtocol.terminal(context, :transport_failure, %{
+               reason: :closed,
+               certainty: :dispatched
+             })
+
+    assert {:conflict, candidate} = AttemptProtocol.take_terminal_candidate(context)
+    assert candidate.kind == :response
+    refute inspect(candidate) =~ "secret"
+    assert :missing = AttemptProtocol.take_terminal_candidate(context)
+    refute_receive {:transport_observation, _, _}
+  end
 end

--- a/test/lasso/core/transport/http/http_test.exs
+++ b/test/lasso/core/transport/http/http_test.exs
@@ -2,11 +2,14 @@ defmodule Lasso.RPC.Transports.HTTPTest do
   use ExUnit.Case, async: false
   import Mox
 
+  alias Lasso.Core.Request.RequestOwner
   alias Lasso.Core.Support.ErrorClassifier
   alias Lasso.JSONRPC.Error, as: JError
+  alias Lasso.RPC.{AttemptIdentity, AttemptTerminal}
   alias Lasso.RPC.Transports.HTTP
 
   defmodule LocalRawClient do
+    @spec request(term(), term(), term(), term()) :: {:ok, {:raw, term()}}
     def request(_config, _method, _params, _opts) do
       {:ok, {:raw, Process.get({__MODULE__, :raw})}}
     end
@@ -27,6 +30,26 @@ defmodule Lasso.RPC.Transports.HTTPTest do
     end)
 
     :ok
+  end
+
+  defp attempt_identity(provider_id) do
+    AttemptIdentity.new(
+      request_id: "classified-error",
+      attempt_id: "classified-error-attempt",
+      profile: "public",
+      chain_id: 1,
+      upstream_instance_id: provider_id,
+      transport: :http,
+      route_generation: 1,
+      circuit_scope: :broad,
+      circuit_epoch: 1,
+      execution_safety: :replay_safe,
+      routing_intent: "default",
+      workload_key: "eth_call",
+      request_budget_ms: 1_000,
+      candidate_admission_count: 1,
+      dispatch_count: 1
+    )
   end
 
   test "treats malformed upstream response as retriable server error" do
@@ -150,6 +173,57 @@ defmodule Lasso.RPC.Transports.HTTPTest do
     assert error.category == expected.category
     assert error.retriable? == expected.retriable?
     assert error.breaker_penalty? == expected.breaker_penalty?
+  end
+
+  test "request ownership projects production HTTP errors into canonical classes" do
+    provider_id = "owner-classified-provider"
+
+    channel = %{
+      provider_id: provider_id,
+      config: %{id: provider_id, url: "https://example.invalid"}
+    }
+
+    rpc_request = %{
+      "jsonrpc" => "2.0",
+      "method" => "eth_call",
+      "params" => [],
+      "id" => "classified-error"
+    }
+
+    cases = [
+      {-32_602, "invalid params", :deterministic, :return_response, :none},
+      {-32_005, "rate limited", :quota, :try_next_candidate, :none},
+      {-32_601, "method not found", :capability, :try_next_candidate, :none},
+      {-32_002, "provider unavailable", :provider_failure, :try_next_candidate, :failure}
+    ]
+
+    for {code, message, category, action, breaker_effect} <- cases do
+      raw =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => "classified-error",
+          "error" => %{"code" => code, "message" => message}
+        })
+
+      expect(Lasso.RPC.HttpClientMock, :request, fn _config, _method, _params, _opts ->
+        {:ok, {:raw, raw}}
+      end)
+
+      outcome =
+        RequestOwner.execute(
+          attempt_identity(provider_id),
+          System.monotonic_time(:microsecond) + 1_000_000,
+          fn -> HTTP.request(channel, rpc_request, 1_000) end
+        )
+
+      assert %AttemptTerminal.Response{
+               kind: :application_error,
+               error_category: ^category
+             } = outcome.fact
+
+      assert outcome.projection.recommended_action == action
+      assert outcome.projection.breaker_effect == breaker_effect
+    end
   end
 
   test "composes the per-attempt timeout with the shared decision deadline" do

--- a/test/lasso/core/transport/websocket/transport_protocol_test.exs
+++ b/test/lasso/core/transport/websocket/transport_protocol_test.exs
@@ -960,9 +960,10 @@ defmodule Lasso.RPC.Transport.WebSocket.TransportProtocolTest do
       Enum.each(traced_mfas, &:erlang.trace_pattern(&1, false, [:local]))
     end)
 
-    task = request_task(context.channel, "one-authorization", 1_000)
+    {task, release_request} = gated_request_task(context.channel, "one-authorization", 1_000)
     task_pid = task.pid
     :erlang.trace(task_pid, true, [:call])
+    release_request.()
 
     assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
 
@@ -1324,6 +1325,20 @@ defmodule Lasso.RPC.Transport.WebSocket.TransportProtocolTest do
 
   defp request_task(channel, client_id, timeout) do
     Task.async(fn -> WebSocket.request(channel, rpc_request(client_id), timeout) end)
+  end
+
+  defp gated_request_task(channel, client_id, timeout) do
+    parent = self()
+
+    task =
+      Task.async(fn ->
+        receive do
+          {:begin_request, ^parent} ->
+            WebSocket.request(channel, rpc_request(client_id), timeout)
+        end
+      end)
+
+    {task, fn -> send(task.pid, {:begin_request, parent}) end}
   end
 
   defp observed_request_task(channel, timeout \\ 5_000) do

--- a/test/lasso/core/transport/websocket/transport_protocol_test.exs
+++ b/test/lasso/core/transport/websocket/transport_protocol_test.exs
@@ -1,13 +1,14 @@
 defmodule Lasso.RPC.Transport.WebSocket.TransportProtocolTest do
   use ExUnit.Case, async: false
 
+  alias Lasso.Core.Request.RequestOwner
   alias Lasso.Core.Support.{CircuitBreaker, ErrorClassifier}
   alias Lasso.Core.Support.CircuitBreaker.{ControlRing, Snapshot}
   alias Lasso.Core.Transport.UpstreamResponse
   alias Lasso.Core.Transport.UpstreamResponse.Validated
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.InstanceState
-  alias Lasso.RPC.Response
+  alias Lasso.RPC.{AttemptIdentity, AttemptTerminal, Response}
   alias Lasso.RPC.Transport.WebSocket.{Connection, Endpoint, Handler}
   alias Lasso.RPC.Transports.WebSocket
 
@@ -142,6 +143,48 @@ defmodule Lasso.RPC.Transport.WebSocket.TransportProtocolTest do
 
     assert_observation(attempt_ref, :response)
     assert {:ok, %Response.Success{id: "observed"}, _io_ms} = Task.await(task)
+  end
+
+  test "request ownership projects production WebSocket errors into canonical classes", context do
+    cases = [
+      {-32_602, "invalid params", :deterministic, :return_response, :none},
+      {-32_005, "rate limited", :quota, :try_next_candidate, :none},
+      {-32_601, "method not found", :capability, :try_next_candidate, :none},
+      {-32_002, "provider unavailable", :provider_failure, :try_next_candidate, :failure}
+    ]
+
+    for {code, message, category, action, breaker_effect} <- cases do
+      client_id = "owner-error-#{code}"
+
+      task =
+        Task.async(fn ->
+          RequestOwner.execute(
+            ws_attempt_identity(context, client_id),
+            System.monotonic_time(:microsecond) + 1_000_000,
+            fn -> WebSocket.request(context.channel, rpc_request(client_id), 1_000) end
+          )
+        end)
+
+      assert_receive {:protocol_ws_send, ws_pid, transport_id, _payload}
+
+      raw =
+        Jason.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => transport_id,
+          "error" => %{"code" => code, "message" => message}
+        })
+
+      :ok = TestSupport.ProtocolWSClient.acknowledge(ws_pid, transport_id, raw)
+      outcome = Task.await(task, 1_000)
+
+      assert %AttemptTerminal.Response{
+               kind: :application_error,
+               error_category: ^category
+             } = outcome.fact
+
+      assert outcome.projection.recommended_action == action
+      assert outcome.projection.breaker_effect == breaker_effect
+    end
   end
 
   test "a timeout after the post-write acknowledgement remains dispatched", context do
@@ -1302,6 +1345,26 @@ defmodule Lasso.RPC.Transport.WebSocket.TransportProtocolTest do
       end)
 
     {task, attempt_ref}
+  end
+
+  defp ws_attempt_identity(context, request_id) do
+    AttemptIdentity.new(
+      request_id: request_id,
+      attempt_id: "#{request_id}-attempt",
+      profile: "public",
+      chain_id: 1,
+      upstream_instance_id: context.instance_id,
+      transport: :ws,
+      route_generation: 1,
+      circuit_scope: :broad,
+      circuit_epoch: 1,
+      execution_safety: :replay_safe,
+      routing_intent: "default",
+      workload_key: "eth_blockNumber",
+      request_budget_ms: 1_000,
+      candidate_admission_count: 1,
+      dispatch_count: 1
+    )
   end
 
   defp assert_observation(attempt_ref, kind) do


### PR DESCRIPTION
## Summary

Adds the bounded request-owned attempt runtime that will replace the transitional `AttemptLifecycle` topology in the next cutover slice.

- The calling request/item process owns deadline arbitration, dispatch certainty, the single terminal transition, and the returned result.
- Each authorized attempt has exactly one linked and monitored transport task; there is no second lifecycle process in this path.
- Transport terminal facts and return values settle as one task-local `AttemptCompletion`, preventing contradictory success/error outcomes.
- A deadline-fenced atomic gate arbitrates send start, positive dispatch proof, pre-send proof, owner closure, and caller abandonment.
- Canonical facts use the existing tagged terminal types and pure projector. Production HTTP and WebSocket error categories map once into `deterministic`, `quota`, `capability`, or `provider_failure`.
- The slice remains intentionally unwired. `RequestPipeline` and compatibility callers continue using `AttemptLifecycle` until the atomic pipeline/entrypoint cutover above this PR.

## Stack position

This PR is based on draft transport PR #58 (`feat/500-stamped-transport-protocol`). It must not be rebased onto `main` or merged independently of that transport contract.

## Correctness evidence

Fresh BEAM and state-machine reviews approve the final tree. Deterministic coverage includes:

- strict `D-1 / D / D+1` eligibility and prearmed mailbox cutoff ordering;
- caller death versus task completion and send authorization;
- task death before send, during ambiguity, and after positive dispatch proof;
- missing, malformed, conflicting, and result-mismatched terminal candidates;
- absorbing full gate snapshots under late observations and 10,000+ close/proof races;
- backdated send-start invoked after the actual deadline returning `deadline_expired`;
- stale predispatch facts rewritten to conservative transport failures when stronger certainty exists;
- real linked-process `trap_exit` behavior for prior true/false and normal/abnormal exits;
- bounded exit reasons, no retained request/error secrets, and no post-run mailbox/monitor/link residue;
- production HTTP and WebSocket application-error paths across all four canonical classes.

## Verification

- `PORT=0 MIX_ENV=test mix test --include integration` — 1,267 tests, 0 failures
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer` — zero unskipped errors
- `git diff --check`

## Fixed-resource diagnostic

Prepared healthy-path median on four schedulers, compared with the exact #58 compatibility baseline:

| Metric | c1 | c32 |
|---|---:|---:|
| Throughput | +58.1% | +73.2% |
| CPU/request | -38.0% | -39.4% |
| Reductions | -9.6% | -8.8% |
| p95/p99 | 40–46% lower | 40–46% lower |

Topology changes from two spawned processes and eight application messages per attempt to one transport task and two Task-protocol messages. A 10,000-attempt residue check ended with the original process count, an empty mailbox, no monitors/links, restored `trap_exit`, and the original post-GC heap size.

The reclaimed-word proxy remains higher because this path constructs the richer canonical fact/projector result. It has no measured retention, CPU, reduction, or tail regression and remains an explicit full-union benchmark metric.

Part of #500 and the #528 accepted execution contract.
