### PR TITLE
Reduce JSON-RPC fast-path encoding work

### DIFF
--- a/lib/lasso/core/request/prepared_request.ex
+++ b/lib/lasso/core/request/prepared_request.ex
@@ -31,7 +31,7 @@ defmodule Lasso.RPC.PreparedRequest do
         {:error, :invalid_client_id}
 
       true ->
-        case Jason.encode(Map.put(rpc_request, "id", transport_id)) do
+        case encode_request(Map.put(rpc_request, "id", transport_id)) do
           {:ok, encoded} ->
             {:ok,
              %__MODULE__{
@@ -56,4 +56,15 @@ defmodule Lasso.RPC.PreparedRequest do
 
   defp valid_client_id?(client_id),
     do: is_binary(client_id) or is_integer(client_id) or is_nil(client_id)
+
+  defp encode_request(rpc_request) do
+    {:ok, rpc_request |> :json.encode(&encode_json_value/2) |> IO.iodata_to_binary()}
+  rescue
+    _error -> Jason.encode(rpc_request)
+  catch
+    _kind, _reason -> Jason.encode(rpc_request)
+  end
+
+  defp encode_json_value(nil, _encoder), do: "null"
+  defp encode_json_value(value, encoder), do: :json.encode_value(value, encoder)
 end

--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -74,28 +74,26 @@ defmodule Lasso.RPC.RequestProjection do
   def encode(%__MODULE__{} = event) do
     event = validate!(event)
 
-    with {:ok, fact_payload} <- Codec.encode(event.fact) do
-      payload =
-        :erlang.term_to_binary(
-          {
-            @schema,
-            @version,
-            fact_payload,
-            event.method,
-            event.provider_id,
-            event.instance_id,
-            event.transport,
-            event.request_origin,
-            event.failover_count,
-            event.emitted_at_ms
-          },
-          [:deterministic]
-        )
+    payload =
+      :erlang.term_to_binary(
+        {
+          @schema,
+          @version,
+          event.fact,
+          event.method,
+          event.provider_id,
+          event.instance_id,
+          event.transport,
+          event.request_origin,
+          event.failover_count,
+          event.emitted_at_ms
+        },
+        [:deterministic]
+      )
 
-      if byte_size(payload) <= @max_bytes,
-        do: {:ok, payload},
-        else: {:error, :event_too_large}
-    end
+    if byte_size(payload) <= @max_bytes,
+      do: {:ok, payload},
+      else: {:error, :event_too_large}
   rescue
     ArgumentError -> {:error, :invalid_event}
   end
@@ -115,7 +113,7 @@ defmodule Lasso.RPC.RequestProjection do
         failover_count,
         emitted_at_ms
       } ->
-        case Codec.decode(fact_payload) do
+        case decode_fact_payload(fact_payload) do
           {:ok, fact} ->
             event = %__MODULE__{
               version: @version,
@@ -148,6 +146,13 @@ defmodule Lasso.RPC.RequestProjection do
   end
 
   def decode(payload) when is_binary(payload), do: {:error, :event_too_large}
+
+  defp decode_fact_payload(fact_payload) when is_binary(fact_payload),
+    do: Codec.decode(fact_payload)
+
+  defp decode_fact_payload(%_module{} = fact), do: {:ok, fact}
+
+  defp decode_fact_payload(_fact_payload), do: {:error, :invalid_fact}
 
   @spec routing_decision(t()) :: {:ok, RoutingDecision.t()} | :not_routed
   def routing_decision(%__MODULE__{provider_id: provider_id, transport: transport} = event)

--- a/lib/lasso/core/transport/upstream_response.ex
+++ b/lib/lasso/core/transport/upstream_response.ex
@@ -37,10 +37,12 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
 
   @spec parse_unary(binary()) :: parsed()
   def parse_unary(raw_bytes) when is_binary(raw_bytes) do
-    case decode(raw_bytes, response_mode(raw_bytes)) do
+    {mode, id_span} = response_metadata(raw_bytes)
+
+    case decode(raw_bytes, mode) do
       {{:container, :object}, {:root, fields}, rest} ->
         if only_json_whitespace?(rest) do
-          classify_fields(fields)
+          attach_id_span(classify_fields(fields), id_span)
         else
           {:invalid, :invalid_json, candidate_id(fields)}
         end
@@ -434,17 +436,22 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
     end
   end
 
-  defp response_mode(raw_bytes) do
+  defp attach_id_span({:ok, %Validated{} = validated}, id_span),
+    do: {:ok, %{validated | id_span: id_span}}
+
+  defp attach_id_span(parsed, _id_span), do: parsed
+
+  defp response_metadata(raw_bytes) do
     start = skip_whitespace(raw_bytes, 0)
 
     if byte_at(raw_bytes, start) == ?{ do
-      scan_response_mode(raw_bytes, skip_whitespace(raw_bytes, start + 1))
+      scan_response_metadata(raw_bytes, skip_whitespace(raw_bytes, start + 1), nil)
     else
-      :discard
+      {:discard, nil}
     end
   end
 
-  defp scan_response_mode(raw_bytes, index) do
+  defp scan_response_metadata(raw_bytes, index, id_span) do
     with ?" <- byte_at(raw_bytes, index),
          {:ok, key_end} <- skip_string(raw_bytes, index),
          {:ok, key} <- decode_key(raw_bytes, index, key_end) do
@@ -454,30 +461,39 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
         value_start = skip_whitespace(raw_bytes, colon_index + 1)
 
         case key do
-          "error" -> :retain_error
-          "result" -> :discard
-          _other -> continue_response_mode(raw_bytes, value_start)
+          "error" -> {:retain_error, id_span}
+          "result" -> {:discard, id_span}
+          "id" -> continue_response_metadata(raw_bytes, value_start, value_start)
+          _other -> continue_response_metadata(raw_bytes, value_start, id_span)
         end
       else
-        :discard
+        {:discard, id_span}
       end
     else
-      _invalid -> :discard
+      _invalid -> {:discard, id_span}
     end
   end
 
-  defp continue_response_mode(raw_bytes, value_start) do
+  defp continue_response_metadata(raw_bytes, value_start, id_start_or_span) do
     case skip_value(raw_bytes, value_start) do
       {:ok, value_end} ->
+        id_span =
+          if is_integer(id_start_or_span),
+            do: {id_start_or_span, value_end - id_start_or_span},
+            else: id_start_or_span
+
         next = skip_whitespace(raw_bytes, value_end)
 
         case byte_at(raw_bytes, next) do
-          ?, -> scan_response_mode(raw_bytes, skip_whitespace(raw_bytes, next + 1))
-          _end_or_invalid -> :discard
+          ?, ->
+            scan_response_metadata(raw_bytes, skip_whitespace(raw_bytes, next + 1), id_span)
+
+          _end_or_invalid ->
+            {:discard, id_span}
         end
 
       :error ->
-        :discard
+        {:discard, nil}
     end
   end
 
@@ -528,8 +544,14 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
   end
 
   defp decode_key(raw_bytes, start, finish) do
-    token = binary_part(raw_bytes, start, finish - start)
-    {:ok, :json.decode(token)}
+    case binary_part(raw_bytes, start, finish - start) do
+      ~s("id") -> {:ok, "id"}
+      ~s("jsonrpc") -> {:ok, "jsonrpc"}
+      ~s("result") -> {:ok, "result"}
+      ~s("error") -> {:ok, "error"}
+      ~s("method") -> {:ok, "method"}
+      token -> {:ok, :json.decode(token)}
+    end
   rescue
     _error -> :error
   end

--- a/test/lasso/core/request/prepared_request_test.exs
+++ b/test/lasso/core/request/prepared_request_test.exs
@@ -32,6 +32,23 @@ defmodule Lasso.RPC.PreparedRequestTest do
     assert {:ok, %{"id" => nil}} = PreparedRequest.to_legacy_map(prepared)
   end
 
+  test "preserves nested JSON values through the prepared binary" do
+    params = [
+      %{
+        "unicode" => "route → upstream",
+        "decimal" => 1.25,
+        "nested" => [nil, true, %{"quantity" => "0x01"}]
+      }
+    ]
+
+    request = %{"jsonrpc" => "2.0", "method" => "eth_call", "params" => params, "id" => 7}
+
+    assert {:ok, prepared} = PreparedRequest.new(request, "lasso-json-values")
+
+    assert {:ok, %{"id" => "lasso-json-values", "params" => ^params}} =
+             Jason.decode(prepared.encoded)
+  end
+
   test "rejects invalid transport ids and unencodable request values" do
     request = %{"jsonrpc" => "2.0", "method" => "eth_call", "params" => [], "id" => 1}
 

--- a/test/lasso/core/request/request_projection_test.exs
+++ b/test/lasso/core/request/request_projection_test.exs
@@ -11,6 +11,8 @@ defmodule Lasso.RPC.RequestProjectionTest do
     RequestTerminal
   }
 
+  alias Lasso.RPC.ExecutionFact.Codec
+
   setup do
     Application.ensure_all_started(:lasso)
     :ok
@@ -63,6 +65,36 @@ defmodule Lasso.RPC.RequestProjectionTest do
     assert {:ok, payload} = RequestProjection.encode(event)
     assert byte_size(payload) <= 4_096
     assert {:ok, ^event} = RequestProjection.decode(payload)
+  end
+
+  test "native facts avoid a JSON round trip while queued JSON facts remain compatible" do
+    event = request_projection()
+
+    assert {:ok, native_payload} = RequestProjection.encode(event)
+
+    assert {:lasso_request_projection, 1, %RequestTerminal.UpstreamResponse{}, _method,
+            _provider_id, _instance_id, _transport, _origin, _failovers,
+            _emitted_at_ms} =
+             :erlang.binary_to_term(native_payload, [:safe])
+
+    legacy_payload =
+      :erlang.term_to_binary(
+        {
+          :lasso_request_projection,
+          1,
+          Codec.encode!(event.fact),
+          event.method,
+          event.provider_id,
+          event.instance_id,
+          event.transport,
+          event.request_origin,
+          event.failover_count,
+          event.emitted_at_ms
+        },
+        [:deterministic]
+      )
+
+    assert {:ok, ^event} = RequestProjection.decode(legacy_payload)
   end
 
   test "routing decision preserves canonical request and final route identity" do

--- a/test/lasso/core/transport/upstream_response_test.exs
+++ b/test/lasso/core/transport/upstream_response_test.exs
@@ -15,6 +15,25 @@ defmodule Lasso.Core.Transport.UpstreamResponseTest do
     assert {:ok, %{"id" => 7, "result" => "0x1"}} = Jason.decode(response.raw_bytes)
   end
 
+  test "captures a top-level id span during the mode scan and falls back when result comes first" do
+    canonical = ~s({"jsonrpc":"2.0","id":"internal","result":"0x1"})
+
+    assert {:ok, %Validated{id: "internal", id_span: {start, length}}} =
+             UpstreamResponse.parse_unary(canonical)
+
+    assert binary_part(canonical, start, length) == ~s("internal")
+
+    result_first = ~s({"result":"0x1","id":"internal","jsonrpc":"2.0"})
+
+    assert {:ok, %Validated{id: "internal", id_span: nil}} =
+             UpstreamResponse.parse_unary(result_first)
+
+    assert {:ok, %Response.Success{raw_bytes: restored}} =
+             UpstreamResponse.validate_unary(result_first, "internal", 9)
+
+    assert {:ok, %{"id" => 9, "result" => "0x1"}} = Jason.decode(restored)
+  end
+
   test "rejects invalid unary envelopes with bounded reasons" do
     vectors = [
       {"not-json", :invalid_json},
@@ -45,10 +64,9 @@ defmodule Lasso.Core.Transport.UpstreamResponseTest do
       {~s({"jsonrpc":"2.0","id":"internal","error":{"code":-32000,"message":"busy","data":{"secret":"discarded"}}}),
        {:ok, :error, "internal"}},
       {~s({"jsonrpc":"2.0","id":"internal","result":[1,]}), {:invalid, :invalid_json}},
-      {<<"{\"jsonrpc\":\"2.0\",\"id\":\"internal\",\"result\":\"", 0xFF, "\"}">>,
+      {~s({"jsonrpc":"2.0","id":"internal","result":") <> <<0xFF>> <> ~s("}),
        {:invalid, :invalid_json}},
-      {"{\"jsonrpc\":\"2.0\",\"id\":\"internal\",\"result\":\"" <>
-         "\\u" <> "D800\"}", {:invalid, :invalid_json}},
+      {~S({"jsonrpc":"2.0","id":"internal","result":"\uD800"}), {:invalid, :invalid_json}},
       {~s({"jsonrpc":"2.0","result":{"id":"internal"}}), {:invalid, :invalid_envelope}},
       {~s({"jsonrpc":"2.0","id":"internal","id":"internal","result":1}),
        {:invalid, :invalid_envelope}},


### PR DESCRIPTION
## Summary

- encode prepared JSON-RPC requests with OTP's native JSON encoder while preserving Jason-compatible fallback behavior
- carry the validated top-level response ID span from the existing structural scan to avoid rescanning canonical responses
- keep bounded request projection facts in their native validated form while retaining compatibility with queued JSON payloads

## Safety

- strict upstream JSON validation and exact response-ID correlation remain unchanged
- result-first and escaped-key response shapes retain the existing fallback path
- projection payloads remain deterministic, bounded to 4 KiB, and delivered through the same diagnostics lane
- dashboard routing decisions and terminal telemetry remain unchanged

## Verification

- 1,417 integration-enabled tests, 0 failures
- 166 focused parser/transport/pipeline/projection tests, 0 failures
- OTP 27 / Elixir 1.17 production Docker build passed
- 25 directly affected tests passed on OTP 27 / Elixir 1.17
- warnings-as-errors compile, strict Credo, dev Dialyzer, formatting, and diff checks passed
