### PR TITLE
Select execution candidates incrementally

### DIFF
--- a/lib/lasso/core/providers/adapter_filter.ex
+++ b/lib/lasso/core/providers/adapter_filter.ex
@@ -49,24 +49,29 @@ defmodule Lasso.RPC.Providers.AdapterFilter do
     )
   end
 
+  @doc false
+  @spec method_supported?(Channel.t(), String.t()) :: boolean()
+  def method_supported?(%Channel{provider_id: provider_id} = channel, method)
+      when is_binary(method) do
+    category = MethodRegistry.method_category(method)
+
+    try do
+      :ok == Capabilities.supports_method?(method, category, provider_capabilities(channel))
+    rescue
+      error ->
+        Logger.error(
+          "Capabilities crash in supports_method?: #{provider_id}, #{Exception.message(error)}"
+        )
+
+        true
+    end
+  end
+
   # Private Implementation
 
   defp do_filter_channels(channels, method) do
-    category = MethodRegistry.method_category(method)
-
     {capable, filtered} =
-      Enum.split_with(channels, fn %{provider_id: id} = channel ->
-        caps = provider_capabilities(channel)
-
-        try do
-          :ok == Capabilities.supports_method?(method, category, caps)
-        rescue
-          e ->
-            Logger.error("Capabilities crash in supports_method?: #{id}, #{Exception.message(e)}")
-
-            true
-        end
-      end)
+      Enum.split_with(channels, &method_supported?(&1, method))
 
     apply_safety_check(capable, filtered, channels, method)
   end

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -41,6 +41,7 @@ defmodule Lasso.RPC.RequestPipeline do
     RequestProjection,
     RequestTerminal,
     Selection,
+    Selection.CandidateCursor,
     TransportRegistry
   }
 
@@ -55,7 +56,8 @@ defmodule Lasso.RPC.RequestPipeline do
   @type result :: {:ok, any(), RequestContext.t()} | {:error, JError.t(), RequestContext.t()}
 
   # A channel source is a function that returns channels to try
-  @type channel_source :: (RequestContext.t() -> [Channel.t()])
+  @type candidates :: [Channel.t()] | CandidateCursor.t()
+  @type channel_source :: (RequestContext.t() -> candidates())
 
   # Configuration
   @max_channel_candidates 10
@@ -223,23 +225,25 @@ defmodule Lasso.RPC.RequestPipeline do
     # Get channels from the source
     ctx = RequestContext.mark_selection_start(ctx)
 
-    channels = get_channels_from_source(channel_source, ctx)
+    candidates = get_channels_from_source(channel_source, ctx)
+
+    {selected, remaining} = pop_candidate(candidates)
 
     ctx =
       RequestContext.mark_selection_end(ctx,
-        candidates: Enum.map(channels, &"#{&1.provider_id}:#{&1.transport}"),
-        selected: List.first(channels)
+        candidates: candidate_labels(candidates, selected),
+        selected: selected
       )
 
     case request_open(ctx, caller_guard) do
       :ok ->
-        case channels do
-          [] ->
+        case selected do
+          nil ->
             handle_no_channels(ctx)
 
-          _ ->
+          %Channel{} = channel ->
             ctx = RequestContext.mark_upstream_start(ctx)
-            attempt_channels(channels, ctx, [], caller_guard)
+            attempt_channels({channel, remaining}, ctx, [], caller_guard)
         end
 
       {:error, :caller_abandoned} ->
@@ -250,7 +254,7 @@ defmodule Lasso.RPC.RequestPipeline do
     end
   end
 
-  @spec get_channels_from_source(channel_source(), RequestContext.t()) :: [Channel.t()]
+  @spec get_channels_from_source(channel_source(), RequestContext.t()) :: candidates()
   defp get_channels_from_source(channel_source, ctx), do: channel_source.(ctx)
 
   # Builds a function that returns channels to try, unifying override vs normal selection
