### PR TITLE
Fence learned rate-limit expiry by observation

### DIFF
--- a/lib/lasso/providers/instance_state.ex
+++ b/lib/lasso/providers/instance_state.ex
@@ -215,8 +215,15 @@ defmodule Lasso.Providers.InstanceState do
 
     direct_expiries =
       case Keyword.get(opts, :routing_state) do
-        %{rate_limit_expiry_ms: expiry} when include_learned? and expiry > now_ms -> [expiry]
-        _other -> []
+        %{
+          rate_limit_expiry_ms: expiry,
+          rate_limit_observed_at_us: observed_at_us
+        }
+        when include_learned? and is_integer(observed_at_us) and expiry > now_ms ->
+          [expiry]
+
+        _other ->
+          []
       end
 
     expiries =

--- a/test/lasso/providers/instance_state_test.exs
+++ b/test/lasso/providers/instance_state_test.exs
@@ -184,6 +184,37 @@ defmodule Lasso.Providers.InstanceStateTest do
              )
   end
 
+  describe "read_rate_limit/3 direct routing state" do
+    test "ignores an expiry without a rate-limit observation" do
+      routing_state = %{
+        rate_limit_expiry_ms: System.monotonic_time(:millisecond) + 10_000,
+        rate_limit_observed_at_us: nil
+      }
+
+      assert %{rate_limited: false, expiry_ms: nil} =
+               InstanceState.read_rate_limit(@instance_id, :http, routing_state: routing_state)
+    end
+
+    test "does not treat the unobserved zero sentinel as a future monotonic expiry" do
+      routing_state = %{rate_limit_expiry_ms: 0, rate_limit_observed_at_us: nil}
+
+      assert %{rate_limited: false, expiry_ms: nil} =
+               InstanceState.read_rate_limit(@instance_id, :http, routing_state: routing_state)
+    end
+
+    test "retains an observed future monotonic expiry regardless of epoch origin" do
+      expiry_ms = System.monotonic_time(:millisecond) + 10_000
+
+      routing_state = %{
+        rate_limit_expiry_ms: expiry_ms,
+        rate_limit_observed_at_us: System.monotonic_time(:microsecond)
+      }
+
+      assert %{rate_limited: true, expiry_ms: ^expiry_ms} =
+               InstanceState.read_rate_limit(@instance_id, :http, routing_state: routing_state)
+    end
+  end
+
   test "clear removes every application-owned breaker row for the instance" do
     id = {@instance_id, :http}
     {:ok, pid} = CircuitBreaker.start_link({id, %{control_ring_capacity: 4}})


### PR DESCRIPTION
## Summary
- require a real learned rate-limit observation before applying a direct routing expiry
- prevent the zero sentinel from being treated as a future monotonic timestamp on negative-origin VMs
- cover unobserved, sentinel, and observed-future states

## Verification
- `MIX_ENV=test mix test` (1,434 tests)
- `mix credo --strict`
- `mix dialyzer`
- warnings-as-errors compile
- `git diff --check`