### PR TITLE
Reduce request terminal construction overhead

### DIFF
--- a/lib/lasso/core/request/execution_fact/terminals.ex
+++ b/lib/lasso/core/request/execution_fact/terminals.ex
@@ -289,7 +289,12 @@ end
 
 defmodule Lasso.RPC.RequestTerminal.UpstreamResponse do
   @moduledoc false
-  alias Lasso.RPC.{AttemptTerminal.Response, RequestTerminal.Common}
+  alias Lasso.RPC.{
+    AttemptIdentity,
+    AttemptTerminal.Response,
+    ExecutionFact,
+    RequestTerminal.Common
+  }
 
   @enforce_keys [
     :request_id,
@@ -324,6 +329,46 @@ defmodule Lasso.RPC.RequestTerminal.UpstreamResponse do
 
     unless coherent?, do: raise(ArgumentError, "request terminal and attempt identity disagree")
     struct!(__MODULE__, Map.put(normalized, :attempt, attempt))
+  end
+
+  @doc false
+  @spec new_runtime(
+          Response.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          binary() | nil
+        ) :: t()
+  def new_runtime(
+        %Response{identity: %AttemptIdentity{} = identity} = attempt,
+        elapsed_us,
+        candidate_admission_count,
+        dispatch_count,
+        observed_at
+      ) do
+    elapsed_us = ExecutionFact.non_negative!(elapsed_us, :elapsed_us)
+    candidate_admission_count = ExecutionFact.candidate_count!(candidate_admission_count)
+    dispatch_count = ExecutionFact.dispatch_count!(dispatch_count)
+    observed_at = ExecutionFact.optional_bounded!(observed_at, :observed_at)
+
+    unless candidate_admission_count == identity.candidate_admission_count and
+             dispatch_count == identity.dispatch_count,
+           do: raise(ArgumentError, "request terminal and attempt identity disagree")
+
+    %__MODULE__{
+      request_id: identity.request_id,
+      profile: identity.profile,
+      subject_token: identity.subject_token,
+      chain_id: identity.chain_id,
+      execution_safety: identity.execution_safety,
+      routing_intent: identity.routing_intent,
+      workload_key: identity.workload_key,
+      elapsed_us: elapsed_us,
+      candidate_admission_count: candidate_admission_count,
+      dispatch_count: dispatch_count,
+      observed_at: observed_at,
+      attempt: attempt
+    }
   end
 end
 

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -1105,7 +1105,7 @@ defmodule Lasso.RPC.RequestPipeline do
           public_response_attempt: %AttemptTerminal.Response{} = attempt
         } = ctx
       ) do
-    RequestTerminal.UpstreamResponse.new(request_terminal_attrs(ctx), attempt)
+    build_upstream_request_terminal(ctx, attempt)
   end
 
   def build_request_terminal(
@@ -1115,7 +1115,7 @@ defmodule Lasso.RPC.RequestPipeline do
           public_response_attempt: %AttemptTerminal.Response{} = attempt
         } = ctx
       ) do
-    RequestTerminal.UpstreamResponse.new(request_terminal_attrs(ctx), attempt)
+    build_upstream_request_terminal(ctx, attempt)
   end
 
   def build_request_terminal(
@@ -1145,6 +1145,18 @@ defmodule Lasso.RPC.RequestPipeline do
     RequestTerminal.LocalFailure.new(request_terminal_attrs(ctx), :internal)
   end
 
+  defp build_upstream_request_terminal(ctx, attempt) do
+    envelope = ctx.execution_envelope
+
+    RequestTerminal.UpstreamResponse.new_runtime(
+      attempt,
+      request_elapsed_us(envelope),
+      envelope.candidate_admission_count,
+      envelope.dispatch_count,
+      nil
+    )
+  end
+
   defp request_terminal_attrs(ctx) do
     envelope = ctx.execution_envelope
 
@@ -1156,11 +1168,15 @@ defmodule Lasso.RPC.RequestPipeline do
       execution_safety: envelope.execution_safety,
       routing_intent: Atom.to_string(ctx.opts.strategy),
       workload_key: request_workload_key(ctx),
-      elapsed_us: max(System.monotonic_time(:microsecond) - envelope.started_at_us, 0),
+      elapsed_us: request_elapsed_us(envelope),
       candidate_admission_count: envelope.candidate_admission_count,
       dispatch_count: envelope.dispatch_count,
       observed_at: nil
     ]
+  end
+
+  defp request_elapsed_us(envelope) do
+    max(System.monotonic_time(:microsecond) - envelope.started_at_us, 0)
   end
 
   defp final_exhaustion_reason(%RequestContext{terminal_reason: reason})

--- a/test/lasso/core/request/execution_fact_test.exs
+++ b/test/lasso/core/request/execution_fact_test.exs
@@ -95,6 +95,47 @@ defmodule Lasso.RPC.ExecutionFactTest do
              RequestTerminal.OrdinaryExhaustion.new(request_attrs(), :providers_exhausted)
   end
 
+  test "runtime upstream response construction preserves the validated public shape" do
+    response = AttemptTerminal.Response.new(identity(), :success, 20)
+
+    assert RequestTerminal.UpstreamResponse.new_runtime(
+             response,
+             50_000,
+             2,
+             1,
+             "2026-08-13T20:00:00Z"
+           ) == RequestTerminal.UpstreamResponse.new(request_attrs(), response)
+  end
+
+  test "runtime upstream response construction retains boundary validation" do
+    response = AttemptTerminal.Response.new(identity(), :success, 20)
+
+    assert_raise ArgumentError, ~r/identity disagree/, fn ->
+      RequestTerminal.UpstreamResponse.new_runtime(response, 50_000, 3, 1, nil)
+    end
+
+    assert_raise ArgumentError, ~r/identity disagree/, fn ->
+      RequestTerminal.UpstreamResponse.new_runtime(response, 50_000, 2, 2, nil)
+    end
+
+    assert_raise ArgumentError, ~r/elapsed_us must be non-negative/, fn ->
+      RequestTerminal.UpstreamResponse.new_runtime(response, -1, 2, 1, nil)
+    end
+
+    long_observed_at = String.duplicate("observed-at/", 1_000)
+
+    assert %{observed_at: observed_at} =
+             RequestTerminal.UpstreamResponse.new_runtime(
+               response,
+               50_000,
+               2,
+               1,
+               long_observed_at
+             )
+
+    assert byte_size(observed_at) <= 128
+  end
+
   test "illegal combinations are rejected by tagged constructors" do
     assert_raise ArgumentError, ~r/successful responses/, fn ->
       AttemptTerminal.Response.new(identity(), :success, 20, error_code: -1)


### PR DESCRIPTION
## Summary
- build upstream request terminals directly from the already-validated attempt identity
- preserve elapsed-time, count-coherence, and bounded timestamp validation
- retain the general keyword constructor for external callers and other terminal variants

## Validation
- warnings-as-errors compilation
- 92 focused execution fact, request owner, and pipeline tests
- strict Credo, formatting, and diff check
- fixed `+S 4:4` actual-module diagnostic: ~242 -> ~12.5 reductions and ~0.59 -> ~0.054 microseconds per upstream terminal construction

This is a bounded OSS runtime change only; it contains no benchmark artifacts and makes no eRPC or launch-performance claim.