### PR TITLE
Share immutable routing plans across requests

### DIFF
--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -26,8 +26,10 @@ defmodule Lasso.Providers.Catalog do
   ## Concurrency
 
   `build_from_config/0` builds a fresh ETS table and atomically swaps the
-  persistent_term reference. Concurrent readers always see a consistent snapshot.
-  The old table is deleted after a grace period to cover in-flight reads.
+  persistent_term snapshot. The snapshot shares immutable routing plans across
+  request processes while the table retains live catalog indexes. Concurrent
+  readers always see a consistent generation. The old table is deleted after a
+  grace period to cover in-flight reads.
   """
 
   require Logger
@@ -38,7 +40,11 @@ defmodule Lasso.Providers.Catalog do
 
   @persistent_term_key :lasso_catalog_active
 
-  @type snapshot :: %{table: :ets.tid(), generation: non_neg_integer()}
+  @type snapshot :: %{
+          required(:table) => :ets.tid(),
+          required(:generation) => non_neg_integer(),
+          optional(:routing_plans) => %{{String.t(), pos_integer()} => RoutingPlan.t()}
+        }
 
   @doc """
   Atomically rebuilds the catalog from ConfigStore.
@@ -95,11 +101,28 @@ defmodule Lasso.Providers.Catalog do
   @doc false
   @spec get_routing_plan(snapshot(), String.t(), pos_integer()) ::
           {:ok, RoutingPlan.t()} | {:error, :not_found}
+  def get_routing_plan(%{table: table, routing_plans: routing_plans}, profile, chain_id) do
+    if table_available?(table),
+      do: Map.fetch(routing_plans, {profile, chain_id}),
+      else: {:error, :not_found}
+  end
+
   def get_routing_plan(%{table: table}, profile, chain_id) do
     case safe_lookup(table, {:routing_plan, profile, chain_id}) do
       [{_, %RoutingPlan{} = plan}] -> {:ok, plan}
       _other -> {:error, :not_found}
     end
+  end
+
+  @doc false
+  @spec routing_plans(:ets.tid()) :: %{{String.t(), pos_integer()} => RoutingPlan.t()}
+  def routing_plans(table) do
+    Map.new(
+      :ets.match_object(table, {{:routing_plan, :_, :_}, :_}),
+      fn {{:routing_plan, profile, chain_id}, %RoutingPlan{} = plan} ->
+        {{profile, chain_id}, plan}
+      end
+    )
   end
 
   @doc false
@@ -257,6 +280,15 @@ defmodule Lasso.Providers.Catalog do
   @spec snapshot() :: snapshot() | nil
   def snapshot do
     case :persistent_term.get(@persistent_term_key, nil) do
+      %{table: table, generation: generation, routing_plans: routing_plans} = snapshot
+      when not is_nil(table) and is_integer(generation) and generation >= 0 and
+             is_map(routing_plans) ->
+        snapshot
+
+      %{table: table, generation: generation} = snapshot
+      when not is_nil(table) and is_integer(generation) and generation >= 0 ->
+        snapshot
+
       {table, generation} when is_integer(generation) and generation >= 0 ->
         %{table: table, generation: generation}
 
@@ -293,6 +325,8 @@ defmodule Lasso.Providers.Catalog do
   rescue
     ArgumentError -> []
   end
