### PR TITLE
Prepare only strategy-required routing context

### DIFF
--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -110,7 +110,7 @@ defmodule Lasso.RPC.Selection do
             selection_opts.timeout
           )
           |> Map.put(:workload_key, workload_for_origin(selection_opts.request_origin))
-          |> enrich_strategy_context(candidates, plan)
+          |> enrich_strategy_context(candidates, plan, strategy_mod)
 
         channels =
           candidates
@@ -307,7 +307,7 @@ defmodule Lasso.RPC.Selection do
     prepared_ctx =
       strategy_mod.prepare_context(plan.profile, plan.chain_id, method, timeout)
       |> Map.put(:workload_key, workload_key)
-      |> enrich_strategy_context(candidates, plan)
+      |> enrich_strategy_context(candidates, plan, strategy_mod)
 
     ordered_channels =
       if Enum.any?(candidates, & &1.learned_feedback_degraded?) and
@@ -534,7 +534,24 @@ defmodule Lasso.RPC.Selection do
     {filters, consensus_height || :unavailable}
   end
 
-  defp enrich_strategy_context(ctx, candidates, %RoutingPlan{} = plan) do
+  defp enrich_strategy_context(
+         ctx,
+         _candidates,
+         %RoutingPlan{} = plan,
+         Lasso.RPC.Strategies.Priority
+       ) do
+    %{ctx | provider_priorities: plan.provider_priorities}
+  end
+
+  defp enrich_strategy_context(
+         ctx,
+         _candidates,
+         %RoutingPlan{},
+         Lasso.RPC.Strategies.LoadBalanced
+       ),
+       do: ctx
+
+  defp enrich_strategy_context(ctx, candidates, %RoutingPlan{} = plan, _strategy_mod) do
     summaries =
       Enum.reduce(candidates, %{}, fn candidate, acc ->
         Enum.reduce(candidate.transports, acc, fn transport, route_acc ->

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -33,6 +33,27 @@ defmodule Lasso.RPC.SelectionTest do
     end
   end
 
+  defmodule ContextCaptureStrategy do
+    @behaviour Lasso.RPC.Strategy
+
+    alias Lasso.RPC.StrategyContext
+
+    @impl true
+    def prepare_context(_profile, chain_id, _method, timeout) do
+      StrategyContext.new(chain_id, timeout)
+    end
+
+    @impl true
+    def rank_channels(channels, _method, context, _profile, _chain_id) do
+      send(
+        Application.fetch_env!(:lasso, :selection_context_test_pid),
+        {:strategy_context, context}
+      )
+
+      channels
+    end
+  end
+
   describe "select_provider/3 - filter handling" do
     test "respects exclude filter", %{chain: chain} do
       profile = "public"
@@ -283,6 +304,46 @@ defmodule Lasso.RPC.SelectionTest do
                  transport: :http
                )
     end
+
+    test "custom strategies retain the complete routing context", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "context_provider", priority: 10, behavior: :healthy, profile: profile}
+      ])
+
+      previous_registry = Application.get_env(:lasso, :strategy_registry)
+      previous_pid = Application.get_env(:lasso, :selection_context_test_pid)
+
+      Application.put_env(
+        :lasso,
+        :strategy_registry,
+        Map.put(
+          Lasso.RPC.Strategies.Registry.default_registry(),
+          :context_capture,
+          ContextCaptureStrategy
+        )
+      )
+
+      Application.put_env(:lasso, :selection_context_test_pid, self())
+
+      on_exit(fn ->
+        restore_env(:strategy_registry, previous_registry)
+        restore_env(:selection_context_test_pid, previous_pid)
+      end)
+
+      assert {:ok, "context_provider"} =
+               Selection.select_provider(profile, chain, "eth_blockNumber",
+                 strategy: :context_capture,
+                 protocol: :http
+               )
+
+      assert_receive {:strategy_context,
+                      %{routing_summaries: summaries, provider_priorities: priorities}}
+
+      assert map_size(summaries) == 1
+      assert priorities == %{"context_provider" => 10}
+    end
   end
 
   describe "select_channels/4 - archival filtering" do
@@ -349,4 +410,7 @@ defmodule Lasso.RPC.SelectionTest do
     {:ok, current} = Snapshot.lookup({instance_id, :http})
     Snapshot.put(%{current | state: state, control_health: :healthy})
   end
+
+  defp restore_env(key, nil), do: Application.delete_env(:lasso, key)
+  defp restore_env(key, value), do: Application.put_env(:lasso, key, value)
 end


### PR DESCRIPTION
## Summary
- skip learned-routing summary materialization for the built-in load-balanced strategy
- prepare only provider priorities for the built-in priority strategy
- retain complete routing summaries and priorities for Fastest, LatencyWeighted, and custom strategy overrides

## Local diagnostic
With nine healthy providers and priority selection, request-owner reductions fell from ~7,023 to ~6,721 (about 4.3%). Relative to the pre-optimization baseline before #74/#75, the combined multi-provider reduction is about 13.5%. Wall timing remained host-noisy, so no latency claim is made from this layer.

No benchmark artifacts are included.

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- 1,440 default tests, 0 failures
- selection integration: 15 tests, 0 failures
- custom-strategy regression proves full routing context remains available
- Credo strict on changed production source: clean
- `git diff --check`
