### PR TITLE
Reduce attempt identity construction overhead

### DIFF
--- a/lib/lasso/core/request/execution_fact.ex
+++ b/lib/lasso/core/request/execution_fact.ex
@@ -128,34 +128,61 @@ defmodule Lasso.RPC.AttemptIdentity do
 
   @spec new(keyword()) :: t()
   def new(attrs) when is_list(attrs) do
-    identity = struct!(__MODULE__, attrs)
+    normalize(struct!(__MODULE__, attrs))
+  end
 
-    normalized = %{
-      identity
-      | request_id: ExecutionFact.bounded!(identity.request_id, :request_id),
-        attempt_id: ExecutionFact.bounded!(identity.attempt_id, :attempt_id),
-        profile: ExecutionFact.bounded!(identity.profile, :profile),
-        subject_token: ExecutionFact.optional_bounded!(identity.subject_token, :subject_token),
-        chain_id: ExecutionFact.positive!(identity.chain_id, :chain_id),
-        upstream_instance_id:
-          ExecutionFact.bounded!(identity.upstream_instance_id, :upstream_instance_id),
-        transport: ExecutionFact.transport!(identity.transport),
-        route_generation:
-          ExecutionFact.non_negative!(identity.route_generation, :route_generation),
-        circuit_scope:
-          ExecutionFact.member!(identity.circuit_scope, :circuit_scope, @circuit_scopes),
-        circuit_epoch: ExecutionFact.non_negative!(identity.circuit_epoch, :circuit_epoch),
-        execution_safety: ExecutionFact.execution_safety!(identity.execution_safety),
-        routing_intent: ExecutionFact.bounded!(identity.routing_intent, :routing_intent),
-        workload_key: ExecutionFact.bounded!(identity.workload_key, :workload_key),
-        request_budget_ms:
-          ExecutionFact.non_negative!(identity.request_budget_ms, :request_budget_ms),
-        candidate_admission_count:
-          ExecutionFact.candidate_count!(identity.candidate_admission_count),
-        dispatch_count:
-          identity.dispatch_count
-          |> ExecutionFact.dispatch_count!()
-          |> ensure_positive_dispatch!()
+  @doc false
+  @spec new_runtime(map()) :: t()
+  def new_runtime(
+        %{
+          request_id: _,
+          attempt_id: _,
+          profile: _,
+          subject_token: _,
+          chain_id: _,
+          upstream_instance_id: _,
+          transport: _,
+          route_generation: _,
+          circuit_scope: _,
+          circuit_epoch: _,
+          execution_safety: _,
+          routing_intent: _,
+          workload_key: _,
+          request_budget_ms: _,
+          candidate_admission_count: _,
+          dispatch_count: _
+        } = attrs
+      )
+      when map_size(attrs) == 16,
+      do: normalize(attrs)
+
+  def new_runtime(_attrs), do: raise(ArgumentError, "invalid attempt identity attributes")
+
+  defp normalize(identity) do
+    normalized = %__MODULE__{
+      request_id: ExecutionFact.bounded!(identity.request_id, :request_id),
+      attempt_id: ExecutionFact.bounded!(identity.attempt_id, :attempt_id),
+      profile: ExecutionFact.bounded!(identity.profile, :profile),
+      subject_token: ExecutionFact.optional_bounded!(identity.subject_token, :subject_token),
+      chain_id: ExecutionFact.positive!(identity.chain_id, :chain_id),
+      upstream_instance_id:
+        ExecutionFact.bounded!(identity.upstream_instance_id, :upstream_instance_id),
+      transport: ExecutionFact.transport!(identity.transport),
+      route_generation: ExecutionFact.non_negative!(identity.route_generation, :route_generation),
+      circuit_scope:
+        ExecutionFact.member!(identity.circuit_scope, :circuit_scope, @circuit_scopes),
+      circuit_epoch: ExecutionFact.non_negative!(identity.circuit_epoch, :circuit_epoch),
+      execution_safety: ExecutionFact.execution_safety!(identity.execution_safety),
+      routing_intent: ExecutionFact.bounded!(identity.routing_intent, :routing_intent),
+      workload_key: ExecutionFact.bounded!(identity.workload_key, :workload_key),
+      request_budget_ms:
+        ExecutionFact.non_negative!(identity.request_budget_ms, :request_budget_ms),
+      candidate_admission_count:
+        ExecutionFact.candidate_count!(identity.candidate_admission_count),
+      dispatch_count:
+        identity.dispatch_count
+        |> ExecutionFact.dispatch_count!()
+        |> ensure_positive_dispatch!()
     }
 
     if normalized.candidate_admission_count == 0 or

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -694,7 +694,7 @@ defmodule Lasso.RPC.RequestPipeline do
   defp attempt_identity(channel, instance_id, ctx, receipt) do
     envelope = ctx.execution_envelope
 
-    AttemptIdentity.new(
+    AttemptIdentity.new_runtime(%{
       request_id: ctx.request_id,
       attempt_id: "#{envelope.execution_nonce}:#{envelope.candidate_admission_count}",
       profile: ctx.opts.profile,
@@ -711,7 +711,7 @@ defmodule Lasso.RPC.RequestPipeline do
       request_budget_ms: envelope.original_timeout_ms,
       candidate_admission_count: envelope.candidate_admission_count,
       dispatch_count: envelope.dispatch_count
-    )
+    })
   end
 
   defp commit_attempt_context(ctx, channel, instance_id, outcome) do

--- a/test/lasso/core/request/execution_fact_test.exs
+++ b/test/lasso/core/request/execution_fact_test.exs
@@ -190,6 +190,24 @@ defmodule Lasso.RPC.ExecutionFactTest do
     assert byte_size(id.request_id) <= 128
   end
 
+  test "runtime construction preserves validation without an intermediate struct" do
+    attrs = identity() |> Map.from_struct() |> Map.put(:request_id, String.duplicate("r", 1_000))
+
+    assert %AttemptIdentity{} = runtime = AttemptIdentity.new_runtime(attrs)
+    assert runtime.request_id == Lasso.RPC.BoundedIdentifier.encode(attrs.request_id)
+
+    assert_raise ArgumentError, ~r/invalid attempt identity attributes/, fn ->
+      attrs |> Map.delete(:dispatch_count) |> AttemptIdentity.new_runtime()
+    end
+
+    assert_raise ArgumentError, ~r/attempt counts are incoherent/, fn ->
+      attrs
+      |> Map.put(:candidate_admission_count, 1)
+      |> Map.put(:dispatch_count, 2)
+      |> AttemptIdentity.new_runtime()
+    end
+  end
+
   test "bounded identifiers preserve valid multibyte UTF-8 at the byte limit" do
     identifier = String.duplicate("é", 64)
 


### PR DESCRIPTION
## Summary
- construct runtime attempt identities directly from the already-shaped map
- retain all field, count, and bounded-identifier validation
- keep the keyword constructor for external and test callers

## Validation
- warnings-as-errors compilation
- 90 focused execution fact, request owner, and pipeline tests
- strict Credo, formatting, and diff check
- fixed `+S 4:4` actual-module diagnostic: ~238 -> ~114 reductions and roughly half the median construction time

This is a bounded OSS runtime change only; it contains no benchmark artifacts and makes no eRPC or launch-performance claim.