### PR TITLE
Reduce candidate routing gate overhead

### DIFF
--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -286,11 +286,11 @@ defmodule Lasso.Providers.CandidateListing do
     http_routing = route_record(learned_scope, instance_id, :http, transports)
     ws_routing = route_record(learned_scope, instance_id, :ws, transports)
 
-    http_cb = circuit_state(instance_id, :http, transports)
-    ws_cb = circuit_state(instance_id, :ws, transports)
+    {http_cb, http_rl} =
+      candidate_gate(instance_id, :http, transports, include_learned?, http_routing)
 
-    http_rl = rate_limit(instance_id, :http, transports, include_learned?, http_routing)
-    ws_rl = rate_limit(instance_id, :ws, transports, include_learned?, ws_routing)
+    {ws_cb, ws_rl} =
+      candidate_gate(instance_id, :ws, transports, include_learned?, ws_routing)
 
     candidate = %{
       id: provider.id,
@@ -300,8 +300,8 @@ defmodule Lasso.Providers.CandidateListing do
       transports: transports,
       routing_states: %{http: http_routing, ws: ws_routing},
       workload_key: workload_key,
-      circuit_state: %{http: http_cb.state, ws: ws_cb.state},
-      rate_limited: %{http: http_rl.rate_limited, ws: ws_rl.rate_limited},
+      circuit_state: %{http: http_cb, ws: ws_cb},
+      rate_limited: %{http: http_rl, ws: ws_rl},
       learned_feedback_degraded?: learned_scope.degraded?
     }
 
@@ -353,20 +353,11 @@ defmodule Lasso.Providers.CandidateListing do
       else: nil
   end
 
-  defp circuit_state(instance_id, transport, transports) do
-    if transport in transports,
-      do: InstanceState.read_circuit(instance_id, transport),
-      else: %{state: :unavailable}
-  end
-
-  defp rate_limit(instance_id, transport, transports, include_learned?, routing) do
+  defp candidate_gate(instance_id, transport, transports, include_learned?, routing) do
     if transport in transports do
-      InstanceState.read_rate_limit(instance_id, transport,
-        include_learned: include_learned?,
-        routing_state: routing
-      )
+      InstanceState.read_candidate_gate(instance_id, transport, routing, include_learned?)
     else
-      %{rate_limited: false}
+      {:unavailable, false}
     end
   end
 

--- a/lib/lasso/providers/instance_state.ex
+++ b/lib/lasso/providers/instance_state.ex
@@ -179,29 +179,73 @@ defmodule Lasso.Providers.InstanceState do
   @spec read_circuit(String.t(), :http | :ws) :: map()
   def read_circuit(instance_id, transport)
       when is_binary(instance_id) and transport in [:http, :ws] do
-    case Snapshot.lookup({instance_id, transport}) do
-      {:ok, %{owner_pid: owner_pid, ready?: true} = snapshot} when is_pid(owner_pid) ->
-        if Process.alive?(owner_pid) do
-          state =
-            if snapshot.control_health == :degraded,
-              do: :half_open,
-              else: snapshot.state
+    case live_circuit_snapshot(instance_id, transport) do
+      {:ok, snapshot} ->
+        %{
+          state: effective_circuit_state(snapshot),
+          error: nil,
+          recovery_deadline_ms: recovery_deadline_ms(snapshot.recovery_deadline_us),
+          control_health: snapshot.control_health
+        }
 
-          %{
-            state: state,
-            error: nil,
-            recovery_deadline_ms: recovery_deadline_ms(snapshot.recovery_deadline_us),
-            control_health: snapshot.control_health
-          }
-        else
-          @default_circuit
-        end
-
-      _ ->
+      :unavailable ->
         @default_circuit
     end
   rescue
     ArgumentError -> @default_circuit
+  end
+
+  @doc false
+  @spec read_candidate_gate(String.t(), :http | :ws, map() | nil, boolean()) ::
+          {atom(), boolean()}
+  def read_candidate_gate(instance_id, transport, routing_state, include_learned?)
+      when is_binary(instance_id) and transport in [:http, :ws] and
+             is_boolean(include_learned?) do
+    circuit_state =
+      case live_circuit_snapshot(instance_id, transport) do
+        {:ok, snapshot} -> effective_circuit_state(snapshot)
+        :unavailable -> :unavailable
+      end
+
+    {circuit_state,
+     candidate_rate_limited?(instance_id, transport, routing_state, include_learned?)}
+  rescue
+    ArgumentError -> {:unavailable, false}
+  end
+
+  defp live_circuit_snapshot(instance_id, transport) do
+    case Snapshot.lookup({instance_id, transport}) do
+      {:ok, %{owner_pid: owner_pid, ready?: true} = snapshot} when is_pid(owner_pid) ->
+        if Process.alive?(owner_pid), do: {:ok, snapshot}, else: :unavailable
+
+      _other ->
+        :unavailable
+    end
+  end
+
+  defp effective_circuit_state(%{control_health: :degraded}), do: :half_open
+  defp effective_circuit_state(snapshot), do: snapshot.state
+
+  defp candidate_rate_limited?(instance_id, transport, routing_state, include_learned?) do
+    now_ms = System.monotonic_time(:millisecond)
+
+    learned_limited? =
+      case routing_state do
+        %{rate_limit_expiry_ms: expiry, rate_limit_observed_at_us: observed_at_us}
+        when include_learned? and is_integer(observed_at_us) and expiry > now_ms ->
+          true
+
+        _other ->
+          false
+      end
+
+    local_limited? =
+      case safe_lookup({:rate_limit, instance_id, transport}) do
+        [{_, %{expiry_ms: expiry}}] when expiry > now_ms -> true
+        _other -> false
+      end
+
+    learned_limited? or local_limited?
   end
 
   defp recovery_deadline_ms(nil), do: nil

