### PR TITLE
Isolate system routing evidence from client routing

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,3 +48,9 @@ A bounded, node-local summary of attempt evidence used to qualify or rank an ups
 Evidence qualification is separate from live admission, and another profile may reuse evidence
 only when it explicitly references the same upstream instance.
 _Avoid_: Lifetime average, health score
+
+**Evidence partition**:
+One of the fixed workload keys that isolates client attempt evidence from system-probe evidence.
+Client evidence is authoritative for adaptive client routing. Fresh system evidence may order an
+otherwise unqualified client fallback, but it cannot qualify the route.
+_Avoid_: Dynamic method bucket, shared default workload

--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -14,7 +14,7 @@ defmodule Lasso.RPC.AttemptProjection do
   }
 
   alias Lasso.RPC.ExecutionFact.Codec
-  alias Lasso.RPC.RoutingEvidence.{AttemptEvent, Summary}
+  alias Lasso.RPC.RoutingEvidence.{AttemptEvent, Summary, Workload}
 
   @dispatcher Lasso.ExecutionProjectionDispatcher
   @schema :lasso_attempt_projection
@@ -24,10 +24,12 @@ defmodule Lasso.RPC.AttemptProjection do
   @probation_deliveries 32
   @routing_evidence_max_age_us 300_000_000
   @max_count 9_223_372_036_854_775_807
-  @default_workload "default"
+  @default_workload "client"
   @availability_dimensions [
-    {:fastest, :default},
-    {:latency_weighted, :default}
+    {:fastest, :client},
+    {:latency_weighted, :client},
+    {:fastest, :system},
+    {:latency_weighted, :system}
   ]
 
   @enforce_keys [:version, :fact, :provider_id, :method, :emitted_at_us]
@@ -92,10 +94,14 @@ defmodule Lasso.RPC.AttemptProjection do
   defp apply_control(event, barrier) do
     identity = identity(event.fact)
     generation = ConfigStore.route_generation()
+    workload = Workload.decode(identity.workload_key)
 
     cond do
       identity.route_generation != generation ->
         record_stale(identity, generation, event.emitted_at_us)
+        :stale
+
+      workload == :unknown ->
         :stale
 
       match?(%AttemptTerminal.PredispatchFailure{}, event.fact) ->
@@ -216,14 +222,29 @@ defmodule Lasso.RPC.AttemptProjection do
   @spec route_state(scope_state(), binary(), :http | :ws, binary()) :: map() | nil
   def route_state(scope, instance_id, transport, workload_key \\ @default_workload)
       when is_binary(instance_id) and transport in [:http, :ws] and is_binary(workload_key) do
+    with row when not is_nil(row) <- route_record(scope, instance_id, transport),
+         observed_at_us when is_integer(observed_at_us) <-
+           partition_observed_at(row, Workload.decode(workload_key)),
+         true <- visible_after_floor?(scope, observed_at_us) do
+      partition_state(row, Workload.decode(workload_key))
+    else
+      _other -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc false
+  @spec route_record(scope_state(), binary(), :http | :ws) :: map() | nil
+  def route_record(scope, instance_id, transport)
+      when is_binary(instance_id) and transport in [:http, :ws] do
     key =
       {:routing_control, scope.profile, scope.chain_id, BoundedIdentifier.encode(instance_id),
-       transport, BoundedIdentifier.encode(workload_key)}
+       transport, @default_workload}
 
     case :ets.lookup(:lasso_instance_state, key) do
-      [{^key, %{generation: generation, observed_at_us: observed_at_us} = row}]
-      when generation == scope.generation and is_integer(observed_at_us) ->
-        if visible_after_floor?(scope, observed_at_us), do: row
+      [{^key, %{generation: generation} = row}] when generation == scope.generation ->
+        visible_route_record(scope, row)
 
       _other ->
         nil
@@ -235,14 +256,22 @@ defmodule Lasso.RPC.AttemptProjection do
   @spec batch_summaries(binary(), [Channel.t() | map()], pos_integer(), atom()) :: map()
   def batch_summaries(profile, channels, chain_id, workload_key) do
     scope = scope_state(profile, chain_id)
-    workload = workload_key |> Atom.to_string() |> BoundedIdentifier.encode()
+    workload_key = normalize_workload(workload_key)
     now_us = System.monotonic_time(:microsecond)
 
     Map.new(channels, fn channel ->
       key = {channel.instance_id, channel.transport}
-      row = route_state(scope, channel.instance_id, channel.transport, workload)
+      row = route_record(scope, channel.instance_id, channel.transport)
 
-      {key, summary(row, channel.instance_id, channel.transport, chain_id, workload_key, now_us)}
+      {key,
+       summary_for_workload(
+         row,
+         channel.instance_id,
+         channel.transport,
+         chain_id,
+         workload_key,
+         now_us
+       )}
     end)
   end
 
@@ -252,7 +281,7 @@ defmodule Lasso.RPC.AttemptProjection do
   def summarize_route(row, instance_id, transport, chain_id, workload_key)
       when is_binary(instance_id) and transport in [:http, :ws] and is_integer(chain_id) and
              chain_id > 0 and is_atom(workload_key) do
