### PR TITLE
Reduce bounded identity validation cost

### DIFF
--- a/lib/lasso/core/request/bounded_identifier.ex
+++ b/lib/lasso/core/request/bounded_identifier.ex
@@ -7,7 +7,7 @@ defmodule Lasso.RPC.BoundedIdentifier do
 
   @spec encode(binary()) :: binary()
   def encode(value) when is_binary(value) do
-    if byte_size(value) <= @max_bytes and String.valid?(value) do
+    if byte_size(value) <= @max_bytes and valid_utf8?(value) do
       value
     else
       "sha256:" <> Base.url_encode64(:crypto.hash(:sha256, value), padding: false)
@@ -20,8 +20,12 @@ defmodule Lasso.RPC.BoundedIdentifier do
 
   @spec valid?(term()) :: boolean()
   def valid?(value),
-    do: is_binary(value) and byte_size(value) <= @max_bytes and String.valid?(value)
+    do: is_binary(value) and byte_size(value) <= @max_bytes and valid_utf8?(value)
 
   @spec max_bytes() :: pos_integer()
   def max_bytes, do: @max_bytes
+
+  defp valid_utf8?(value) do
+    is_binary(:unicode.characters_to_binary(value, :utf8, :utf8))
+  end
 end

--- a/lib/lasso/core/request/execution_fact.ex
+++ b/lib/lasso/core/request/execution_fact.ex
@@ -26,13 +26,7 @@ defmodule Lasso.RPC.ExecutionFact do
   @type dispatch_certainty :: :not_dispatched | :indeterminate | :dispatched
 
   @spec bounded!(term(), atom()) :: binary()
-  def bounded!(value, field) when is_binary(value) do
-    encoded = BoundedIdentifier.encode(value)
-
-    if BoundedIdentifier.valid?(encoded),
-      do: encoded,
-      else: raise(ArgumentError, "invalid #{field}")
-  end
+  def bounded!(value, _field) when is_binary(value), do: BoundedIdentifier.encode(value)
 
   def bounded!(_value, field), do: raise(ArgumentError, "#{field} must be a string")
 

--- a/test/lasso/core/request/execution_fact_test.exs
+++ b/test/lasso/core/request/execution_fact_test.exs
@@ -181,6 +181,22 @@ defmodule Lasso.RPC.ExecutionFactTest do
     refute id.request_id =~ "sensitive"
   end
 
+  test "invalid UTF-8 identifiers normalize to valid bounded hashes" do
+    invalid = <<0xFF, 0xFE, 0xFD>>
+    id = AttemptIdentity.new(Keyword.merge(Map.to_list(identity()), request_id: invalid))
+
+    assert id.request_id == Lasso.RPC.BoundedIdentifier.encode(invalid)
+    assert String.valid?(id.request_id)
+    assert byte_size(id.request_id) <= 128
+  end
+
+  test "bounded identifiers preserve valid multibyte UTF-8 at the byte limit" do
+    identifier = String.duplicate("é", 64)
+
+    assert Lasso.RPC.BoundedIdentifier.encode(identifier) == identifier
+    assert Lasso.RPC.BoundedIdentifier.valid?(identifier)
+  end
+
   test "execution plans and composite leases remain narrow and ordered" do
     plan =
       ExecutionPlan.new(


### PR DESCRIPTION
## Summary
- validate bounded UTF-8 identifiers once during normalization
- avoid re-validating the guaranteed-valid encoded result
- preserve invalid UTF-8 hashing and valid multibyte boundary behavior

## Validation
- warnings-as-errors compilation
- 89 focused execution fact, request owner, and pipeline tests
- strict Credo, formatting, and diff check
- fixed `+S 4:4` identifier diagnostic: common valid IDs fell from ~50.5 to ~13.5 reductions per normalization

This is a bounded OSS runtime change only; it includes no benchmark artifacts and makes no eRPC or launch-performance claim.