@@ -258,7 +262,7 @@ defmodule Lasso.RPC.RequestPipeline do
   @spec build_channel_source(RequestOptions.t()) :: channel_source()
   defp build_channel_source(%RequestOptions{provider_override: nil, profile: profile} = opts) do
     fn %RequestContext{chain_id: chain_id, method: method, params: params} = _ctx ->
-      Selection.select_channels(profile, chain_id, method,
+      Selection.select_channel_candidates(profile, chain_id, method,
         strategy: opts.strategy,
         transport: opts.transport || :both,
         limit: @max_channel_candidates,
@@ -293,7 +297,7 @@ defmodule Lasso.RPC.RequestPipeline do
   end
 
   @spec attempt_channels(
-          [Channel.t()],
+          candidates() | {Channel.t(), candidates()},
           RequestContext.t(),
           [Channel.t()],
           ExecutionScope.CallerGuard.t() | nil
@@ -308,6 +312,20 @@ defmodule Lasso.RPC.RequestPipeline do
 
       {:error, :deadline_exhausted} ->
         finalize_bounded_error(ctx, :deadline_exhausted)
+    end
+  end
+
+  defp do_attempt_channels({%Channel{} = channel, rest}, ctx, param_rejected, caller_guard) do
+    do_attempt_channels([channel], ctx, param_rejected, caller_guard, rest)
+  end
+
+  defp do_attempt_channels(%CandidateCursor{} = cursor, ctx, param_rejected, caller_guard) do
+    case CandidateCursor.next(cursor) do
+      {:ok, channel, rest} ->
+        do_attempt_channels([channel], ctx, param_rejected, caller_guard, rest)
+
+      result when result in [:done, :stale] ->
+        do_attempt_channels([], ctx, param_rejected, caller_guard)
     end
   end
 
@@ -343,6 +361,26 @@ defmodule Lasso.RPC.RequestPipeline do
 
   defp do_attempt_channels([%Channel{} = channel | rest], ctx, param_rejected, caller_guard)
        when is_list(rest) do
+    do_attempt_channels([channel], ctx, param_rejected, caller_guard, rest)
+  end
+
+  defp do_attempt_channels(
+         [%Channel{} = channel],
+         %{bypass_param_limits: true} = ctx,
+         _acc,
+         caller_guard,
+         rest
+       ) do
+    case ExecutionEnvelope.admit_candidate(ctx.execution_envelope) do
+      {:ok, envelope} ->
+        execute_on_channel(channel, rest, %{ctx | execution_envelope: envelope}, caller_guard)
+
+      {:error, reason} ->
+        finalize_bounded_error(ctx, reason)
+    end
+  end
+
+  defp do_attempt_channels([%Channel{} = channel], ctx, param_rejected, caller_guard, rest) do
     case ExecutionEnvelope.admit_candidate(ctx.execution_envelope) do
       {:ok, envelope} ->
         ctx = %{ctx | execution_envelope: envelope}
@@ -367,6 +405,24 @@ defmodule Lasso.RPC.RequestPipeline do
         finalize_bounded_error(ctx, reason)
     end
   end
+
+  defp pop_candidate([%Channel{} = channel | rest]), do: {channel, rest}
+  defp pop_candidate([]), do: {nil, []}
+
+  defp pop_candidate(%CandidateCursor{} = cursor) do
+    case CandidateCursor.next(cursor) do
+      {:ok, channel, remaining} -> {channel, remaining}
+      result when result in [:done, :stale] -> {nil, []}
+    end
+  end
+
+  defp candidate_labels(channels, _selected) when is_list(channels),
+    do: Enum.map(channels, &"#{&1.provider_id}:#{&1.transport}")
+
+  defp candidate_labels(%CandidateCursor{}, nil), do: []
+
+  defp candidate_labels(%CandidateCursor{}, %Channel{} = selected),
+    do: ["#{selected.provider_id}:#{selected.transport}"]
 
   defp retry_param_rejected(channels, ctx, caller_guard) do
     Logger.warning("All channels rejected by parameter limits, attempting anyway",
@@ -398,7 +454,7 @@ defmodule Lasso.RPC.RequestPipeline do
 
   @spec execute_on_channel(
           Channel.t(),
-          [Channel.t()],
+          candidates(),
           RequestContext.t(),
           ExecutionScope.CallerGuard.t() | nil
         ) :: result()
@@ -692,30 +748,34 @@ defmodule Lasso.RPC.RequestPipeline do
        do: handle_success(result, fact_latency_ms(fact), channel, ctx)
 
   defp handle_owner_outcome(outcome, channel, rest_channels, ctx, caller_guard) do
-    cond do
-      outcome.projection.fallback_eligible and rest_channels != [] ->
-        handle_owner_fallback(outcome, channel, rest_channels, ctx, caller_guard)
-
-      outcome.projection.fallback_eligible and
-          match?(%AttemptTerminal.PredispatchFailure{}, outcome.fact) ->
-        attempt_channels([], ctx, [], caller_guard)
-
-      true ->
-        handle_owner_terminal(outcome, channel, ctx)
+    if outcome.projection.fallback_eligible do
+      handle_owner_fallback(outcome, channel, rest_channels, ctx, caller_guard)
+    else
+      handle_owner_terminal(outcome, channel, ctx)
     end
   end
 
   defp handle_owner_fallback(outcome, channel, rest_channels, ctx, caller_guard) do
     {reason, _latency_ms} = owner_error(outcome)
-    ctx = record_owner_failure(ctx, channel, outcome.fact, reason)
-
-    ctx =
-      ctx
-      |> RequestContext.increment_retries()
-      |> RequestContext.track_error_category(extract_error_category(reason))
-
     next_channels = maybe_exclude_provider_for_method_not_found(rest_channels, channel, reason)
-    attempt_channels(next_channels, ctx, [], caller_guard)
+
+    case pop_candidate(next_channels) do
+      {%Channel{} = next_channel, remaining} ->
+        ctx = record_owner_failure(ctx, channel, outcome.fact, reason)
+
+        ctx =
+          ctx
+          |> RequestContext.increment_retries()
+          |> RequestContext.track_error_category(extract_error_category(reason))
+
+        attempt_channels({next_channel, remaining}, ctx, [], caller_guard)
+
+      {nil, _remaining} when is_struct(outcome.fact, AttemptTerminal.PredispatchFailure) ->
+        attempt_channels([], ctx, [], caller_guard)
+
+      {nil, _remaining} ->
+        handle_owner_terminal(outcome, channel, ctx)
+    end
   end
 
   defp handle_owner_terminal(outcome, channel, ctx) do
@@ -847,7 +907,7 @@ defmodule Lasso.RPC.RequestPipeline do
 
   @spec handle_circuit_open(
           Channel.t(),
-          [Channel.t()],
+          candidates(),
           RequestContext.t(),
           ExecutionScope.CallerGuard.t() | nil
         ) :: result()
@@ -1297,13 +1357,15 @@ defmodule Lasso.RPC.RequestPipeline do
   defp extract_error_category(:circuit_open), do: :circuit_open
   defp extract_error_category(_), do: :unknown
 
-  @spec maybe_exclude_provider_for_method_not_found([Channel.t()], Channel.t(), any()) :: [
-          Channel.t()
-        ]
+  @spec maybe_exclude_provider_for_method_not_found(candidates(), Channel.t(), any()) ::
+          candidates()
   defp maybe_exclude_provider_for_method_not_found(rest_channels, channel, %JError{
          category: :method_not_found
        }) do
-    Enum.reject(rest_channels, &(&1.provider_id == channel.provider_id))
+    case rest_channels do
+      %CandidateCursor{} = cursor -> CandidateCursor.exclude_provider(cursor, channel.provider_id)
+      channels -> Enum.reject(channels, &(&1.provider_id == channel.provider_id))
+    end
   end
 
   defp maybe_exclude_provider_for_method_not_found(rest_channels, _channel, _reason),

--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -1,0 +1,274 @@
+defmodule Lasso.RPC.Selection.CandidateCursor do
+  @moduledoc false
+
+  alias Lasso.Config.ConfigStore
+  alias Lasso.Providers.{CandidateListing, Catalog}
+
+  alias Lasso.RPC.{
+    AttemptProjection,
+    Channel,
+    RequestAnalysis,
+    RoutingPlan,
+    SelectionFilters,
+    TransportRegistry
+  }
+
+  alias Lasso.RPC.Providers.AdapterFilter
+  alias Lasso.RPC.RoutingEvidence.Workload
+
+  @enforce_keys [
+    :snapshot,
+    :plan,
+    :method,
+    :filters,
+    :consensus_height,
+    :learned_scope,
+    :descriptors,
+    :limit
+  ]
+  defstruct @enforce_keys ++
+              [
+                returned: 0,
+                supported?: false,
+                supported_deferred: %{2 => :queue.new(), 3 => :queue.new(), 4 => :queue.new()},
+                unsupported_deferred: %{
+                  1 => :queue.new(),
+                  2 => :queue.new(),
+                  3 => :queue.new(),
+                  4 => :queue.new()
+                }
+              ]
+
+  @type descriptor :: {RoutingPlan.provider(), :http | :ws}
+  @type t :: %__MODULE__{}
+
+  @spec new(Catalog.snapshot(), RoutingPlan.t(), String.t(), keyword()) :: t()
+  def new(snapshot, %RoutingPlan{} = plan, method, opts) do
+    transport = Keyword.get(opts, :transport, :both)
+    strategy = Keyword.get(opts, :strategy, :load_balanced)
+    consensus_height = consensus_height(plan.chain_id)
+
+    requirements =
+      RequestAnalysis.analyze(
+        method,
+        Keyword.get(opts, :params, []),
+        consensus_height: unavailable_to_nil(consensus_height),
+        archival_threshold: plan.archival_threshold
+      )
+
+    filters =
+      SelectionFilters.new(
+        protocol: nil,
+        exclude: Keyword.get(opts, :exclude, []),
+        include_half_open: Keyword.get(opts, :include_half_open, true),
+        max_lag_blocks: plan.max_lag_blocks,
+        min_block: requirements.requested_block,
+        requires_archival: requirements.requires_archival,
+        requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false),
+        workload_key: workload_for_origin(Keyword.get(opts, :request_origin, :client))
+      )
+
+    descriptors = build_descriptors(plan, strategy, transport, filters)
+
+    %__MODULE__{
+      snapshot: snapshot,
+      plan: plan,
+      method: method,
+      filters: filters,
+      consensus_height: consensus_height,
+      learned_scope: AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation),
+      descriptors: descriptors,
+      limit: Keyword.get(opts, :limit, 1000)
+    }
+  end
+
+  @spec next(t()) :: {:ok, Channel.t(), t()} | :done | :stale
+  def next(%__MODULE__{returned: returned, limit: limit}) when returned >= limit, do: :done
+
+  def next(%__MODULE__{} = cursor) do
+    if current?(cursor) do
+      scan(cursor)
+    else
+      :stale
+    end
+  end
+
+  @spec exclude_provider(t(), String.t()) :: t()
+  def exclude_provider(%__MODULE__{} = cursor, provider_id) when is_binary(provider_id) do
+    %{
+      cursor
+      | descriptors:
+          Enum.reject(cursor.descriptors, fn {provider, _transport} ->
+            provider.id == provider_id
+          end),
+        supported_deferred: reject_queued_provider(cursor.supported_deferred, provider_id),
+        unsupported_deferred: reject_queued_provider(cursor.unsupported_deferred, provider_id)
+    }
+  end
+
+  defp scan(%__MODULE__{descriptors: [descriptor | rest]} = cursor) do
+    cursor = %{cursor | descriptors: rest}
+
+    case materialize(cursor, descriptor) do
+      {:ok, channel, tier, true} when tier == 1 ->
+        return(channel, %{cursor | supported?: true, unsupported_deferred: empty_unsupported()})
+
+      {:ok, channel, tier, true} ->
+        cursor
+        |> defer(:supported_deferred, tier, channel)
+        |> Map.put(:supported?, true)
+        |> Map.put(:unsupported_deferred, empty_unsupported())
+        |> scan()
+
+      {:ok, _channel, _tier, false} when cursor.supported? ->
+        scan(cursor)
+
+      {:ok, channel, tier, false} ->
+        cursor |> defer(:unsupported_deferred, tier, channel) |> scan()
+
+      :skip ->
+        scan(cursor)
+    end
+  end
+
+  defp scan(%__MODULE__{supported?: true} = cursor),
+    do: pop_deferred(cursor, :supported_deferred, [2, 3, 4])
+
+  defp scan(%__MODULE__{} = cursor),
+    do: pop_deferred(cursor, :unsupported_deferred, [1, 2, 3, 4])
+
+  defp pop_deferred(cursor, _field, []), do: if(current?(cursor), do: :done, else: :stale)
+
+  defp pop_deferred(cursor, field, [tier | rest]) do
+    queues = Map.fetch!(cursor, field)
+
+    case :queue.out(Map.fetch!(queues, tier)) do
+      {{:value, channel}, queue} ->
+        return(channel, Map.put(cursor, field, Map.put(queues, tier, queue)))
+
+      {:empty, _queue} ->
+        pop_deferred(cursor, field, rest)
+    end
+  end
+
+  defp return(channel, cursor) do
+    if current?(cursor) do
+      {:ok, channel, %{cursor | returned: cursor.returned + 1}}
+    else
+      :stale
+    end
+  end
+
+  defp materialize(cursor, {provider, transport}) do
+    filters = %{SelectionFilters.to_map(cursor.filters) | protocol: transport}
+
+    case CandidateListing.routing_candidate_from_plan(
+           cursor.plan,
+           provider,
+           filters,
+           cursor.consensus_height,
+           cursor.learned_scope
+         ) do
+      %{circuit_state: circuit_state, rate_limited: rate_limited} = candidate ->
+        with {:ok, channel} <- channel(cursor, candidate, transport),
+             tier when tier in 1..4 <- tier(circuit_state, rate_limited, transport) do
+          {:ok, channel, tier, AdapterFilter.method_supported?(channel, cursor.method)}
+        else
+          _unavailable -> :skip
+        end
+
+      nil ->
+        :skip
+    end
+  end
+
+  defp channel(cursor, candidate, transport) do
+    TransportRegistry.get_channel(
+      cursor.plan.profile,
+      cursor.plan.chain_id,
+      candidate.id,
+      transport,
+      method: cursor.method,
+      provider_config: candidate.config,
+      instance_id: candidate.instance_id,
+      route_generation: candidate.route_generation
+    )
+  end
+
+  defp tier(circuit_state, rate_limited, transport) do
+    case {Map.fetch!(circuit_state, transport), Map.fetch!(rate_limited, transport)} do
+      {:closed, false} -> 1
+      {:half_open, false} -> 2
+      {:closed, true} -> 3
+      {:half_open, true} -> 4
+      _unavailable -> nil
+    end
+  end
+
+  defp defer(cursor, field, tier, channel) do
+    queues = Map.fetch!(cursor, field)
+    queue = :queue.in(channel, Map.fetch!(queues, tier))
+    Map.put(cursor, field, Map.put(queues, tier, queue))
+  end
+
+  defp build_descriptors(plan, strategy, transport, filters) do
+    exclude = MapSet.new(filters.exclude)
+
+    descriptors =
+      plan.providers
+      |> Enum.reject(&MapSet.member?(exclude, &1.id))
+      |> Enum.filter(fn provider ->
+        (not filters.requires_archival or provider.archival) and
+          (not filters.requires_subscribe_new_heads or provider.subscribe_new_heads)
+      end)
+      |> Enum.flat_map(fn provider ->
+        transport
+        |> transports_to_check()
+        |> Enum.filter(&(&1 in provider.transports))
+        |> Enum.map(&{provider, &1})
+      end)
+
+    case strategy do
+      :priority ->
+        Enum.sort_by(descriptors, fn {provider, protocol} ->
+          {provider.priority, if(protocol == :http, do: 0, else: 1)}
+        end)
+
+      :load_balanced ->
+        Enum.shuffle(descriptors)
+    end
+  end
+
+  defp current?(cursor) do
+    Catalog.snapshot() == cursor.snapshot and
+      ConfigStore.route_generation() == cursor.snapshot.generation
+  end
+
+  defp consensus_height(chain_id) do
+    case Lasso.RPC.ChainState.consensus_height(chain_id) do
+      {:ok, height} -> height
+      {:error, _reason} -> :unavailable
+    end
+  end
+
+  defp unavailable_to_nil(:unavailable), do: nil
+  defp unavailable_to_nil(height), do: height
+
+  defp transports_to_check(:http), do: [:http]
+  defp transports_to_check(:ws), do: [:ws]
+  defp transports_to_check(_both), do: [:http, :ws]
+
+  defp workload_for_origin(:system), do: Workload.normalize(:system)
+  defp workload_for_origin(_origin), do: Workload.normalize(:client)
+
+  defp empty_unsupported do
+    %{1 => :queue.new(), 2 => :queue.new(), 3 => :queue.new(), 4 => :queue.new()}
+  end
+
+  defp reject_queued_provider(queues, provider_id) do
+    Map.new(queues, fn {tier, queue} ->
+      filtered = queue |> :queue.to_list() |> Enum.reject(&(&1.provider_id == provider_id))
+      {tier, :queue.from_list(filtered)}
+    end)
+  end
+end

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -27,6 +27,7 @@ defmodule Lasso.RPC.Selection do
     RequestAnalysis,
     RoutingEvidence,
     RoutingPlan,
+    Selection.CandidateCursor,
     SelectionFilters,
     TransportRegistry
   }
@@ -182,6 +183,21 @@ defmodule Lasso.RPC.Selection do
     case capture_selection_snapshot(profile, chain_id) do
       {:ok, snapshot, plan} -> select_channels_from_plan(snapshot, plan, method, opts)
       :unavailable -> []
+    end
+  end
+
+  @doc false
+  @spec select_channel_candidates(String.t(), pos_integer(), String.t(), keyword()) ::
+          [Channel.t()] | CandidateCursor.t()
+  def select_channel_candidates(profile, chain_id, method, opts)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_binary(method) do
+    if Keyword.get(opts, :strategy, :load_balanced) in [:priority, :load_balanced] do
+      case capture_selection_snapshot(profile, chain_id) do
+        {:ok, snapshot, plan} -> CandidateCursor.new(snapshot, plan, method, opts)
+        :unavailable -> []
+      end
+    else
+      select_channels(profile, chain_id, method, opts)
     end
   end
 

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -125,17 +125,97 @@ defmodule Lasso.Providers.CandidateListing do
     do_list_candidates(plan, filters, :routing, consensus_height)
   end
 
+  @doc false
+  @spec routing_candidate_from_plan(
+          RoutingPlan.t(),
+          RoutingPlan.provider(),
+          SelectionFilters.t() | map(),
+          non_neg_integer() | :unavailable
+        ) :: map() | nil
+  def routing_candidate_from_plan(
+        %RoutingPlan{} = plan,
+        provider,
+        %SelectionFilters{} = filters,
+        consensus_height
+      ) do
+    routing_candidate_from_plan(
+      plan,
+      provider,
+      SelectionFilters.to_map(filters),
+      consensus_height
+    )
+  end
+
+  def routing_candidate_from_plan(%RoutingPlan{} = plan, provider, filters, consensus_height)
+      when is_map(provider) and is_map(filters) do
+    routing_candidate_from_plan(plan, provider, filters, consensus_height, nil)
+  end
+
+  @doc false
+  @spec routing_candidate_from_plan(
+          RoutingPlan.t(),
+          RoutingPlan.provider(),
+          SelectionFilters.t() | map(),
+          non_neg_integer() | :unavailable,
+          map() | nil
+        ) :: map() | nil
+  def routing_candidate_from_plan(
+        %RoutingPlan{} = plan,
+        provider,
+        %SelectionFilters{} = filters,
+        consensus_height,
+        learned_scope
+      ) do
+    routing_candidate_from_plan(
+      plan,
+      provider,
+      SelectionFilters.to_map(filters),
+      consensus_height,
+      learned_scope
+    )
+  end
+
+  def routing_candidate_from_plan(
+        %RoutingPlan{} = plan,
+        provider,
+        filters,
+        consensus_height,
+        learned_scope
+      )
+      when is_map(provider) and is_map(filters) and
+             (is_map(learned_scope) or is_nil(learned_scope)) do
+    plan
+    |> Map.put(:providers, [provider])
+    |> do_list_candidates(filters, :routing, consensus_height, false, learned_scope)
+    |> List.first()
+  end
+
   defp do_list_candidates(%RoutingPlan{} = plan, filters),
     do: do_list_candidates(plan, filters, :full)
 
   defp do_list_candidates(%RoutingPlan{} = plan, filters, mode),
     do: do_list_candidates(plan, filters, mode, capture_consensus_height(plan.chain_id))
 
-  defp do_list_candidates(%RoutingPlan{} = plan, filters, mode, consensus_height) do
+  defp do_list_candidates(%RoutingPlan{} = plan, filters, mode, consensus_height),
+    do: do_list_candidates(plan, filters, mode, consensus_height, true)
+
+  defp do_list_candidates(%RoutingPlan{} = plan, filters, mode, consensus_height, warn_on_lag?),
+    do: do_list_candidates(plan, filters, mode, consensus_height, warn_on_lag?, nil)
+
+  defp do_list_candidates(
+         %RoutingPlan{} = plan,
+         filters,
+         mode,
+         consensus_height,
+         warn_on_lag?,
+         learned_scope
+       ) do
     protocol = Map.get(filters, :protocol)
     workload_key = filters |> Map.get(:workload_key, :client) |> Workload.normalize()
     include_half_open = Map.get(filters, :include_half_open, false)
-    learned_scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
+
+    learned_scope =
+      learned_scope || AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
 
     candidates =
       plan.providers
@@ -149,7 +229,8 @@ defmodule Lasso.Providers.CandidateListing do
         plan.profile,
         plan.chain_id,
         Map.get(filters, :max_lag_blocks),
-        consensus_height
+        consensus_height,
+        warn_on_lag?
       )
       |> filter_by_min_block(plan.profile, plan.chain_id, Map.get(filters, :min_block))
       |> filter_by_archival(Map.get(filters, :requires_archival))