-    summary(
+    summary_for_workload(
       row,
       instance_id,
       transport,
@@ -318,7 +347,7 @@ defmodule Lasso.RPC.AttemptProjection do
   def record_availability_degradation(profile, chain_id, strategy, workload_key)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_atom(strategy) and
              is_atom(workload_key) do
-    dimension = {strategy, workload_key}
+    dimension = {strategy, normalize_workload(workload_key)}
 
     if dimension in @availability_dimensions do
       generation = ConfigStore.route_generation()
@@ -340,7 +369,7 @@ defmodule Lasso.RPC.AttemptProjection do
           non_neg_integer()
   def availability_degradation_count(profile, chain_id, strategy, workload_key) do
     scope = scope_state(profile, chain_id)
-    Map.get(scope.availability_degradations, {strategy, workload_key}, 0)
+    Map.get(scope.availability_degradations, {strategy, normalize_workload(workload_key)}, 0)
   end
 
   @doc false
@@ -370,7 +399,7 @@ defmodule Lasso.RPC.AttemptProjection do
        chain_id: identity.chain_id,
        provider_id: event.provider_id,
        transport: identity.transport,
-       workload_key: :default,
+       workload_key: Workload.decode(identity.workload_key),
        observed_at_ms: div(event.emitted_at_us, 1_000),
        outcome: fields.outcome,
        elapsed_io_ms: Map.get(fields, :elapsed_io_ms),
@@ -397,7 +426,8 @@ defmodule Lasso.RPC.AttemptProjection do
   defp do_update_route(key, generation, event, delta, retries, barrier) do
     case :ets.lookup(:lasso_instance_state, key) do
       [{^key, %{generation: ^generation} = current}] ->
-        updated = apply_delta(current, event, delta)
+        workload = event.fact |> identity() |> Map.fetch!(:workload_key) |> Workload.decode()
+        updated = apply_delta(current, event, delta, workload)
         await_control_barrier(barrier)
 
         case replace_exact(key, current, updated) do
@@ -438,7 +468,7 @@ defmodule Lasso.RPC.AttemptProjection do
     end
   end
 
-  defp apply_delta(current, event, delta) do
+  defp apply_delta(current, event, delta, :client) do
     delta = Map.put(delta, :observed_at_us, event.emitted_at_us)
 
     current
@@ -452,6 +482,44 @@ defmodule Lasso.RPC.AttemptProjection do
     |> apply_aggregate(delta)
     |> apply_latest_state(event.emitted_at_us, delta)
   end
+
+  defp apply_delta(current, event, delta, :system) do
+    delta = Map.put(delta, :observed_at_us, event.emitted_at_us)
+
+    system =
+      current.system
+      |> Map.put(:observed_at_us, max_floor(current.system.observed_at_us, event.emitted_at_us))
+      |> Map.put(
+        :oldest_observed_at_us,
+        min_observation(current.system.oldest_observed_at_us, event.emitted_at_us)
+      )
+      |> Map.put(:comparable_attempts, increment(current.system.comparable_attempts))
+      |> apply_aggregate(delta)
+      |> apply_latest_state(event.emitted_at_us, delta)
+
+    current
+    |> Map.put(:revision, increment(current.revision))
+    |> Map.put(:system, system)
+    |> apply_shared_admission(delta)
+  end
+
+  defp apply_delta(current, _event, _delta, _workload), do: current
+
+  defp apply_shared_admission(row, %{kind: :rate_limit, retry_after_ms: retry_after_ms} = delta) do
+    observed_at_us = Map.fetch!(delta, :observed_at_us)
+    expiry_ms = div(observed_at_us, 1_000) + retry_after_ms
+    replace_expiry? = expiry_ms >= row.rate_limit_expiry_ms
+
+    %{
+      row
+      | rate_limit_expiry_ms: max(row.rate_limit_expiry_ms, expiry_ms),
+        rate_limit_retry_after_ms:
+          if(replace_expiry?, do: retry_after_ms, else: row.rate_limit_retry_after_ms),
+        rate_limit_observed_at_us: max_floor(row.rate_limit_observed_at_us, observed_at_us)
+    }
+  end
+
+  defp apply_shared_admission(row, _delta), do: row
 
   defp apply_aggregate(row, %{kind: :success, latency_ms: latency_ms}) do
     successes = increment(row.usable_successes)
@@ -694,7 +762,7 @@ defmodule Lasso.RPC.AttemptProjection do
     case :ets.lookup(:lasso_instance_state, key) do
       [{^key, %{generation: ^generation} = current}] ->
         counts = Map.fetch!(current, :availability_degradations)
-        updated_counts = Map.update!(counts, dimension, &increment/1)
+        updated_counts = Map.update(counts, dimension, 1, &increment/1)
         updated = %{current | availability_degradations: updated_counts}
 
         case replace_exact(key, current, updated) do
@@ -734,8 +802,15 @@ defmodule Lasso.RPC.AttemptProjection do
 
   defp publish_route(key, generation) do
     case :ets.lookup(:lasso_instance_state, key) do
-      [{^key, %{generation: ^generation}}] ->
-        :ok
+      [{^key, %{generation: ^generation} = current}] ->
+        if Map.has_key?(current, :system) do
+          :ok
+        else
+          replacement = Map.put(current, :system, default_partition())
+
+          if replace_exact(key, current, replacement) == 0,
+            do: publish_route(key, generation)
+        end
 
       [{^key, current}] ->
         if replace_exact(key, current, default_route(generation)) == 0,
@@ -840,9 +915,18 @@ defmodule Lasso.RPC.AttemptProjection do
   end
 
   defp default_route(generation) do
-    %{
+    Map.merge(default_partition(), %{
       generation: generation,
       revision: 0,
+      stale_drops: 0,
+      missing_drops: 0,
+      contention_drops: 0,
+      system: default_partition()
+    })
+  end
+
+  defp default_partition do
+    %{
       observed_at_us: nil,
       oldest_observed_at_us: nil,
       state_observed_at_us: nil,
@@ -858,10 +942,7 @@ defmodule Lasso.RPC.AttemptProjection do
       total_failures: 0,
       total_rate_limits: 0,
       successful_mean_latency_ms: nil,
-      successful_p95_latency_ms: nil,
-      stale_drops: 0,
-      missing_drops: 0,
-      contention_drops: 0
+      successful_p95_latency_ms: nil
     }
   end
 
@@ -887,8 +968,10 @@ defmodule Lasso.RPC.AttemptProjection do
 
   defp route_key(identity) do
     {:routing_control, identity.profile, identity.chain_id, identity.upstream_instance_id,
-     identity.transport, identity.workload_key}
+     identity.transport, @default_workload}
   end
+
+  defp normalize_workload(workload), do: Workload.normalize(workload)
 
   defp replace_exact(key, current, updated) do
     :ets.select_replace(
@@ -903,7 +986,85 @@ defmodule Lasso.RPC.AttemptProjection do
   defp visible_after_floor?(%{recovery_floor_us: floor_us}, observed_at_us),
     do: observed_at_us > floor_us
 
+  defp visible_route_record(%{recovery_floor_us: nil}, row), do: row
+
+  defp visible_route_record(%{recovery_floor_us: floor_us}, row) do
+    visible =
+      row
+      |> maybe_clear_partition(:client, floor_us)
+      |> maybe_clear_partition(:system, floor_us)
+
+    preserve_shared_rate_limit(visible, row, floor_us)
+  end
+
+  defp maybe_clear_partition(row, workload, floor_us) do
+    observed_at_us = partition_observed_at(row, workload)
+
+    if is_integer(observed_at_us) and observed_at_us > floor_us do
+      row
+    else
+      case workload do
+        :client -> Map.merge(row, default_partition())
+        :system -> Map.put(row, :system, default_partition())
+      end
+    end
+  end
+
+  defp preserve_shared_rate_limit(visible, original, floor_us) do
+    if is_integer(original.rate_limit_observed_at_us) and
+         original.rate_limit_observed_at_us > floor_us do
+      %{
+        visible
+        | rate_limit_expiry_ms: original.rate_limit_expiry_ms,
+          rate_limit_retry_after_ms: original.rate_limit_retry_after_ms,
+          rate_limit_observed_at_us: original.rate_limit_observed_at_us
+      }
+    else
+      %{
+        visible
+        | rate_limit_expiry_ms: 0,
+          rate_limit_retry_after_ms: nil,
+          rate_limit_observed_at_us: nil
+      }
+    end
+  end
+
+  defp partition_observed_at(nil, _workload), do: nil
+  defp partition_observed_at(row, :system), do: row.system.observed_at_us
+  defp partition_observed_at(row, _workload), do: row.observed_at_us
+
+  defp partition_state(nil, _workload), do: nil
+  defp partition_state(row, :system), do: Map.put(row.system, :generation, row.generation)
+  defp partition_state(row, _workload), do: row
+
+  defp summary_for_workload(row, instance_id, transport, chain_id, :system, now_us) do
+    row
+    |> partition_state(:system)
+    |> summary(instance_id, transport, chain_id, :system, now_us)
+  end
+
+  defp summary_for_workload(row, instance_id, transport, chain_id, _workload, now_us) do
+    primary = summary(row, instance_id, transport, chain_id, :client, now_us)
+
+    prior =
+      row
+      |> partition_state(:system)
+      |> summary(instance_id, transport, chain_id, :system, now_us)
+
+    attach_system_prior(primary, prior)
+  end
+
   defp summary(nil, _instance_id, _transport, _chain_id, _workload_key, _now_us), do: nil
+
+  defp summary(
+         %{observed_at_us: nil},
+         _instance_id,
+         _transport,
+         _chain_id,
+         _workload_key,
+         _now_us
+       ),
+       do: nil
 
   defp summary(row, instance_id, transport, chain_id, workload_key, now_us) do
     state =
@@ -926,10 +1087,62 @@ defmodule Lasso.RPC.AttemptProjection do
       successful_p95_latency_ms: row.successful_p95_latency_ms,
       last_observed_at_ms: div(row.observed_at_us, 1_000),
       oldest_observed_at_ms: div(row.oldest_observed_at_us, 1_000),
-      support_source: :request_terminal,
+      support_source: workload_support_source(workload_key),
       generation: row.generation
     }
   end
+
+  defp attach_system_prior(nil, nil), do: nil
+  defp attach_system_prior(nil, %Summary{state: :stale}), do: nil
+
+  defp attach_system_prior(nil, %Summary{} = prior) do
+    %{
+      prior
+      | workload_key: :client,
+        state: :unqualified,
+        comparable_attempts: 0,
+        usable_successes: 0,
+        support_source: :system_prior
+    }
+  end
+
+  defp attach_system_prior(%Summary{state: :qualified} = primary, _prior), do: primary
+
+  defp attach_system_prior(%Summary{state: :stale} = primary, prior) do
+    attach_fresh_prior(
+      %{primary | successful_mean_latency_ms: nil, successful_p95_latency_ms: nil},
+      prior
+    )
+  end
+
+  defp attach_system_prior(%Summary{} = primary, nil), do: primary
+  defp attach_system_prior(%Summary{} = primary, %Summary{state: :stale}), do: primary
+
+  defp attach_system_prior(%Summary{} = primary, %Summary{} = prior),
+    do: attach_fresh_prior(primary, prior)
+
+  defp attach_fresh_prior(%Summary{} = primary, nil), do: primary
+  defp attach_fresh_prior(%Summary{} = primary, %Summary{state: :stale}), do: primary
+
+  defp attach_fresh_prior(%Summary{} = primary, %Summary{} = prior) do
+    if is_number(primary.successful_mean_latency_ms) do
+      primary
+    else
+      %{
+        primary
+        | state: if(primary.state == :stale, do: :unqualified, else: primary.state),
+          successful_mean_latency_ms: prior.successful_mean_latency_ms,
+          successful_p95_latency_ms: prior.successful_p95_latency_ms,
+          last_observed_at_ms: prior.last_observed_at_ms,
+          oldest_observed_at_ms: prior.oldest_observed_at_ms,
+          support_source: :system_prior
+      }
+    end
+  end
+
+  defp workload_support_source(:client), do: :client_attempt
+  defp workload_support_source(:system), do: :system_attempt
+  defp workload_support_source(_workload), do: :request_terminal
 
   defp routing_evidence_stale?(observed_at_us, now_us),
     do: now_us - observed_at_us >= @routing_evidence_max_age_us

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -46,6 +46,7 @@ defmodule Lasso.RPC.RequestPipeline do
 
   alias Lasso.RPC.Providers.AdapterFilter
   alias Lasso.RPC.RequestOptions
+  alias Lasso.RPC.RoutingEvidence.Workload
 
   # Type definitions
   @type chain_id :: pos_integer()
@@ -261,7 +262,8 @@ defmodule Lasso.RPC.RequestPipeline do
         strategy: opts.strategy,
         transport: opts.transport || :both,
         limit: @max_channel_candidates,
-        params: params
+        params: params,
+        request_origin: opts.request_origin
       )
     end
   end
@@ -278,6 +280,7 @@ defmodule Lasso.RPC.RequestPipeline do
             strategy: opts.strategy,
             transport: :both,
             exclude: [provider_id],
+            request_origin: opts.request_origin,
             limit: @max_channel_candidates,
             params: params
           )