+
+  defp table_available?(table), do: :ets.info(table, :size) != :undefined
 
   defp build_chain_entries(
          ets_table,

--- a/lib/lasso/providers/catalog/owner.ex
+++ b/lib/lasso/providers/catalog/owner.ex
@@ -147,13 +147,14 @@ defmodule Lasso.Providers.Catalog.Owner do
       :ets.delete(new_table)
       do_rebuild()
     else
+      routing_plans = Catalog.routing_plans(new_table)
       publication_barrier(:before_pointer_swap, generation)
 
       if ConfigStore.route_generation() != generation do
         :ets.delete(new_table)
         do_rebuild()
       else
-        publish(new_table, generation)
+        publish(new_table, generation, routing_plans)
       end
     end
   end
@@ -163,10 +164,17 @@ defmodule Lasso.Providers.Catalog.Owner do
     do_rebuild()
   end
 
-  defp publish(new_table, generation) do
+  defp publish(new_table, generation, routing_plans) do
     key = Catalog.persistent_term_key()
     old_table = Catalog.table()
-    :persistent_term.put(key, {new_table, generation})
+
+    snapshot = %{
+      table: new_table,
+      generation: generation,
+      routing_plans: routing_plans
+    }
+
+    :persistent_term.put(key, snapshot)
 
     if old_table, do: Process.send_after(self(), {:delete_table, old_table}, @grace_period_ms)
     :ok

--- a/test/lasso/providers/catalog_test.exs
+++ b/test/lasso/providers/catalog_test.exs
@@ -257,6 +257,75 @@ defmodule Lasso.Providers.CatalogTest do
       assert provider.config.capabilities == %{methods: ["eth_blockNumber"]}
       assert {"authorization", "Bearer secret"} in provider.config.headers
     end
+
+    test "reads a captured routing plan without copying it through ETS" do
+      register_chain(@profile_a, @chain_id, [
+        %{
+          id: "shared-plan",
+          name: "Shared Plan",
+          url: "https://shared-plan.example.com",
+          priority: 1
+        }
+      ])
+
+      Catalog.build_from_config()
+      snapshot = Catalog.snapshot()
+
+      :erlang.trace_pattern({:ets, :lookup, 2}, true, [:local])
+      :erlang.trace(self(), true, [:call])
+
+      on_exit(fn ->
+        :erlang.trace(self(), false, [:all])
+        :erlang.trace_pattern({:ets, :lookup, 2}, false, [:local])
+      end)
+
+      assert {:ok, %Lasso.RPC.RoutingPlan{}} =
+               Catalog.get_routing_plan(snapshot, @profile_a, @chain_id)
+
+      refute_receive {:trace, _pid, :call, {:ets, :lookup, _args}}
+
+      :erlang.trace(self(), false, [:all])
+      :erlang.trace_pattern({:ets, :lookup, 2}, false, [:local])
+    end
+
+    test "rejects a shared plan after its catalog table owner exits" do
+      register_chain(@profile_a, @chain_id, [
+        %{
+          id: "owner-bound-plan",
+          name: "Owner Bound Plan",
+          url: "https://owner-bound-plan.example.com",
+          priority: 1
+        }
+      ])
+
+      Catalog.build_from_config()
+      active = Catalog.snapshot()
+      assert {:ok, plan} = Catalog.get_routing_plan(active, @profile_a, @chain_id)
+
+      parent = self()
+
+      {owner, monitor} =
+        spawn_monitor(fn ->
+          table = :ets.new(:expired_catalog, [:set, :public])
+          send(parent, {:expired_catalog, self(), table})
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive {:expired_catalog, ^owner, table}
+      send(owner, :stop)
+      assert_receive {:DOWN, ^monitor, :process, ^owner, :normal}
+
+      expired = %{
+        table: table,
+        generation: active.generation,
+        routing_plans: %{{@profile_a, @chain_id} => plan}
+      }
+
+      assert {:error, :not_found} = Catalog.get_routing_plan(expired, @profile_a, @chain_id)
+    end
   end
 
   describe "lookup_instance_id/3" do


### PR DESCRIPTION
## Summary
- publish immutable routing plans inside the generation-fenced catalog snapshot
- read captured plans without copying the full provider plan through ETS on every request
- preserve the catalog table liveness check, legacy snapshot compatibility, and atomic publication semantics

## Local diagnostic
In a fixed-scheduler nine-provider priority-route diagnostic, median throughput increased about 13%, median request time fell about 12%, and reclaimed-word pressure fell about 21%. This is a local directional measurement, not a launch or cross-runtime claim. No benchmark artifacts are included.

## Validation
- `MIX_ENV=test mix test --include integration` (1,447 tests, 0 failures)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=dev mix dialyzer` (production pass; 26 existing ignored warnings)
- `MIX_ENV=test mix credo --strict`
- `mix format --check-formatted`
- `git diff --check`