### PR TITLE
Avoid revalidating request diagnostics

### DIFF
--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -985,8 +985,8 @@ defmodule Lasso.RPC.RequestPipeline do
        when status in [:ok, :error] do
     request_terminal = build_request_terminal(status, value, ctx)
 
-    request_projection =
-      RequestProjection.new(
+    _enqueue_result =
+      RequestProjection.new_and_enqueue(
         request_terminal,
         ctx.method,
         request_projection_route(ctx),
@@ -994,7 +994,6 @@ defmodule Lasso.RPC.RequestPipeline do
         ctx.opts.request_origin
       )
 
-    _enqueue_result = RequestProjection.enqueue(request_projection)
     {status, value, release_execution_payloads(ctx)}
   end
 

--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -62,18 +62,46 @@ defmodule Lasso.RPC.RequestProjection do
 
   @spec enqueue(t(), atom()) :: term()
   def enqueue(%__MODULE__{} = event, dispatcher \\ @dispatcher) when is_atom(dispatcher) do
+    enqueue_lazy(event, dispatcher, fn -> encode(event) end)
+  end
+
+  @doc false
+  @spec new_and_enqueue(
+          RequestTerminal.t(),
+          binary(),
+          route_identity() | nil,
+          non_neg_integer(),
+          :client | :system,
+          atom()
+        ) :: term()
+  def new_and_enqueue(
+        fact,
+        method,
+        route_identity,
+        failover_count,
+        request_origin \\ :client,
+        dispatcher \\ @dispatcher
+      )
+      when is_atom(dispatcher) do
+    event = new(fact, method, route_identity, failover_count, request_origin)
+    enqueue_lazy(event, dispatcher, fn -> encode_validated(event) end)
+  end
+
+  defp enqueue_lazy(event, dispatcher, encoder) do
     ProjectionDispatcher.enqueue_lazy(
       dispatcher,
       :diagnostics,
       {Map.fetch!(event.fact, :profile), Map.fetch!(event.fact, :chain_id)},
-      fn -> encode(event) end
+      encoder
     )
   end
 
   @spec encode(t()) :: {:ok, binary()} | {:error, atom()}
   def encode(%__MODULE__{} = event) do
-    event = validate!(event)
+    event |> validate!() |> encode_validated()
+  end
 
+  defp encode_validated(event) do
     payload =
       :erlang.term_to_binary(
         {

--- a/test/lasso/core/request/request_projection_test.exs
+++ b/test/lasso/core/request/request_projection_test.exs
@@ -1,6 +1,7 @@
 defmodule Lasso.RPC.RequestProjectionTest do
   use ExUnit.Case, async: false
 
+  alias Lasso.Core.ProjectionDispatcher
   alias Lasso.Events.RoutingDecision
 
   alias Lasso.RPC.{
@@ -12,6 +13,8 @@ defmodule Lasso.RPC.RequestProjectionTest do
   }
 
   alias Lasso.RPC.ExecutionFact.Codec
+
+  @fast_dispatcher Lasso.TestRequestProjectionFastDispatcher
 
   setup do
     Application.ensure_all_started(:lasso)
@@ -223,6 +226,42 @@ defmodule Lasso.RPC.RequestProjectionTest do
   test "a terminal without an upstream route remains telemetry-only" do
     event = RequestProjection.new(local_failure(), "eth_call", nil, 0)
     assert :not_routed = RequestProjection.routing_decision(event)
+  end
+
+  test "constructing and enqueueing preserves the bounded event" do
+    parent = self()
+
+    start_supervised!({
+      ProjectionDispatcher,
+      name: @fast_dispatcher,
+      lanes: [
+        diagnostics: [
+          capacity: 8,
+          byte_capacity: 32_768,
+          scope_capacity: 8,
+          scope_byte_capacity: 32_768,
+          shards: 1,
+          max_age_ms: 1_000,
+          audit_interval_ms: 1_000,
+          sink: fn _scope, payload -> send(parent, {:diagnostic, payload}) end
+        ]
+      ]
+    })
+
+    assert {:ok, _token} =
+             RequestProjection.new_and_enqueue(
+               terminal(),
+               "eth_blockNumber",
+               %{provider_id: "provider-a", instance_id: "instance-a", transport: :http},
+               2,
+               :client,
+               @fast_dispatcher
+             )
+
+    assert_receive {:diagnostic, payload}
+
+    assert {:ok, %{method: "eth_blockNumber", provider_id: "provider-a"}} =
+             RequestProjection.decode(payload)
   end
 
   defp request_projection do


### PR DESCRIPTION
## Summary
- combine construction and enqueue for the internal request-terminal diagnostic path
- preserve defensive validation for the public encoder
- encode the already-validated internal event after the bounded lane reservation

## Why
A healthy request constructed a bounded request projection and then immediately performed the same full validation again during encoding. This keeps one validation pass on the production path without changing the emitted envelope or dispatcher semantics.

## Verification
- warnings-as-errors compile
- focused projection/pipeline/integration: 93 tests, 0 failures
- full default suite: 1,435 tests, 0 failures
- Credo strict: clean
- Dialyzer: passed (26 ignored, 0 unignored)
- direct request diagnostic: one validation call instead of two; about 180-190 fewer reductions/request (~3.1%) in repeated fixed-scheduler local runs

No benchmark harness or comparison artifacts are included.