@@ -648,7 +651,7 @@ defmodule Lasso.RPC.RequestPipeline do
       circuit_epoch: receipt.epoch,
       execution_safety: envelope.execution_safety,
       routing_intent: Atom.to_string(ctx.opts.strategy),
-      workload_key: "default",
+      workload_key: origin_workload_key(ctx),
       request_budget_ms: envelope.original_timeout_ms,
       candidate_admission_count: envelope.candidate_admission_count,
       dispatch_count: envelope.dispatch_count
@@ -1099,7 +1102,7 @@ defmodule Lasso.RPC.RequestPipeline do
       chain_id: ctx.chain_id,
       execution_safety: envelope.execution_safety,
       routing_intent: Atom.to_string(ctx.opts.strategy),
-      workload_key: "default",
+      workload_key: request_workload_key(ctx),
       elapsed_us: max(System.monotonic_time(:microsecond) - envelope.started_at_us, 0),
       candidate_admission_count: envelope.candidate_admission_count,
       dispatch_count: envelope.dispatch_count,
@@ -1116,6 +1119,19 @@ defmodule Lasso.RPC.RequestPipeline do
        do: reason
 
   defp final_exhaustion_reason(_ctx), do: :providers_exhausted
+
+  defp request_workload_key(%RequestContext{public_response_attempt: fact})
+       when not is_nil(fact) do
+    fact.identity.workload_key
+  end
+
+  defp request_workload_key(%RequestContext{terminal_attempt_fact: fact}) when not is_nil(fact),
+    do: fact.identity.workload_key
+
+  defp request_workload_key(ctx), do: origin_workload_key(ctx)
+
+  defp origin_workload_key(ctx),
+    do: Workload.encode(Workload.for_origin(ctx.opts.request_origin))
 
   defp release_execution_payloads(ctx) do
     opts = bounded_return_options(ctx.opts)

