### PR TITLE
Stagger initial block sync polls

### DIFF
--- a/lib/lasso/core/block_sync/strategies/http_strategy.ex
+++ b/lib/lasso/core/block_sync/strategies/http_strategy.ex
@@ -30,6 +30,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
 
   @default_poll_interval_ms 15_000
   @default_timeout_ms 3_000
+  @max_initial_stagger_ms 2_000
   @max_consecutive_failures 3
   @degraded_threshold 2
   @unhealthy_threshold 5
@@ -103,6 +104,17 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
     parent = Keyword.get(opts, :parent, self())
     poll_interval = Keyword.get(opts, :poll_interval_ms, @default_poll_interval_ms)
 
+    initial_delay_ms =
+      case Keyword.get_lazy(opts, :initial_delay_ms, fn ->
+             initial_poll_delay_ms(chain_id, instance_id, poll_interval)
+           end) do
+        delay_ms when is_integer(delay_ms) and delay_ms >= 0 ->
+          delay_ms
+
+        invalid ->
+          raise ArgumentError, "initial_delay_ms must be non-negative, got: #{inspect(invalid)}"
+      end
+
     state = %__MODULE__{
       instance_id: instance_id,
       chain_id: chain_id,
@@ -121,7 +133,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
       route_resolver: Keyword.get(opts, :route_resolver, &resolve_route/2)
     }
 
-    state = schedule_poll(state, 0)
+    state = schedule_poll(state, initial_delay_ms)
 
     {:ok, state}
   end
@@ -236,6 +248,15 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategy do
       )
 
     %{state | timer_ref: ref, poll_generation: generation}
+  end
+
+  @doc false
+  @spec initial_poll_delay_ms(pos_integer(), String.t(), pos_integer()) :: non_neg_integer()
+  def initial_poll_delay_ms(chain_id, instance_id, poll_interval_ms)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) and
+             is_integer(poll_interval_ms) and poll_interval_ms > 0 do
+    stagger_window_ms = min(poll_interval_ms, @max_initial_stagger_ms)
+    :erlang.phash2({chain_id, instance_id}, stagger_window_ms)
   end
 
   defp start_poll_owner(state) do

--- a/test/lasso/core/block_sync/http_strategy_test.exs
+++ b/test/lasso/core/block_sync/http_strategy_test.exs
@@ -42,6 +42,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategyTest do
     {:ok, state} =
       HttpStrategy.start(1, instance_id,
         parent: self(),
+        initial_delay_ms: 0,
         poll_interval_ms: 10_000,
         route_resolver: fn ^instance_id, 1 -> {:ok, "profile-b", "provider-b"} end,
         poll_runner: runner
@@ -103,6 +104,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategyTest do
     {:ok, state} =
       HttpStrategy.start(1, instance_id,
         parent: self(),
+        initial_delay_ms: 0,
         poll_interval_ms: 10_000,
         route_resolver: fn ^instance_id, 1 -> {:ok, "profile-a", "provider-a"} end,
         poll_runner: fn _plan ->
@@ -139,6 +141,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategyTest do
     {:ok, state} =
       HttpStrategy.start(1, instance_id,
         parent: self(),
+        initial_delay_ms: 0,
         route_resolver: fn ^instance_id, 1 -> {:ok, "profile-a", "provider-a"} end,
         poll_runner: fn _plan ->
           send(test_pid, {:poll_blocked, self()})
@@ -163,6 +166,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategyTest do
     {:ok, strategy} =
       HttpStrategy.start(1, instance_id,
         parent: self(),
+        initial_delay_ms: 0,
         route_resolver: fn ^instance_id, 1 -> {:ok, "profile", "provider"} end,
         poll_runner: fn _plan ->
           send(test_pid, {:poll_blocked, self()})
@@ -219,6 +223,7 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategyTest do
     {:ok, state} =
       HttpStrategy.start(1, instance_id,
         parent: self(),
+        initial_delay_ms: 0,
         poll_interval_ms: 10_000,
         route_resolver: resolver,
         poll_runner: runner
@@ -250,5 +255,43 @@ defmodule Lasso.BlockSync.Strategies.HttpStrategyTest do
 
     HttpStrategy.stop(state)
     refute Process.alive?(second_owner)
+  end
+
+  test "initial polls are deterministically staggered without delaying a full interval" do
+    delays =
+      for index <- 1..256 do
+        HttpStrategy.initial_poll_delay_ms(1, "startup-instance-#{index}", 15_000)
+      end
+
+    assert Enum.all?(delays, &(&1 in 0..1_999))
+    assert length(Enum.uniq(delays)) > 220
+    assert Enum.min(delays) < 100
+    assert Enum.max(delays) > 1_900
+
+    assert HttpStrategy.initial_poll_delay_ms(1, "stable-instance", 15_000) ==
+             HttpStrategy.initial_poll_delay_ms(1, "stable-instance", 15_000)
+
+    assert HttpStrategy.initial_poll_delay_ms(1, "short-interval", 25) in 0..24
+  end
+
+  test "the production default schedules the first poll at its deterministic offset" do
+    instance_id =
+      Enum.find_value(1..1_000, fn index ->
+        candidate = "delayed-startup-instance-#{index}"
+
+        if HttpStrategy.initial_poll_delay_ms(1, candidate, 15_000) >= 500,
+          do: candidate
+      end)
+
+    expected_delay_ms = HttpStrategy.initial_poll_delay_ms(1, instance_id, 15_000)
+    {:ok, state} = HttpStrategy.start(1, instance_id, parent: self())
+    remaining_ms = Process.read_timer(state.timer_ref)
+
+    assert is_integer(remaining_ms)
+    assert remaining_ms > 0
+    assert remaining_ms <= expected_delay_ms
+    refute_receive {:http_strategy, :poll, ^instance_id, _generation}, 5
+
+    HttpStrategy.stop(state)
   end
 end


### PR DESCRIPTION
## Summary

- deterministically spread first BlockSync HTTP polls over a bounded two-second window
- preserve immediate test control and steady-state polling semantics
- cover deterministic bounds, distribution, and actual timer scheduling

## Why

A restart currently schedules every provider poll at 0 ms. With roughly 100 provider instances this creates a synchronized upstream burst. The bounded stagger reduces the representative worst 100 ms startup slice from 100 polls to 7 without adding steady-state processes, messages, ETS work, or randomness.

## Verification

- 43 focused BlockSync/GapFiller tests
- warnings-as-errors compile
- full integration-enabled suite reached 1,422 tests; its two failures were external MIX_BUILD_PATH priv-link artifacts and both passed in the normal build path
- strict Credo on changed files
- formatting and diff check
