### PR TITLE
Reuse consensus during provider selection

### DIFF
--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -830,12 +830,6 @@ defmodule Lasso.RPC.RequestPipeline do
 
   @spec handle_success(any(), number(), Channel.t(), RequestContext.t()) :: result()
   defp handle_success(result, io_ms, channel, ctx) do
-    Logger.debug("Request succeeded",
-      channel: Channel.to_string(channel),
-      request_id: ctx.request_id,
-      io_latency_ms: io_ms
-    )
-
     log_slow_request_if_needed(io_ms, ctx.method, channel, ctx)
 
     # Update context with success info

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -80,7 +80,7 @@ defmodule Lasso.RPC.Selection do
   end
 
   defp do_select_provider(snapshot, plan, method, params, selection_opts) do
-    filters =
+    {filters, consensus_height} =
       build_selection_filters(
         plan,
         method,
@@ -92,7 +92,8 @@ defmodule Lasso.RPC.Selection do
         workload_key: workload_for_origin(selection_opts.request_origin)
       )
 
-    candidates = CandidateListing.list_routing_candidates_from_plan(plan, filters)
+    candidates =
+      CandidateListing.list_routing_candidates_from_plan(plan, filters, consensus_height)
 
     case candidates do
       [] ->
@@ -222,7 +223,12 @@ defmodule Lasso.RPC.Selection do
         workload_key: workload_key
       )
 
-    provider_candidates = CandidateListing.list_routing_candidates_from_plan(plan, pool_filters)
+    provider_candidates =
+      CandidateListing.list_routing_candidates_from_plan(
+        plan,
+        pool_filters,
+        consensus_height || :unavailable
+      )
 
     # Build channel candidates via TransportRegistry (enforces channel-level health/capabilities)
     # Map provider list into channels, lazily opening as needed
@@ -513,16 +519,19 @@ defmodule Lasso.RPC.Selection do
         archival_threshold: plan.archival_threshold
       )
 