--- a/lib/lasso/core/routing_evidence/workload.ex
+++ b/lib/lasso/core/routing_evidence/workload.ex
@@ -1,0 +1,30 @@
+defmodule Lasso.RPC.RoutingEvidence.Workload do
+  @moduledoc """
+  Fixed routing-evidence partitions for client and system request traffic.
+
+  The finite set keeps route-state cardinality bounded. System evidence may seed cold-start
+  ordering, but only client evidence can qualify adaptive client routing.
+  """
+
+  @type t :: :client | :system
+
+  @partitions [:client, :system]
+
+  @spec for_origin(:client | :system) :: t()
+  def for_origin(:client), do: :client
+  def for_origin(:system), do: :system
+
+  @spec normalize(term()) :: t()
+  def normalize(:system), do: :system
+  def normalize("system"), do: :system
+  def normalize(_workload), do: :client
+
+  @spec encode(t()) :: binary()
+  def encode(workload) when workload in @partitions, do: Atom.to_string(workload)
+
+  @spec decode(binary()) :: t() | :unknown
+  def decode("client"), do: :client
+  def decode("default"), do: :client
+  def decode("system"), do: :system
+  def decode(_workload), do: :unknown
+end

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -60,7 +60,8 @@ defmodule Lasso.RPC.Selection do
       exclude: Keyword.get(opts, :exclude, []),
       include_half_open: Keyword.get(opts, :include_half_open, false),
       timeout: Keyword.get(opts, :timeout, 30_000),
-      requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false)
+      requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false),
+      request_origin: Keyword.get(opts, :request_origin, :client)
     }
 
     select_provider_from_plan(profile, chain_id, method, params, selection_opts)
@@ -87,7 +88,8 @@ defmodule Lasso.RPC.Selection do
         selection_opts.exclude,
         selection_opts.protocol,
         include_half_open: selection_opts.include_half_open,
-        requires_subscribe_new_heads: selection_opts.requires_subscribe_new_heads
+        requires_subscribe_new_heads: selection_opts.requires_subscribe_new_heads,
+        workload_key: workload_for_origin(selection_opts.request_origin)
       )
 
     candidates = CandidateListing.list_routing_candidates_from_plan(plan, filters)
@@ -106,6 +108,7 @@ defmodule Lasso.RPC.Selection do
             method,
             selection_opts.timeout
           )
+          |> Map.put(:workload_key, workload_for_origin(selection_opts.request_origin))
           |> enrich_strategy_context(candidates, plan)
 
         channels =
@@ -188,6 +191,7 @@ defmodule Lasso.RPC.Selection do
     limit = Keyword.get(opts, :limit, 1000)
     include_half_open = Keyword.get(opts, :include_half_open, true)
     params = Keyword.get(opts, :params, [])
+    workload_key = workload_for_origin(Keyword.get(opts, :request_origin, :client))
 
     pool_protocol =
       case transport do
@@ -214,7 +218,8 @@ defmodule Lasso.RPC.Selection do
         max_lag_blocks: plan.max_lag_blocks,
         min_block: requirements.requested_block,
         requires_archival: requirements.requires_archival,
-        requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false)
+        requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false),
+        workload_key: workload_key
       )
 
     provider_candidates = CandidateListing.list_routing_candidates_from_plan(plan, pool_filters)
@@ -248,7 +253,8 @@ defmodule Lasso.RPC.Selection do
         strategy,
         method,
         plan,
-        Keyword.get(opts, :timeout, 30_000)
+        Keyword.get(opts, :timeout, 30_000),
+        workload_key
       )
 
     selected = final_channels |> Enum.take(limit)
@@ -258,13 +264,21 @@ defmodule Lasso.RPC.Selection do
       else: []
   end
 
-  defp order_capable_channels([channel], candidates, strategy, _method, plan, _timeout)
+  defp order_capable_channels(
+         [channel],
+         candidates,
+         strategy,
+         _method,
+         plan,
+         _timeout,
+         workload_key
+       )
        when strategy in [:fastest, :priority, :load_balanced, :latency_weighted] do
-    maybe_record_single_channel_degradation(channel, candidates, strategy, plan)
+    maybe_record_single_channel_degradation(channel, candidates, strategy, plan, workload_key)
     [channel]
   end
 
-  defp order_capable_channels(channels, candidates, strategy, method, plan, timeout) do
+  defp order_capable_channels(channels, candidates, strategy, method, plan, timeout, workload_key) do
     circuit_state_map =
       candidates
       |> Enum.flat_map(fn %{id: provider_id} = candidate ->
@@ -286,6 +300,7 @@ defmodule Lasso.RPC.Selection do
 
     prepared_ctx =
       strategy_mod.prepare_context(plan.profile, plan.chain_id, method, timeout)
+      |> Map.put(:workload_key, workload_key)
       |> enrich_strategy_context(candidates, plan)
 
     ordered_channels =
@@ -305,18 +320,30 @@ defmodule Lasso.RPC.Selection do
     tier_channels(ordered_channels, circuit_state_map, rate_limit_map)
   end
 
-  defp maybe_record_single_channel_degradation(_channel, _candidates, strategy, _plan)
+  defp maybe_record_single_channel_degradation(
+         _channel,
+         _candidates,
+         strategy,
+         _plan,
+         _workload_key
+       )
        when strategy in [:priority, :load_balanced],
        do: :ok
 
-  defp maybe_record_single_channel_degradation(channel, candidates, strategy, plan) do
+  defp maybe_record_single_channel_degradation(
+         channel,
+         candidates,
+         strategy,
+         plan,
+         workload_key
+       ) do
     if Enum.any?(candidates, & &1.learned_feedback_degraded?) do
       :ok
     else
       summary =
         candidates
         |> Enum.find(&(&1.instance_id == channel.instance_id))
-        |> single_channel_summary(channel, plan)
+        |> single_channel_summary(channel, plan, workload_key)
 
       if RoutingEvidence.qualified?(summary) do
         :ok
@@ -325,23 +352,22 @@ defmodule Lasso.RPC.Selection do
           plan.profile,
           strategy,
           plan.chain_id,
-          :default,
+          workload_key,
           1
         )
       end
     end
   end
 
-  defp single_channel_summary(nil, _channel, _plan), do: nil
+  defp single_channel_summary(nil, _channel, _plan, _workload_key), do: nil
 
