### PR TITLE
Reduce provider filtering and response scan cost

### DIFF
--- a/lib/lasso/core/providers/adapter_filter.ex
+++ b/lib/lasso/core/providers/adapter_filter.ex
@@ -13,6 +13,7 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
 
   require Logger
   alias Lasso.RPC.Channel
+  alias Lasso.RPC.MethodRegistry
   alias Lasso.RPC.Providers.Capabilities
 
   @doc """
@@ -51,12 +52,14 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
   # Private Implementation
 
   defp do_filter_channels(channels, method) do
+    category = MethodRegistry.method_category(method)
+
     {capable, filtered} =
       Enum.split_with(channels, fn %{provider_id: id} = channel ->
         caps = provider_capabilities(channel)
 
         try do
-          :ok == Capabilities.supports_method?(method, caps)
+          :ok == Capabilities.supports_method?(method, category, caps)
         rescue
           e ->
             Logger.error("Capabilities crash in supports_method?: #{id}, #{Exception.message(e)}")

--- a/lib/lasso/core/providers/capabilities.ex
+++ b/lib/lasso/core/providers/capabilities.ex
@@ -53,9 +53,18 @@ defmodule Lasso.RPC.Providers.Capabilities do
   Returns `:ok` if supported, `{:error, :method_unsupported}` if not.
   """
   @spec supports_method?(String.t(), map() | nil) :: :ok | {:error, :method_unsupported}
-  def supports_method?(method, nil), do: supports_method?(method, default_capabilities())
+  def supports_method?(method, capabilities) when is_binary(method) do
+    supports_method?(method, MethodRegistry.method_category(method), capabilities)
+  end
 
-  def supports_method?(method, capabilities) when is_map(capabilities) do
+  @doc false
+  @spec supports_method?(String.t(), atom(), map() | nil) ::
+          :ok | {:error, :method_unsupported}
+  def supports_method?(_method, :local_only, nil), do: {:error, :method_unsupported}
+  def supports_method?(_method, _category, nil), do: :ok
+
+  def supports_method?(method, category, capabilities)
+      when is_binary(method) and is_atom(category) and is_map(capabilities) do
     unsupported_categories =
       Map.get(capabilities, :unsupported_categories, @default_unsupported_categories)
 
@@ -65,7 +74,7 @@ defmodule Lasso.RPC.Providers.Capabilities do
       method in unsupported_methods ->
         {:error, :method_unsupported}
 
-      MethodRegistry.method_category(method) in unsupported_categories ->
+      category in unsupported_categories ->
         {:error, :method_unsupported}
 
       true ->

--- a/lib/lasso/core/transport/upstream_response.ex
+++ b/lib/lasso/core/transport/upstream_response.ex
@@ -5,6 +5,10 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
   alias Lasso.RPC.Response
 
   @max_transport_id_bytes 128
+  @string_specials ["\"", "\\"]
+  @scalar_delimiters [" ", "\t", "\r", "\n", ",", "}", "]"]
+  @container_specials ["\"", "{", "[", "}", "]"]
+  @linear_scan_threshold 256
 
   defmodule Validated do
     @moduledoc false
@@ -576,41 +580,101 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
   end
 
   defp skip_container(raw_bytes, index, [expected | rest] = stack) do
+    if byte_size(raw_bytes) - index <= @linear_scan_threshold do
+      skip_container_linear(raw_bytes, index, stack)
+    else
+      skip_container_matched(raw_bytes, index, expected, rest, stack)
+    end
+  end
+
+  defp skip_container_matched(raw_bytes, index, expected, rest, stack) do
+    case binary_match_from(raw_bytes, @container_specials, index) do
+      :nomatch ->
+        :error
+
+      {special_index, _length} ->
+        case byte_at(raw_bytes, special_index) do
+          ?" ->
+            case skip_string(raw_bytes, special_index) do
+              {:ok, next} -> skip_container(raw_bytes, next, stack)
+              :error -> :error
+            end
+
+          ?{ ->
+            skip_container(raw_bytes, special_index + 1, [?} | stack])
+
+          ?[ ->
+            skip_container(raw_bytes, special_index + 1, [?] | stack])
+
+          ^expected when rest == [] ->
+            {:ok, special_index + 1}
+
+          ^expected ->
+            skip_container(raw_bytes, special_index + 1, rest)
+
+          _other_closer ->
+            skip_container(raw_bytes, special_index + 1, stack)
+        end
+    end
+  end
+
+  defp skip_container_linear(raw_bytes, index, [expected | rest] = stack) do
     case byte_at(raw_bytes, index) do
       nil ->
         :error
 
       ?" ->
         case skip_string(raw_bytes, index) do