@@ -337,9 +418,17 @@ defmodule Lasso.Providers.CandidateListing do
     end
   end
 
-  defp filter_by_lag(candidates, _profile, _chain_id, nil, _consensus_height), do: candidates
+  defp filter_by_lag(candidates, _profile, _chain_id, nil, _consensus_height, _warn_on_lag?),
+    do: candidates
 
-  defp filter_by_lag(candidates, profile, chain_id, max_lag_blocks, consensus_height)
+  defp filter_by_lag(
+         candidates,
+         profile,
+         chain_id,
+         max_lag_blocks,
+         consensus_height,
+         warn_on_lag?
+       )
        when is_integer(max_lag_blocks) do
     case resolve_consensus_height(chain_id, consensus_height) do
       {:ok, consensus_height} ->
@@ -348,7 +437,8 @@ defmodule Lasso.Providers.CandidateListing do
           profile,
           chain_id,
           max_lag_blocks,
-          consensus_height
+          consensus_height,
+          warn_on_lag?
         )
 
       :unavailable ->
@@ -361,7 +451,8 @@ defmodule Lasso.Providers.CandidateListing do
          profile,
          chain_id,
          max_lag_blocks,
-         consensus_height
+         consensus_height,
+         warn_on_lag?
        ) do
     block_time_ms = LagCalculation.get_block_time_ms(chain_id, profile)
 
