### PR TITLE
Flatten candidate descriptor construction

### DIFF
--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -213,20 +213,16 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
   defp build_descriptors(plan, strategy, transport, filters) do
     exclude = MapSet.new(filters.exclude)
+    transports = transports_to_check(transport)
 
     descriptors =
-      plan.providers
-      |> Enum.reject(&MapSet.member?(exclude, &1.id))
-      |> Enum.filter(fn provider ->
-        (not filters.requires_archival or provider.archival) and
-          (not filters.requires_subscribe_new_heads or provider.subscribe_new_heads)
-      end)
-      |> Enum.flat_map(fn provider ->
-        transport
-        |> transports_to_check()
-        |> Enum.filter(&(&1 in provider.transports))
-        |> Enum.map(&{provider, &1})
-      end)
+      for provider <- plan.providers,
+          not MapSet.member?(exclude, provider.id),
+          not filters.requires_archival or provider.archival,
+          not filters.requires_subscribe_new_heads or provider.subscribe_new_heads,
+          protocol <- transports,
+          protocol in provider.transports,
+          do: {provider, protocol}
 
     case strategy do
       :priority ->


### PR DESCRIPTION
## Summary
- build candidate transport descriptors in one comprehension
- avoid intermediate reject/filter/flat-map lists and repeated transport expansion
- preserve priority and load-balanced ordering behavior

## Validation
- warnings-as-errors compilation
- 55 focused selection/integration tests
- strict Credo and diff check
- fixed `+S 4:4` descriptor diagnostic: ~43% fewer reductions and ~27% lower median wall time for the descriptor loop

This is a bounded OSS runtime change only; it makes no eRPC or launch-performance claim.