-          {:ok, next} -> skip_container(raw_bytes, next, stack)
+          {:ok, next} -> skip_container_linear(raw_bytes, next, stack)
           :error -> :error
         end
 
       ?{ ->
-        skip_container(raw_bytes, index + 1, [?} | stack])
+        skip_container_linear(raw_bytes, index + 1, [?} | stack])
 
       ?[ ->
-        skip_container(raw_bytes, index + 1, [?] | stack])
+        skip_container_linear(raw_bytes, index + 1, [?] | stack])
 
       ^expected when rest == [] ->
         {:ok, index + 1}
 
       ^expected ->
-        skip_container(raw_bytes, index + 1, rest)
+        skip_container_linear(raw_bytes, index + 1, rest)
 
       _byte ->
-        skip_container(raw_bytes, index + 1, stack)
+        skip_container_linear(raw_bytes, index + 1, stack)
     end
   end
 
   defp skip_string(raw_bytes, index), do: do_skip_string(raw_bytes, index + 1)
 
   defp do_skip_string(raw_bytes, index) do
+    if byte_size(raw_bytes) - index <= @linear_scan_threshold do
+      do_skip_string_linear(raw_bytes, index)
+    else
+      do_skip_string_matched(raw_bytes, index)
+    end
+  end
+
+  defp do_skip_string_matched(raw_bytes, index) do
+    case binary_match_from(raw_bytes, @string_specials, index) do
+      :nomatch ->
+        :error
+
+      {special_index, _length} ->
+        case byte_at(raw_bytes, special_index) do
+          ?" -> {:ok, special_index + 1}
+          ?\\ -> skip_escape(raw_bytes, special_index)
+        end
+    end
+  end
+
+  defp do_skip_string_linear(raw_bytes, index) do
     case byte_at(raw_bytes, index) do
       nil -> :error
       ?" -> {:ok, index + 1}
       ?\\ -> skip_escape(raw_bytes, index)
-      _byte -> do_skip_string(raw_bytes, index + 1)
+      _byte -> do_skip_string_linear(raw_bytes, index + 1)
     end
   end
 
@@ -623,11 +687,28 @@ defmodule Lasso.Core.Transport.UpstreamResponse do
   end
 
   defp skip_scalar(raw_bytes, index) do
-    case byte_at(raw_bytes, index) do
-      byte when byte in [nil, ?\s, ?\t, ?\r, ?\n, ?,, ?}, ?]] -> {:ok, index}
-      _byte -> skip_scalar(raw_bytes, index + 1)
+    if byte_size(raw_bytes) - index <= @linear_scan_threshold do
+      skip_scalar_linear(raw_bytes, index)
+    else
+      case binary_match_from(raw_bytes, @scalar_delimiters, index) do
+        :nomatch -> {:ok, byte_size(raw_bytes)}
+        {delimiter_index, _length} -> {:ok, delimiter_index}
+      end
     end
   end
+
+  defp skip_scalar_linear(raw_bytes, index) do
+    case byte_at(raw_bytes, index) do
+      byte when byte in [nil, ?\s, ?\t, ?\r, ?\n, ?,, ?}, ?]] -> {:ok, index}
+      _byte -> skip_scalar_linear(raw_bytes, index + 1)
+    end
+  end
+
+  defp binary_match_from(raw_bytes, pattern, index) when index < byte_size(raw_bytes) do
+    :binary.match(raw_bytes, pattern, scope: {index, byte_size(raw_bytes) - index})
+  end
+
+  defp binary_match_from(_raw_bytes, _pattern, _index), do: :nomatch
 
   defp skip_whitespace(raw_bytes, index) do
     case byte_at(raw_bytes, index) do