@@ -378,7 +469,7 @@ defmodule Lasso.Providers.CandidateListing do
         end
       end)
 
-    if candidates != [] and filtered == [] do
+    if warn_on_lag? and candidates != [] and filtered == [] do
       Logger.warning(
         "All providers for chain_id #{chain_id} excluded due to lag (threshold: -#{max_lag_blocks} blocks)"
       )

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -16,7 +16,9 @@ defmodule Lasso.RPC.SelectionTest do
 
   use Lasso.Test.LassoIntegrationCase
 
+  alias Lasso.Providers.Catalog
   alias Lasso.RPC.{AttemptProjection, Selection}
+  alias Lasso.RPC.Selection.CandidateCursor
 
   defmodule CatalogSwapStrategy do
     @behaviour Lasso.RPC.Strategy
@@ -401,6 +403,105 @@ defmodule Lasso.RPC.SelectionTest do
       provider_ids = Enum.map(channels, & &1.provider_id)
       assert "provider_1" in provider_ids
       assert "provider_2" in provider_ids
+    end
+  end
+
+  describe "lazy execution candidates" do
+    test "priority materializes later candidates only when requested", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "first", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "second", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :priority,
+          transport: :http,
+          limit: 10
+        )
+
+      assert {:ok, %{provider_id: "first"}, cursor} = CandidateCursor.next(cursor)
+
+      second_instance = Catalog.lookup_instance_id(profile, chain, "second")
+      set_circuit_snapshot(second_instance, :open)
+
+      assert :done = CandidateCursor.next(cursor)
+    end
+
+    test "closed candidates remain ahead of earlier half-open candidates", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "half_open", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "closed", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      half_open_instance = Catalog.lookup_instance_id(profile, chain, "half_open")
+      set_circuit_snapshot(half_open_instance, :half_open)
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :priority,
+          transport: :http,
+          include_half_open: true
+        )
+
+      assert {:ok, %{provider_id: "closed"}, cursor} = CandidateCursor.next(cursor)
+      assert {:ok, %{provider_id: "half_open"}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+    end
+
+    test "catalog pointer changes invalidate a cursor", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "provider", priority: 10, behavior: :healthy, profile: profile}
+      ])
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :priority,
+          transport: :http
+        )
+
+      :ok = Catalog.build_from_config()
+
+      assert :stale = CandidateCursor.next(cursor)
+    end
+
+    test "candidate limits bound incremental fallback", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "first", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "second", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :priority,
+          transport: :http,
+          limit: 1
+        )
+
+      assert {:ok, %{provider_id: "first"}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+    end
+
+    test "evidence-driven strategies retain the eager channel list", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "provider", priority: 10, behavior: :healthy, profile: profile}
+      ])
+
+      assert [%Lasso.RPC.Channel{}] =
+               Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+                 strategy: :fastest,
+                 transport: :http
+               )
     end
   end
 


### PR DESCRIPTION
## Summary
- add a generation-fenced candidate cursor for priority and load-balanced request execution
- materialize provider channels only as failover needs them while preserving circuit/rate-limit tiers and capability fail-open behavior
- keep provider overrides and evidence-driven routing strategies on the existing eager selection path
- preserve candidate budgets, method-not-found provider exclusion, and terminal fallback semantics

## Validation
- `MIX_ENV=test mix test --include integration`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix credo --strict`
- `mix dialyzer`
- `mix format --check-formatted`
- `git diff --check`