-  defp single_channel_summary(candidate, channel, plan) do
-    candidate.routing_states
-    |> Map.get(channel.transport)
-    |> AttemptProjection.summarize_route(
+  defp single_channel_summary(candidate, channel, plan, workload_key) do
+    AttemptProjection.summarize_route(
+      Map.get(candidate.routing_states, channel.transport),
       candidate.instance_id,
       channel.transport,
       plan.chain_id,
-      :default
+      workload_key
     )
   end
 
@@ -477,6 +503,7 @@ defmodule Lasso.RPC.Selection do
     consensus_height = get_consensus_height(plan.chain_id)
     include_half_open = Keyword.get(opts, :include_half_open, false)
     requires_subscribe_new_heads = Keyword.get(opts, :requires_subscribe_new_heads, false)
+    workload_key = Keyword.get(opts, :workload_key, :client)
 
     requirements =
       RequestAnalysis.analyze(
@@ -493,7 +520,8 @@ defmodule Lasso.RPC.Selection do
       max_lag_blocks: plan.max_lag_blocks,
       min_block: requirements.requested_block,
       requires_archival: requirements.requires_archival,
-      requires_subscribe_new_heads: requires_subscribe_new_heads
+      requires_subscribe_new_heads: requires_subscribe_new_heads,
+      workload_key: workload_key
     )
   end
 
@@ -518,4 +546,7 @@ defmodule Lasso.RPC.Selection do
 
     %{ctx | routing_summaries: summaries, provider_priorities: plan.provider_priorities}
   end
+
+  defp workload_for_origin(:system), do: :system
+  defp workload_for_origin(_origin), do: :client
 end

--- a/lib/lasso/core/selection/selection_filters.ex
+++ b/lib/lasso/core/selection/selection_filters.ex
@@ -9,6 +9,8 @@ defmodule Lasso.RPC.SelectionFilters do
   @type protocol :: :http | :ws | :both | nil
   @type circuit_state_filter :: :closed | :half_open | :open
 
+  alias Lasso.RPC.RoutingEvidence.Workload
+
   @type t :: %__MODULE__{
           protocol: protocol(),
           exclude: [String.t()],
@@ -17,7 +19,8 @@ defmodule Lasso.RPC.SelectionFilters do
           max_lag_blocks: non_neg_integer() | nil,
           min_block: non_neg_integer() | nil,
           requires_archival: boolean(),
-          requires_subscribe_new_heads: boolean()
+          requires_subscribe_new_heads: boolean(),
+          workload_key: :client | :system
         }
 
   defstruct protocol: nil,
@@ -27,7 +30,8 @@ defmodule Lasso.RPC.SelectionFilters do
             max_lag_blocks: nil,
             min_block: nil,
             requires_archival: false,
-            requires_subscribe_new_heads: false
+            requires_subscribe_new_heads: false,
+            workload_key: :client
 
   @doc """
   Creates a new SelectionFilters struct with validated defaults.
@@ -62,7 +66,8 @@ defmodule Lasso.RPC.SelectionFilters do
       max_lag_blocks: Keyword.get(opts, :max_lag_blocks),
       min_block: Keyword.get(opts, :min_block),
       requires_archival: Keyword.get(opts, :requires_archival, false),
-      requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false)
+      requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false),
+      workload_key: Workload.normalize(Keyword.get(opts, :workload_key, :client))
     }
   end
 
@@ -85,7 +90,8 @@ defmodule Lasso.RPC.SelectionFilters do
       requires_subscribe_new_heads:
         to_boolean(
           map[:requires_subscribe_new_heads] || Map.get(map, "requires_subscribe_new_heads")
-        )
+        ),
+      workload_key: Workload.normalize(map[:workload_key] || Map.get(map, "workload_key"))
     }
   end
 
@@ -102,7 +108,8 @@ defmodule Lasso.RPC.SelectionFilters do
       max_lag_blocks: filters.max_lag_blocks,
       min_block: filters.min_block,
       requires_archival: filters.requires_archival,
-      requires_subscribe_new_heads: filters.requires_subscribe_new_heads
+      requires_subscribe_new_heads: filters.requires_subscribe_new_heads,
+      workload_key: filters.workload_key
     }
   end
 

--- a/lib/lasso/core/selection/strategies/fastest.ex
+++ b/lib/lasso/core/selection/strategies/fastest.ex
@@ -24,9 +24,7 @@ defmodule Lasso.RPC.Strategies.Fastest do
 
     {qualified, remaining} =
       Enum.split_with(channels, fn channel ->
-        summaries
-        |> RoutingEvidence.summary_for_channel(channel)
-        |> RoutingEvidence.qualified?()
+        summaries |> RoutingEvidence.summary_for_channel(channel) |> RoutingEvidence.qualified?()
       end)
 
     case qualified do
@@ -39,12 +37,26 @@ defmodule Lasso.RPC.Strategies.Fastest do
           length(channels)
         )
 
-        deterministic_order(channels)
+        Enum.sort_by(channels, &prior_key(&1, summaries))
 
       _ ->
-        Enum.sort_by(qualified, &ranking_key(&1, summaries)) ++ deterministic_order(remaining)
+        Enum.sort_by(qualified, &ranking_key(&1, summaries)) ++
+          Enum.sort_by(remaining, &prior_key(&1, summaries))
     end
   end
+
+  defp prior_key(channel, summaries) do
+    summary = RoutingEvidence.summary_for_channel(summaries, channel)
+
+    {
+      prior_latency(summary),
+      channel.provider_id,
+      channel.transport
+    }
+  end
+
+  defp prior_latency(%{state: :stale}), do: :infinity
+  defp prior_latency(summary), do: (summary && summary.successful_mean_latency_ms) || :infinity
 
   defp ranking_key(channel, summaries) do
     summary = RoutingEvidence.summary_for_channel(summaries, channel)
@@ -55,9 +67,5 @@ defmodule Lasso.RPC.Strategies.Fastest do
       channel.provider_id,
       channel.transport
     }
-  end
-
-  defp deterministic_order(channels) do
-    Enum.sort_by(channels, &{&1.provider_id, &1.transport})
   end
 end

--- a/lib/lasso/core/selection/strategies/latency_weighted.ex
+++ b/lib/lasso/core/selection/strategies/latency_weighted.ex
@@ -25,9 +25,7 @@ defmodule Lasso.RPC.Strategies.LatencyWeighted do
 
     {qualified, remaining} =
       Enum.split_with(channels, fn channel ->
-        summaries
-        |> RoutingEvidence.summary_for_channel(channel)
-        |> RoutingEvidence.qualified?()
+        summaries |> RoutingEvidence.summary_for_channel(channel) |> RoutingEvidence.qualified?()
       end)
 
     case qualified do
@@ -40,22 +38,41 @@ defmodule Lasso.RPC.Strategies.LatencyWeighted do
           length(channels)
         )
 
-        Enum.shuffle(channels)
+        weighted_available(channels, summaries)
 
       _ ->
-        latencies =
-          Enum.map(qualified, fn channel ->
-            RoutingEvidence.summary_for_channel(summaries, channel).successful_mean_latency_ms
-          end)
-
-        beta = Application.get_env(:lasso, :lw_beta, @default_beta)
-
-        qualified
-        |> Enum.zip(relative_weights(latencies, beta))
-        |> weighted_permutation()
-        |> Kernel.++(Enum.shuffle(remaining))
+        weighted_available(qualified, summaries) ++ weighted_available(remaining, summaries)
     end
   end
+
+  defp weighted_available([], _summaries), do: []
+
+  defp weighted_available(channels, summaries) do
+    {measured, unmeasured} =
+      Enum.split_with(channels, fn channel ->
+        summary = RoutingEvidence.summary_for_channel(summaries, channel)
+        summary && summary.state != :stale && is_number(summary.successful_mean_latency_ms)
+      end)
+
+    weighted =
+      case measured do
+        [] ->
+          []
+
+        _ ->
+          latencies = Enum.map(measured, &mean_latency(&1, summaries))
+          beta = Application.get_env(:lasso, :lw_beta, @default_beta)
+
+          measured
+          |> Enum.zip(relative_weights(latencies, beta))
+          |> weighted_permutation()
+      end
+
+    weighted ++ Enum.shuffle(unmeasured)
+  end
+
+  defp mean_latency(channel, summaries),
+    do: RoutingEvidence.summary_for_channel(summaries, channel).successful_mean_latency_ms
 
   @doc false
   @spec relative_weights([number()], number()) :: [float()]

--- a/lib/lasso/core/selection/strategy_context.ex
+++ b/lib/lasso/core/selection/strategy_context.ex
@@ -23,7 +23,7 @@ defmodule Lasso.RPC.StrategyContext do
     :cold_start_baseline,
     :routing_summaries,
     :provider_priorities,
-    workload_key: :default
+    workload_key: :client
   ]
 
   @type t :: %__MODULE__{

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -22,6 +22,7 @@ defmodule Lasso.Providers.CandidateListing do
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.{Catalog, InstanceState, LagCalculation}
   alias Lasso.RPC.{AttemptProjection, RoutingPlan, SelectionFilters}
+  alias Lasso.RPC.RoutingEvidence.Workload
 
   @doc """
   Lists provider candidates for a (profile, chain_id) pair, filtered by selection criteria.
@@ -110,12 +111,13 @@ defmodule Lasso.Providers.CandidateListing do
 
   defp do_list_candidates(%RoutingPlan{} = plan, filters, mode) do
     protocol = Map.get(filters, :protocol)
+    workload_key = filters |> Map.get(:workload_key, :client) |> Workload.normalize()
     include_half_open = Map.get(filters, :include_half_open, false)
     learned_scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
 
     candidates =
       plan.providers
-      |> Enum.map(&build_candidate(&1, learned_scope, plan, protocol, mode))
+      |> Enum.map(&build_candidate(&1, learned_scope, plan, protocol, workload_key, mode))
       |> Enum.filter(fn c ->
         transport_available?(c, protocol) and
           circuit_breaker_ready?(c, protocol, include_half_open) and
@@ -168,13 +170,13 @@ defmodule Lasso.Providers.CandidateListing do
     end
   end
 
-  defp build_candidate(provider, learned_scope, plan, protocol, mode) do
+  defp build_candidate(provider, learned_scope, plan, protocol, workload_key, mode) do
     instance_id = provider.instance_id
     transports = live_transports(provider, protocol, plan.profile, plan.chain_id)
 
     include_learned? = not learned_scope.degraded?
-    http_routing = route_state(learned_scope, instance_id, :http, transports)
-    ws_routing = route_state(learned_scope, instance_id, :ws, transports)
+    http_routing = route_record(learned_scope, instance_id, :http, transports)
+    ws_routing = route_record(learned_scope, instance_id, :ws, transports)
 
     http_cb = circuit_state(instance_id, :http, transports)
     ws_cb = circuit_state(instance_id, :ws, transports)
@@ -189,6 +191,7 @@ defmodule Lasso.Providers.CandidateListing do
       config: provider.config,
       transports: transports,
       routing_states: %{http: http_routing, ws: ws_routing},
+      workload_key: workload_key,
       circuit_state: %{http: http_cb.state, ws: ws_cb.state},
       rate_limited: %{http: http_rl.rate_limited, ws: ws_rl.rate_limited},
       learned_feedback_degraded?: learned_scope.degraded?
@@ -236,9 +239,9 @@ defmodule Lasso.Providers.CandidateListing do
     end)
   end
 
-  defp route_state(scope, instance_id, transport, transports) do
+  defp route_record(scope, instance_id, transport, transports) do
     if transport in transports,
-      do: AttemptProjection.route_state(scope, instance_id, transport),
+      do: AttemptProjection.route_record(scope, instance_id, transport),
       else: nil
   end
 

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -287,6 +287,127 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert row.successful_p95_latency_ms == nil
   end
 
+  test "client and system evidence stay isolated while system latency seeds a client prior" do
+    generation = publish_routes(["projection-instance"])
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+
+    key = route_key("projection-instance")
+    assert [{^key, _row}] = :ets.lookup(:lasso_instance_state, key)
+
+    for stamp <- 100..102 do
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_for(stamp, 20_000, "projection-instance", generation, "system")
+               )
+    end
+
+    client = AttemptProjection.route_state(scope, "projection-instance", :http, "client")
+    system = AttemptProjection.route_state(scope, "projection-instance", :http, "system")
+
+    assert is_nil(client)
+    assert system.usable_successes == 3
+
+    row = AttemptProjection.route_record(scope, "projection-instance", :http)
+
+    prior =
+      AttemptProjection.summarize_route(row, "projection-instance", :http, @chain_id, :client)
+
+    assert prior.state == :unqualified
+    assert prior.support_source == :system_prior
+    assert prior.comparable_attempts == 0
+    assert prior.successful_mean_latency_ms == 20.0
+
+    for stamp <- 200..202 do
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_for(stamp, 80_000, "projection-instance", generation, "client")
+               )
+    end
+
+    client = AttemptProjection.route_state(scope, "projection-instance", :http, "client")
+    system = AttemptProjection.route_state(scope, "projection-instance", :http, "system")
+
+    row = AttemptProjection.route_record(scope, "projection-instance", :http)
+
+    authoritative =
+      AttemptProjection.summarize_route(row, "projection-instance", :http, @chain_id, :client)
+
+    assert authoritative.state == :qualified
+    assert authoritative.support_source == :client_attempt
+    assert authoritative.successful_mean_latency_ms == 80.0
+    assert client.usable_successes == 3
+    assert system.usable_successes == 3
+    assert system.successful_mean_latency_ms == 20.0
+  end
+
+  test "unknown workload keys cannot grow the fixed routing table" do
+    generation = publish_routes(["projection-instance"])
+    before_size = :ets.info(:lasso_instance_state, :size)
+
+    assert :stale =
+             AttemptProjection.apply_control(
+               success_event_for(100, 10_000, "projection-instance", generation, "unknown")
+             )
+
+    assert :ets.info(:lasso_instance_state, :size) == before_size
+  end
+
+  test "system quota updates shared admission without becoming client reliability evidence" do
+    generation = publish_routes(["projection-instance"])
+
+    fact =
+      AttemptTerminal.Response.new(
+        identity("projection-instance", generation, "system"),
+        :application_error,
+        10,
+        error_code: -32_005,
+        error_category: :quota,
+        retry_after_ms: 500
+      )
+
+    event = %{AttemptProjection.new(fact, "provider", "eth_call") | emitted_at_us: 2_000_000}
+    assert :ok = AttemptProjection.apply_control(event)
+
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    row = AttemptProjection.route_record(scope, "projection-instance", :http)
+    system = AttemptProjection.route_state(scope, "projection-instance", :http, "system")
+
+    assert row.total_rate_limits == 0
+    assert row.comparable_attempts == 0
+    assert row.rate_limit_expiry_ms == 2_500
+    assert system.total_rate_limits == 1
+    assert system.comparable_attempts == 1
+  end
+
+  test "stale system evidence cannot seed client ordering" do
+    generation = publish_routes(["projection-instance"])
+    stale_us = System.monotonic_time(:microsecond) - 300_000_010
+
+    for offset <- 0..2 do
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_for(
+                   stale_us + offset,
+                   10_000,
+                   "projection-instance",
+                   generation,
+                   "system"
+                 )
+               )
+    end
+
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    row = AttemptProjection.route_record(scope, "projection-instance", :http)
+
+    refute AttemptProjection.summarize_route(
+             row,
+             "projection-instance",
+             :http,
+             @chain_id,
+             :client
+           )
+  end
+
   test "qualified routing evidence becomes stale after five minutes without an observation" do
     generation = publish_routes(["stale-instance", "fresh-instance"])
     now_us = System.monotonic_time(:microsecond)
