### PR TITLE
Acknowledge Cowlib Link encoder advisory

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,8 +15,9 @@ defmodule Lasso.MixProject do
       dialyzer: dialyzer(),
       hex: [
         # Cowlib has no patched release for these encoder-only advisories. Lasso and its
-        # Cowboy/Plug stack do not call cow_cookie:cookie/1 or Cowlib's structured-header encoders.
-        ignore_advisories: ["CVE-2026-43966", "CVE-2026-43969"]
+        # Cowboy/Plug stack do not call cow_cookie:cookie/1, cow_link:link/1, or Cowlib's
+        # structured-header encoders.
+        ignore_advisories: ["CVE-2026-43966", "CVE-2026-43969", "CVE-2026-43971"]
       ]
     ]
   end


### PR DESCRIPTION
## Summary
- acknowledge CVE-2026-43971 in the existing Cowlib encoder-advisory policy
- document that Lasso does not call the affected `cow_link:link/1` encoder
- keep the acknowledgement temporary until Cowlib publishes a patched Hex release

## Rationale
The advisory affects applications that pass untrusted Link target, rel, or attribute-key fields into `cow_link:link/1`. Lasso and its Cowboy/Plug execution path do not call that encoder. Cowlib 2.19.0 is the latest Hex release and no patched release exists as of 2026-08-18.

## Validation
- `mix hex.audit` exits successfully and lists the advisory under ignored findings
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format mix.exs`
- `git diff --check`