-    SelectionFilters.new(
-      exclude: exclude,
-      protocol: protocol,
-      include_half_open: include_half_open,
-      max_lag_blocks: plan.max_lag_blocks,
-      min_block: requirements.requested_block,
-      requires_archival: requirements.requires_archival,
-      requires_subscribe_new_heads: requires_subscribe_new_heads,
-      workload_key: workload_key
-    )
+    filters =
+      SelectionFilters.new(
+        exclude: exclude,
+        protocol: protocol,
+        include_half_open: include_half_open,
+        max_lag_blocks: plan.max_lag_blocks,
+        min_block: requirements.requested_block,
+        requires_archival: requirements.requires_archival,
+        requires_subscribe_new_heads: requires_subscribe_new_heads,
+        workload_key: workload_key
+      )
+
+    {filters, consensus_height || :unavailable}
   end
 
   defp enrich_strategy_context(ctx, candidates, %RoutingPlan{} = plan) do

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -21,7 +21,7 @@ defmodule Lasso.Providers.CandidateListing do
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.{Catalog, InstanceState, LagCalculation}
-  alias Lasso.RPC.{AttemptProjection, RoutingPlan, SelectionFilters}
+  alias Lasso.RPC.{AttemptProjection, ChainState, RoutingPlan, SelectionFilters}
   alias Lasso.RPC.RoutingEvidence.Workload
 
   @doc """
@@ -106,10 +106,32 @@ defmodule Lasso.Providers.CandidateListing do
     do_list_candidates(plan, filters, :routing)
   end
 
+  @doc false
+  @spec list_routing_candidates_from_plan(
+          RoutingPlan.t(),
+          SelectionFilters.t() | map(),
+          non_neg_integer() | :unavailable
+        ) :: [map()]
+  def list_routing_candidates_from_plan(
+        %RoutingPlan{} = plan,
+        %SelectionFilters{} = filters,
+        consensus_height
+      ) do
+    list_routing_candidates_from_plan(plan, SelectionFilters.to_map(filters), consensus_height)
+  end
+
+  def list_routing_candidates_from_plan(%RoutingPlan{} = plan, filters, consensus_height)
+      when is_map(filters) do
+    do_list_candidates(plan, filters, :routing, consensus_height)
+  end
+
   defp do_list_candidates(%RoutingPlan{} = plan, filters),
     do: do_list_candidates(plan, filters, :full)
 
-  defp do_list_candidates(%RoutingPlan{} = plan, filters, mode) do
+  defp do_list_candidates(%RoutingPlan{} = plan, filters, mode),
+    do: do_list_candidates(plan, filters, mode, capture_consensus_height(plan.chain_id))
+
+  defp do_list_candidates(%RoutingPlan{} = plan, filters, mode, consensus_height) do
     protocol = Map.get(filters, :protocol)
     workload_key = filters |> Map.get(:workload_key, :client) |> Workload.normalize()
     include_half_open = Map.get(filters, :include_half_open, false)
@@ -123,7 +145,12 @@ defmodule Lasso.Providers.CandidateListing do
           circuit_breaker_ready?(c, protocol, include_half_open) and
           rate_limit_ok?(c, protocol, filters)
       end)
-      |> filter_by_lag(plan.profile, plan.chain_id, Map.get(filters, :max_lag_blocks))
+      |> filter_by_lag(
+        plan.profile,
+        plan.chain_id,
+        Map.get(filters, :max_lag_blocks),
+        consensus_height
+      )
       |> filter_by_min_block(plan.profile, plan.chain_id, Map.get(filters, :min_block))
       |> filter_by_archival(Map.get(filters, :requires_archival))
       |> filter_by_subscribe_new_heads(Map.get(filters, :requires_subscribe_new_heads))
@@ -310,10 +337,32 @@ defmodule Lasso.Providers.CandidateListing do
     end
   end
 
-  defp filter_by_lag(candidates, _profile, _chain_id, nil), do: candidates
+  defp filter_by_lag(candidates, _profile, _chain_id, nil, _consensus_height), do: candidates
 
-  defp filter_by_lag(candidates, profile, chain_id, max_lag_blocks)
+  defp filter_by_lag(candidates, profile, chain_id, max_lag_blocks, consensus_height)
        when is_integer(max_lag_blocks) do
+    case resolve_consensus_height(chain_id, consensus_height) do
+      {:ok, consensus_height} ->
+        filter_by_lag_with_consensus(
+          candidates,
+          profile,
+          chain_id,
+          max_lag_blocks,
+          consensus_height
+        )
+
+      :unavailable ->
+        candidates
+    end
+  end
+
+  defp filter_by_lag_with_consensus(
+         candidates,
+         profile,
+         chain_id,
+         max_lag_blocks,
+         consensus_height
+       ) do
     block_time_ms = LagCalculation.get_block_time_ms(chain_id, profile)
 
     filtered =
@@ -321,7 +370,8 @@ defmodule Lasso.Providers.CandidateListing do
         case LagCalculation.calculate_optimistic_lag(
                chain_id,
                candidate.instance_id,
-               block_time_ms
+               block_time_ms,
+               consensus_height
              ) do
           {:ok, optimistic_lag, _raw_lag} -> optimistic_lag >= -max_lag_blocks
           {:error, _} -> true
@@ -335,6 +385,19 @@ defmodule Lasso.Providers.CandidateListing do
     end
 
     filtered
+  end
+
+  defp resolve_consensus_height(_chain_id, height)
+       when is_integer(height) and height >= 0,
+       do: {:ok, height}
+
+  defp resolve_consensus_height(_chain_id, :unavailable), do: :unavailable
+
+  defp capture_consensus_height(chain_id) do
+    case ChainState.consensus_height(chain_id) do
+      {:ok, height} -> height
+      {:error, _reason} -> :unavailable
+    end
   end
 
   defp filter_by_min_block(candidates, _profile, _chain_id, nil), do: candidates

--- a/lib/lasso/providers/lag_calculation.ex
+++ b/lib/lasso/providers/lag_calculation.ex
@@ -15,23 +15,50 @@ defmodule Lasso.Providers.LagCalculation do
     with {:ok, {height, timestamp, _source, _meta}} <-
            BlockSyncRegistry.get_height(chain_id, provider_or_instance_id),
          {:ok, consensus} <- ChainState.consensus_height(chain_id) do
-      now = System.system_time(:millisecond)
-      elapsed_ms = now - timestamp
-      raw_lag = height - consensus
-
-      staleness_credit =
-        if block_time_ms > 0, do: div(elapsed_ms, block_time_ms), else: 0
-
-      max_credit = div(30_000, max(block_time_ms, 1))
-      capped_credit = min(staleness_credit, max_credit)
-      optimistic_lag = height + capped_credit - consensus
-
-      {:ok, optimistic_lag, raw_lag}
+      calculate_from_height(height, timestamp, block_time_ms, consensus)
     else
       {:error, :not_found} -> {:error, :no_provider_data}
       {:error, :no_data} -> {:error, :no_consensus}
       error -> error
     end
+  end
+
+  @doc false
+  @spec calculate_optimistic_lag(
+          pos_integer(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: {:ok, integer(), integer()} | {:error, term()}
+  def calculate_optimistic_lag(
+        chain_id,
+        provider_or_instance_id,
+        block_time_ms,
+        consensus
+      )
+      when is_integer(chain_id) and chain_id > 0 and is_integer(consensus) and consensus >= 0 do
+    case BlockSyncRegistry.get_height(chain_id, provider_or_instance_id) do
+      {:ok, {height, timestamp, _source, _meta}} ->
+        calculate_from_height(height, timestamp, block_time_ms, consensus)
+
+      {:error, :not_found} ->
+        {:error, :no_provider_data}
+    end
+  end
+
+  defp calculate_from_height(height, timestamp, block_time_ms, consensus) do
+    now = System.system_time(:millisecond)
+    elapsed_ms = now - timestamp
+    raw_lag = height - consensus
+
+    staleness_credit =
+      if block_time_ms > 0, do: div(elapsed_ms, block_time_ms), else: 0
+
+    max_credit = div(30_000, max(block_time_ms, 1))
+    capped_credit = min(staleness_credit, max_credit)
+    optimistic_lag = height + capped_credit - consensus
+
+    {:ok, optimistic_lag, raw_lag}
   end
 
   @spec get_block_time_ms(pos_integer(), String.t() | nil) :: non_neg_integer()

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -1,9 +1,10 @@
 defmodule Lasso.Providers.CandidateListingTest do
   use ExUnit.Case, async: false
 
+  alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
   alias Lasso.Config.ConfigStore
   alias Lasso.Core.Support.CircuitBreaker.{Snapshot, Storage}
-  alias Lasso.Providers.{Catalog, CandidateListing}
+  alias Lasso.Providers.{CandidateListing, Catalog}
   alias Lasso.RPC.{AttemptIdentity, AttemptProjection, AttemptTerminal}
 
   @profile "cl_test"
@@ -35,6 +36,7 @@ defmodule Lasso.Providers.CandidateListingTest do
 
     on_exit(fn ->
       clean_instance_state()
+      BlockSyncRegistry.clear_chain(@chain)
       ConfigStore.unregister_chain_runtime(@profile, @chain)
       Catalog.build_from_config()
     end)
@@ -78,6 +80,41 @@ defmodule Lasso.Providers.CandidateListingTest do
       assert Map.has_key?(candidate, :routing_states)
       assert Map.has_key?(candidate, :circuit_state)
       assert Map.has_key?(candidate, :rate_limited)
+    end
+
+    test "lag filtering uses the request's captured consensus" do
+      {:ok, plan} = Catalog.get_routing_plan(Catalog.snapshot(), @profile, @chain)
+      providers = Map.new(plan.providers, &{&1.id, &1.instance_id})
+
+      :ok = BlockSyncRegistry.put_height(@chain, providers["p1"], 100, :http)
+      :ok = BlockSyncRegistry.put_height(@chain, providers["p2"], 90, :http)
+      :ok = BlockSyncRegistry.put_height(@chain, providers["p3"], 80, :http)
+
+      candidates =
+        CandidateListing.list_routing_candidates_from_plan(
+          plan,
+          %{protocol: :http, max_lag_blocks: 5},
+          90
+        )
+
+      assert Enum.map(candidates, & &1.id) == ["p1", "p2"]
+    end
+
+    test "lag filtering fails open when the request captured no consensus" do
+      {:ok, plan} = Catalog.get_routing_plan(Catalog.snapshot(), @profile, @chain)
+      providers = Map.new(plan.providers, &{&1.id, &1.instance_id})
+
+      :ok = BlockSyncRegistry.put_height(@chain, providers["p1"], 100, :http)
+      :ok = BlockSyncRegistry.put_height(@chain, providers["p2"], 90, :http)
+
+      candidates =
+        CandidateListing.list_routing_candidates_from_plan(
+          plan,
+          %{protocol: :http, max_lag_blocks: 0},
+          :unavailable
+        )
+
+      assert Enum.map(candidates, & &1.id) == ["p1", "p2", "p3"]
     end
 
     test "does not read or expose a disconnected WebSocket route" do

--- a/test/lasso/rpc/optimistic_lag_test.exs
+++ b/test/lasso/rpc/optimistic_lag_test.exs
@@ -16,6 +16,7 @@ defmodule Lasso.RPC.OptimisticLagTest do
   use ExUnit.Case, async: true
 
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
+  alias Lasso.Providers.LagCalculation
   alias Lasso.RPC.ChainState
 
   @chain 9_999_001
@@ -142,6 +143,19 @@ defmodule Lasso.RPC.OptimisticLagTest do
   end
 
   describe "integration with BlockSyncRegistry" do
+    test "uses a captured consensus without rescanning chain state" do
+      provider_id = "captured_consensus_#{System.unique_integer()}"
+      timestamp = System.system_time(:millisecond)
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, @chain, provider_id}, {995, timestamp, :http, %{}}}
+      )
+
+      assert {:ok, -5, -5} =
+               LagCalculation.calculate_optimistic_lag(@chain, provider_id, 12_000, 1_000)
+    end
+
     test "optimistic lag passes threshold when raw lag would fail" do
       provider_id = "test_http_provider_#{System.unique_integer()}"
 


### PR DESCRIPTION
## Summary
- reuse the request's captured consensus height while filtering provider lag
- preserve standalone candidate-listing behavior by capturing consensus once when no request snapshot is supplied
- remove redundant per-success debug logging; canonical bounded request diagnostics remain authoritative

## Why
Lag filtering previously recomputed chain consensus for every provider. Because consensus itself scans provider heights, the selection stage scaled quadratically with provider count.

In a local nine-provider diagnostic, this change reduced the candidate stage from 9 repeated consensus scans to 0, from ~3,472 to ~1,608 owner reductions per selection, and from ~34 µs to ~9 µs median. These are local diagnostic measurements, not production or cross-runtime claims.

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- 1,438 default tests, 0 failures
- 100 focused selection/pipeline/lag tests, 0 failures
- 46 focused integration tests, 0 failures
- Credo strict, changed surface: clean
- Dialyzer: no warnings in changed production files (existing test-support PLT warnings remain)
- `git diff --check`