@@ -459,7 +580,20 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     %{AttemptProjection.new(fact, "provider", "eth_call") | emitted_at_us: emitted_at_us}
   end
 
-  defp identity(instance_id, generation) do
+  defp success_event_for(emitted_at_us, io_duration_us, instance_id, generation, workload_key) do
+    fact =
+      AttemptTerminal.Response.new(
+        identity(instance_id, generation, workload_key),
+        :success,
+        io_duration_us
+      )
+
+    %{AttemptProjection.new(fact, "provider", "eth_call") | emitted_at_us: emitted_at_us}
+  end
+
+  defp identity(instance_id, generation), do: identity(instance_id, generation, "client")
+
+  defp identity(instance_id, generation, workload_key) do
     AttemptIdentity.new(
       request_id: "projection-request",
       attempt_id: "projection-attempt-#{instance_id}",
@@ -472,16 +606,15 @@ defmodule Lasso.RPC.AttemptProjectionTest do
       circuit_epoch: 1,
       execution_safety: :replay_safe,
       routing_intent: "default",
-      workload_key: "default",
+      workload_key: workload_key,
       request_budget_ms: 100,
       candidate_admission_count: 1,
       dispatch_count: 1
     )
   end
 
-  defp route_key(instance_id) do
-    {:routing_control, @profile, @chain_id, instance_id, :http, "default"}
-  end
+  defp route_key(instance_id),
+    do: {:routing_control, @profile, @chain_id, instance_id, :http, "client"}
 
   defp clear_control_rows do
     :ets.match_delete(:lasso_instance_state, {{:routing_control_scope, @profile, :_}, :_})