--- a/lib/lasso/rpc/method_registry.ex
+++ b/lib/lasso/rpc/method_registry.ex
@@ -147,6 +147,11 @@ defmodule Lasso.RPC.MethodRegistry do
     ]
   }
 
+  @method_categories for {category, methods} <- @standard_methods,
+                         method <- methods,
+                         into: %{},
+                         do: {method, category}
+
   @doc "Returns all standard method categories"
   @spec categories() :: %{atom() => [String.t()]}
   def categories, do: @standard_methods
@@ -166,11 +171,7 @@ defmodule Lasso.RPC.MethodRegistry do
 
   @doc "Returns the category for a given method"
   @spec method_category(String.t()) :: atom()
-  def method_category(method) do
-    Enum.find_value(@standard_methods, :unknown, fn {cat, methods} ->
-      if method in methods, do: cat
-    end)
-  end
+  def method_category(method), do: Map.get(@method_categories, method, :unknown)
 
   @doc """
   Returns default support assumption for unknown methods.

--- a/test/lasso/core/transport/upstream_response_test.exs
+++ b/test/lasso/core/transport/upstream_response_test.exs
@@ -136,6 +136,35 @@ defmodule Lasso.Core.Transport.UpstreamResponseTest do
   end
 
   @tag timeout: 10_000
+  test "large ignored fields retain bounded scan cost" do
+    padding = String.duplicate("x", 100 * 1_024)
+    raw = ~s({"jsonrpc":"2.0","id":"internal","padding":"#{padding}","result":"0x1"})
+
+    nested =
+      ~s({"jsonrpc":"2.0","id":"internal","padding":{"items":["#{padding}"]},"result":"0x1"})
+
+    assert {:ok, %Validated{kind: :result, id: "internal"}} =
+             UpstreamResponse.parse_unary(nested)
+
+    parent = self()
+
+    {worker, monitor} =
+      spawn_monitor(fn ->
+        {:reductions, before_reductions} = Process.info(self(), :reductions)
+        result = UpstreamResponse.parse_unary(raw)
+        {:reductions, after_reductions} = Process.info(self(), :reductions)
+        send(parent, {:large_ignored_field, result, after_reductions - before_reductions})
+      end)
+
+    assert_receive {:large_ignored_field, {:ok, %Validated{kind: :result, id: "internal"}},
+                    reductions},
+                   5_000
+
+    assert reductions < 50_000
+    assert_receive {:DOWN, ^monitor, :process, ^worker, :normal}
+  end
+
+  @tag timeout: 10_000
   test "100 KiB errors avoid the legacy second parse with bounded parser overhead" do
     error_data = "0x" <> String.duplicate("d", 100 * 1_024)
 


### PR DESCRIPTION
## Summary
- compile the static method registry into direct lookups
- compute method capability categories once per candidate set instead of once per provider
- use linear scanning for small JSON-RPC metadata and bounded native binary searches for large strings, scalars, and containers
- preserve strict one-pass error-data decoding and existing response-envelope semantics

## Local diagnostics
- nine-provider request owner: ~7,773 to ~7,023 reductions/request (about 9.6% lower)
- 100 KiB ignored field before `result`: ~413k to ~17k reductions and ~0.66 ms to ~0.13 ms
- canonical small response: approximately 1 µs before and after

These are fixed-scheduler local diagnostics, not production or cross-runtime claims. No benchmark artifacts are included.

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- 1,439 default tests, 0 failures
- 101 focused parser/transport/capability tests, 0 failures
- parser test repeated across 10 seeds
- full integration-enabled suite reached 1,439 tests with one unrelated subscription confirmation timing race; the exact test passed the original seed plus 9 additional isolated seeds
- Credo strict, changed surface: clean
- Dialyzer: no warnings in changed production files (existing test-support PLT warnings remain)
- `git diff --check`
