### PR TITLE
Make byte-budget test cleanup deterministic

### DIFF
--- a/test/lasso_web/sockets/rpc_socket_item_owner_test.exs
+++ b/test/lasso_web/sockets/rpc_socket_item_owner_test.exs
@@ -577,7 +577,12 @@ defmodule LassoWeb.RPCSocketItemOwnerTest do
     :persistent_term.put(@test_control_key, %{mode: mode, test_pid: self()})
   end
 
-  defp await_byte_budget_idle!(deadline_ms \\ System.monotonic_time(:millisecond) + 1_000) do
+  defp await_byte_budget_idle! do
+    send(ByteBudget, :audit)
+    await_byte_budget_idle!(System.monotonic_time(:millisecond) + 1_000)
+  end
+
+  defp await_byte_budget_idle!(deadline_ms) do
     if ByteBudget.stats().reservations == 0 do
       :ok
     else


### PR DESCRIPTION
## Summary
- trigger the existing byte-budget dead-owner audit before waiting for global test state to become idle
- preserve the assertion that live reservations cannot leak between tests

## Why
The budget audits every second, while the socket test setup also timed out after exactly one second. Depending on timer phase, setup could fail just before the next legitimate audit. This has failed unrelated PR unit jobs repeatedly even though production recovery and focused tests are sound.

## Verification
- socket item-owner suite: 21 tests × 30 seeds, 630/630 passed
- `mix format`
- `git diff --check`

Test-only change; no runtime behavior changes.