--- a/test/lasso/core/request/request_pipeline_test.exs
+++ b/test/lasso/core/request/request_pipeline_test.exs
@@ -299,6 +299,15 @@ defmodule Lasso.RPC.RequestPipelineTest do
                dispatch_count: 2
              } = RequestPipeline.build_request_terminal(:ok, %{"ok" => true}, ctx)
     end
+
+    test "system requests close in the fixed system evidence partition" do
+      ctx = terminal_context(0, 0, nil, :system)
+
+      error = JError.new(-32_000, "No channels", category: :provider_error, retriable?: true)
+
+      assert %RequestTerminal.OrdinaryExhaustion{workload_key: "system"} =
+               RequestPipeline.build_request_terminal(:error, error, ctx)
+    end
   end
 
   describe "execute_via_channels/4 - strategy support" do
@@ -879,11 +888,17 @@ defmodule Lasso.RPC.RequestPipelineTest do
     end
   end
 
-  defp terminal_context(candidate_count, dispatch_count, terminal_reason) do
+  defp terminal_context(
+         candidate_count,
+         dispatch_count,
+         terminal_reason,
+         request_origin \\ :client
+       ) do
     opts = %RequestOptions{
       profile: "public",
       strategy: :load_balanced,
-      timeout_ms: 100
+      timeout_ms: 100,
+      request_origin: request_origin
     }
 
     ctx =
@@ -917,7 +932,7 @@ defmodule Lasso.RPC.RequestPipelineTest do
       circuit_epoch: 1,
       execution_safety: ctx.execution_envelope.execution_safety,
       routing_intent: Atom.to_string(ctx.opts.strategy),
-      workload_key: "default",
+      workload_key: "client",
       request_budget_ms: ctx.execution_envelope.original_timeout_ms,
       candidate_admission_count: candidate_count,
       dispatch_count: dispatch_count

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -91,6 +91,27 @@ defmodule Lasso.Providers.CandidateListingTest do
       assert candidate.routing_states.ws == nil
     end
 
+    test "preprovisions one fixed partitioned routing row per transport" do
+      instance_ids =
+        @profile
+        |> Catalog.get_profile_providers(@chain)
+        |> Enum.map(& &1.instance_id)
+        |> MapSet.new()
+
+      workloads =
+        :ets.match_object(
+          @instance_table,
+          {{:routing_control, @profile, @chain, :_, :http, :_}, :_}
+        )
+        |> Enum.filter(fn {{:routing_control, _, _, instance_id, _, _}, _} ->
+          MapSet.member?(instance_ids, instance_id)
+        end)
+        |> Enum.map(fn {{:routing_control, _, _, _, _, workload}, _} -> workload end)
+        |> MapSet.new()
+
+      assert workloads == MapSet.new(["client"])
+    end
+
     test "returns empty list for unknown profile" do
       assert CandidateListing.list_candidates("nonexistent", @chain, %{}) == []
     end
@@ -358,7 +379,7 @@ defmodule Lasso.Providers.CandidateListingTest do
       event = %{AttemptProjection.new(fact, "p1", "eth_call") | emitted_at_us: 100}
       assert :ok = AttemptProjection.apply_control(event)
 
-      key = {:routing_control, @profile, @chain, instance_id, :http, "default"}
+      key = {:routing_control, @profile, @chain, instance_id, :http, "client"}
       [{^key, before_row}] = :ets.lookup(:lasso_instance_state, key)
       assert before_row.revision == 1
 
@@ -404,7 +425,7 @@ defmodule Lasso.Providers.CandidateListingTest do
       assert scope.degraded?
       assert scope.stale_drops >= 1
 
