### PR TITLE
Expire stale adaptive routing evidence

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -22,6 +22,7 @@ defmodule Lasso.RPC.AttemptProjection do
   @max_bytes 4_096
   @control_retries 4
   @probation_deliveries 32
+  @routing_evidence_max_age_us 300_000_000
   @max_count 9_223_372_036_854_775_807
   @default_workload "default"
   @availability_dimensions [
@@ -235,11 +236,13 @@ defmodule Lasso.RPC.AttemptProjection do
   def batch_summaries(profile, channels, chain_id, workload_key) do
     scope = scope_state(profile, chain_id)
     workload = workload_key |> Atom.to_string() |> BoundedIdentifier.encode()
+    now_us = System.monotonic_time(:microsecond)
 
     Map.new(channels, fn channel ->
       key = {channel.instance_id, channel.transport}
       row = route_state(scope, channel.instance_id, channel.transport, workload)
-      {key, summary(row, channel.instance_id, channel.transport, chain_id, workload_key)}
+
+      {key, summary(row, channel.instance_id, channel.transport, chain_id, workload_key, now_us)}
     end)
   end
 
@@ -249,7 +252,14 @@ defmodule Lasso.RPC.AttemptProjection do
   def summarize_route(row, instance_id, transport, chain_id, workload_key)
       when is_binary(instance_id) and transport in [:http, :ws] and is_integer(chain_id) and
              chain_id > 0 and is_atom(workload_key) do
-    summary(row, instance_id, transport, chain_id, workload_key)
+    summary(
+      row,
+      instance_id,
+      transport,
+      chain_id,
+      workload_key,
+      System.monotonic_time(:microsecond)
+    )
   end
 
   @spec prepare_routes(non_neg_integer(), [map()]) :: :ok
@@ -893,11 +903,12 @@ defmodule Lasso.RPC.AttemptProjection do
   defp visible_after_floor?(%{recovery_floor_us: floor_us}, observed_at_us),
     do: observed_at_us > floor_us
 
-  defp summary(nil, _instance_id, _transport, _chain_id, _workload_key), do: nil
+  defp summary(nil, _instance_id, _transport, _chain_id, _workload_key, _now_us), do: nil
 
-  defp summary(row, instance_id, transport, chain_id, workload_key) do
+  defp summary(row, instance_id, transport, chain_id, workload_key, now_us) do
     state =
       cond do
+        routing_evidence_stale?(row.observed_at_us, now_us) -> :stale
         row.usable_successes >= 3 and row.consecutive_failures < 3 -> :qualified
         row.comparable_attempts > 0 -> :provisional
         true -> :unqualified
@@ -919,6 +930,9 @@ defmodule Lasso.RPC.AttemptProjection do
       generation: row.generation
     }
   end
+
+  defp routing_evidence_stale?(observed_at_us, now_us),
+    do: now_us - observed_at_us >= @routing_evidence_max_age_us
 
   defp diagnostic_attempt?(%AttemptTerminal.Response{kind: :success}), do: false
   defp diagnostic_attempt?(_fact), do: true

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -287,6 +287,38 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert row.successful_p95_latency_ms == nil
   end
 
+  test "qualified routing evidence becomes stale after five minutes without an observation" do
+    generation = publish_routes(["stale-instance", "fresh-instance"])
+    now_us = System.monotonic_time(:microsecond)
+    stale_us = now_us - 300_000_001
+
+    for offset <- 0..2 do
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event(stale_us + offset, "stale-instance", generation)
+               )
+
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event(now_us - 2 + offset, "fresh-instance", generation)
+               )
+    end
+
+    summaries =
+      AttemptProjection.batch_summaries(
+        @profile,
+        [
+          %{instance_id: "stale-instance", transport: :http},
+          %{instance_id: "fresh-instance", transport: :http}
+        ],
+        @chain_id,
+        :default
+      )
+
+    assert summaries[{"stale-instance", :http}].state == :stale
+    assert summaries[{"fresh-instance", :http}].state == :qualified
+  end
+
   test "availability degradation counters are fixed, generation scoped, and profile isolated" do
     generation = ConfigStore.route_generation()
 


### PR DESCRIPTION
## Summary
- mark routing summaries stale after five minutes without an observation
- compute freshness once per selection batch
- keep stale providers available through deterministic fallback ordering instead of treating obsolete latency as current

## Why
Staging showed providers measured 10–14 minutes earlier still qualifying as Fastest/Latency Weighted winners. The five-minute horizon is deliberately longer than the maximum two-minute background probe cadence, so actively observed routes remain qualified while missing evidence no longer steers adaptive routing indefinitely.

## Verification
- `mix test test/lasso/core/request/attempt_projection_test.exs test/unit/strategies/evidence_ranking_test.exs` (21 tests)
- `mix test test/lasso/core/request test/lasso/core/selection test/unit/strategies` (197 tests, 1 excluded)
- `mix compile --warnings-as-errors`
- `mix credo --strict` on changed files
- `git diff --check`

This PR contains only the OSS runtime change and regression coverage; no eRPC comparison or benchmark artifacts.