--- a/test/lasso/providers/instance_state_test.exs
+++ b/test/lasso/providers/instance_state_test.exs
@@ -2,7 +2,7 @@ defmodule Lasso.Providers.InstanceStateTest do
   use ExUnit.Case, async: false
 
   alias Lasso.Core.Support.CircuitBreaker
-  alias Lasso.Core.Support.CircuitBreaker.{ControlRing, Storage}
+  alias Lasso.Core.Support.CircuitBreaker.{ControlRing, Snapshot, Storage}
   alias Lasso.Providers.InstanceState
 
   @table :lasso_instance_state
@@ -14,6 +14,8 @@ defmodule Lasso.Providers.InstanceStateTest do
         :ets.delete(@table, {:health_probe, @instance_id})
         :ets.delete(@table, {:health_block_sync, @instance_id})
         :ets.delete(@table, {:health_routing, @instance_id})
+        :ets.delete(@table, {:rate_limit, @instance_id, :http})
+        :ets.delete(Storage.snapshot_table(), {@instance_id, :http})
       rescue
         ArgumentError -> :ok
       end
@@ -215,6 +217,77 @@ defmodule Lasso.Providers.InstanceStateTest do
     end
   end
 
+  describe "read_candidate_gate/4" do
+    test "matches unavailable circuit and inactive rate-limit defaults" do
+      routing_state = %{rate_limit_expiry_ms: 0, rate_limit_observed_at_us: nil}
+
+      assert {:unavailable, false} =
+               InstanceState.read_candidate_gate(@instance_id, :http, routing_state, true)
+    end
+
+    test "matches live circuit state and local rate-limit state" do
+      put_circuit_snapshot(:closed)
+      expiry_ms = System.monotonic_time(:millisecond) + 10_000
+
+      :ets.insert(
+        @table,
+        {{:rate_limit, @instance_id, :http}, %{expiry_ms: expiry_ms}}
+      )
+
+      routing_state = %{rate_limit_expiry_ms: 0, rate_limit_observed_at_us: nil}
+
+      assert {:closed, true} =
+               InstanceState.read_candidate_gate(@instance_id, :http, routing_state, true)
+
+      assert %{state: :closed} = InstanceState.read_circuit(@instance_id, :http)
+
+      assert %{rate_limited: true} =
+               InstanceState.read_rate_limit(@instance_id, :http,
+                 include_learned: true,
+                 routing_state: routing_state
+               )
+    end
+
+    test "maps degraded circuit control to half-open" do
+      put_circuit_snapshot(:closed, :degraded)
+
+      assert {:half_open, false} =
+               InstanceState.read_candidate_gate(@instance_id, :http, nil, true)
+    end
+
+    test "uses only observed active learned rate limits when enabled" do
+      put_circuit_snapshot(:closed)
+      expiry_ms = System.monotonic_time(:millisecond) + 10_000
+
+      observed = %{
+        rate_limit_expiry_ms: expiry_ms,
+        rate_limit_observed_at_us: System.monotonic_time(:microsecond)
+      }
+
+      unobserved = %{rate_limit_expiry_ms: expiry_ms, rate_limit_observed_at_us: nil}
+
+      assert {:closed, true} =
+               InstanceState.read_candidate_gate(@instance_id, :http, observed, true)
+
+      assert {:closed, false} =
+               InstanceState.read_candidate_gate(@instance_id, :http, observed, false)
+
+      assert {:closed, false} =
+               InstanceState.read_candidate_gate(@instance_id, :http, unobserved, true)
+    end
+
+    test "treats a dead circuit owner as unavailable" do
+      owner = spawn(fn -> receive do: (:stop -> :ok) end)
+      put_circuit_snapshot(:closed, :healthy, owner)
+      Process.exit(owner, :kill)
+
+      refute Process.alive?(owner)
+
+      assert {:unavailable, false} =
+               InstanceState.read_candidate_gate(@instance_id, :http, nil, true)
+    end
+  end
+
   test "clear removes every application-owned breaker row for the instance" do
     id = {@instance_id, :http}
     {:ok, pid} = CircuitBreaker.start_link({id, %{control_ring_capacity: 4}})
@@ -260,5 +333,20 @@ defmodule Lasso.Providers.InstanceStateTest do
       )
 
     :ets.insert(@table, {{:health_routing, @instance_id}, data})
+  end
+
+  defp put_circuit_snapshot(state, control_health \\ :healthy, owner_pid \\ self()) do
+    Snapshot.put(%Snapshot{
+      breaker_id: {@instance_id, :http},
+      state: state,
+      generation: 1,
+      epoch: 1,
+      owner_pid: owner_pid,
+      ready?: true,
+      recovery_deadline_us: nil,
+      half_open_capacity: 1,
+      half_open_inflight: 0,
+      control_health: control_health
+    })
   end
 end


### PR DESCRIPTION
## Summary
- add a compact candidate-only circuit/rate-limit read that preserves request-time liveness and learned-rate-limit fencing
- reuse the circuit snapshot logic for the existing detailed read API
- avoid temporary maps, keyword lists, and expiry collections while building routing candidates

## Validation
- warnings-as-errors compile
- 57 focused InstanceState/CandidateListing tests
- full non-integration test suite
- strict Credo on changed files
- format and diff checks

## Performance rationale
A fixed-scheduler local microbenchmark of one live candidate transport gate measured roughly 442 -> 251 reductions (-43%) and 1.0us -> 0.65us (-35%). This is diagnostic evidence only; no benchmark artifacts or cross-project comparisons are included in the PR.