-      key = {:routing_control, @profile, @chain, instance_id, :http, "default"}
+      key = {:routing_control, @profile, @chain, instance_id, :http, "client"}
       [{^key, row}] = :ets.lookup(:lasso_instance_state, key)
       assert row.comparable_attempts == 0
     end
@@ -637,7 +658,7 @@ defmodule Lasso.Providers.CandidateListingTest do
           circuit_epoch: 1,
           execution_safety: :replay_safe,
           routing_intent: "default",
-          workload_key: "default",
+          workload_key: "client",
           request_budget_ms: 100,
           candidate_admission_count: 1,
           dispatch_count: 1
@@ -737,7 +758,7 @@ defmodule Lasso.Providers.CandidateListingTest do
       circuit_epoch: 1,
       execution_safety: :replay_safe,
       routing_intent: "default",
-      workload_key: "default",
+      workload_key: "client",
       request_budget_ms: 100,
       candidate_admission_count: 1,
       dispatch_count: 1

--- a/test/lasso/rpc/selection_filters_test.exs
+++ b/test/lasso/rpc/selection_filters_test.exs
@@ -13,6 +13,7 @@ defmodule Lasso.RPC.SelectionFiltersTest do
       assert filters.exclude_rate_limited == false
       assert filters.max_lag_blocks == nil
       assert filters.requires_archival == false
+      assert filters.workload_key == :client
     end
 
     test "accepts all filter options" do
@@ -23,7 +24,8 @@ defmodule Lasso.RPC.SelectionFiltersTest do
           include_half_open: true,
           exclude_rate_limited: true,
           max_lag_blocks: 5,
-          requires_archival: true
+          requires_archival: true,
+          workload_key: :system
         )
 
       assert filters.protocol == :http
@@ -32,6 +34,7 @@ defmodule Lasso.RPC.SelectionFiltersTest do
       assert filters.exclude_rate_limited == true
       assert filters.max_lag_blocks == 5
       assert filters.requires_archival == true
+      assert filters.workload_key == :system
     end
 
     test "normalizes protocol strings" do
@@ -67,7 +70,8 @@ defmodule Lasso.RPC.SelectionFiltersTest do
       map = %{
         "protocol" => "http",
         "exclude" => ["p1"],
-        "requires_archival" => true
+        "requires_archival" => true,
+        "workload_key" => "system"
       }
 
       filters = SelectionFilters.from_map(map)
@@ -75,6 +79,7 @@ defmodule Lasso.RPC.SelectionFiltersTest do
       assert filters.protocol == :http
       assert filters.exclude == ["p1"]
       assert filters.requires_archival == true
+      assert filters.workload_key == :system
     end
 
     test "handles missing keys with defaults" do

--- a/test/unit/strategies/evidence_ranking_test.exs
+++ b/test/unit/strategies/evidence_ranking_test.exs
@@ -68,6 +68,42 @@ defmodule Lasso.RPC.Strategies.EvidenceRankingTest do
     assert degradation_count(:fastest) == before_count + 1
   end
 
+  test "system priors order cold routes but never outrank client-qualified evidence" do
+    channels = channels(["slow-client", "fast-prior"])
+
+    prior =
+      summary("fast-prior", :unqualified, 10.0, nil)
+      |> Map.merge(%{comparable_attempts: 0, usable_successes: 0, support_source: :system_prior})
+
+    put_summaries(%{
+      {"slow-client-instance", :http} => summary("slow-client", :qualified, 100.0, nil),
+      {"fast-prior-instance", :http} => prior
+    })
+
+    ctx = Fastest.prepare_context("public", 1, "eth_getBalance", 5_000)
+
+    assert ["slow-client", "fast-prior"] ==
+             channels
+             |> Fastest.rank_channels("eth_getBalance", ctx, "public", 1)
+             |> Enum.map(& &1.provider_id)
+
+    cold_ctx = %{
+      ctx
+      | routing_summaries: %{
+          {"slow-client-instance", :http} => %{
+            summary("slow-client", :unqualified, 80.0, nil)
+            | comparable_attempts: 0
+          },
+          {"fast-prior-instance", :http} => prior
+        }
+    }
+
+    assert ["fast-prior", "slow-client"] ==
+             channels
+             |> Fastest.rank_channels("eth_getBalance", cold_ctx, "public", 1)
+             |> Enum.map(& &1.provider_id)
+  end
+
   test "missing direct control rows preserve live candidates through degradation" do
     channels = channels(["b", "a"])
     ctx = Fastest.prepare_context("public", 1, "eth_getBalance", 5_000)
@@ -154,7 +190,7 @@ defmodule Lasso.RPC.Strategies.EvidenceRankingTest do
       upstream_instance_id: "#{provider_id}-instance",
       chain_id: 1,
       transport: :http,
-      workload_key: :default,
+      workload_key: :client,
       state: state,
       successful_mean_latency_ms: mean,
       successful_p95_latency_ms: p95,
@@ -180,7 +216,7 @@ defmodule Lasso.RPC.Strategies.EvidenceRankingTest do
         :ok
 
       {{instance_id, transport}, %Summary{} = summary} ->
-        key = {:routing_control, "public", 1, instance_id, transport, "default"}
+        key = {:routing_control, "public", 1, instance_id, transport, "client"}
         [{^key, row}] = :ets.lookup(:lasso_instance_state, key)
         observed_at_us = System.monotonic_time(:microsecond)
 
@@ -204,7 +240,7 @@ defmodule Lasso.RPC.Strategies.EvidenceRankingTest do
   end
 
   defp degradation_count(strategy),
-    do: AttemptProjection.availability_degradation_count("public", 1, strategy, :default)
+    do: AttemptProjection.availability_degradation_count("public", 1, strategy, :client)
 
   defp clear_test_control do
     :ets.match_delete(:lasso_instance_state, {{:routing_control_scope, "public", 1}, :_})


### PR DESCRIPTION
## Summary

- partition routing evidence into fixed client and system namespaces inside one preprovisioned route row
- make client evidence authoritative for adaptive qualification while allowing fresh system latency to seed cold fallback ordering
- keep quota admission shared across both origins without mixing system reliability or latency into client aggregates
- propagate the request origin through selection, attempt facts, request terminals, and diagnostics

## Boundedness and performance

- route-row cardinality is unchanged: one row per profile/chain/generation/instance/transport
- request-time updates cannot create rows or dynamic workload keys
- the row grows by about 40 words to hold the fixed system namespace
- fixed `+S 4:4`, 16-candidate diagnostic against `78a30e4`: full qualified selection was about +1.1% reductions; cold selection about +2.4%; observed wall-time medians were effectively flat/noisy
- the discarded two-row prototype was not used because it added a second cold lookup and materially more reductions

## Verification

- `mix test --include integration`: 1,430 tests, 0 failures
- warnings-as-errors compile
- `mix format --check-formatted`
- `mix credo --strict`
- dev `mix dialyzer`
- `git diff --check`
