### PR TITLE
Reduce transient projection encoding overhead

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -152,7 +152,7 @@ defmodule Lasso.RPC.AttemptProjection do
 
   @spec encode(t()) :: {:ok, binary()} | {:error, :invalid_event | :event_too_large}
   def encode(%__MODULE__{} = event) do
-    payload = :erlang.term_to_binary({@schema, @version, event}, [:deterministic])
+    payload = :erlang.term_to_binary({@schema, @version, event})
 
     if byte_size(payload) <= @max_bytes,
       do: {:ok, payload},

--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -103,21 +103,18 @@ defmodule Lasso.RPC.RequestProjection do
 
   defp encode_validated(event) do
     payload =
-      :erlang.term_to_binary(
-        {
-          @schema,
-          @version,
-          event.fact,
-          event.method,
-          event.provider_id,
-          event.instance_id,
-          event.transport,
-          event.request_origin,
-          event.failover_count,
-          event.emitted_at_ms
-        },
-        [:deterministic]
-      )
+      :erlang.term_to_binary({
+        @schema,
+        @version,
+        event.fact,
+        event.method,
+        event.provider_id,
+        event.instance_id,
+        event.transport,
+        event.request_origin,
+        event.failover_count,
+        event.emitted_at_ms
+      })
 
     if byte_size(payload) <= @max_bytes,
       do: {:ok, payload},


### PR DESCRIPTION
## Summary

- encode transient request and attempt projection envelopes without deterministic term ordering
- preserve the existing bounded binary format, schema/version tags, safe decoding, and lane byte limits
- keep diagnostic delivery and routing behavior unchanged

These payloads are process-local, short-lived queue messages. They are not hashed, persisted, or compared byte-for-byte, so deterministic map ordering adds CPU cost without providing a contract benefit.

## Verification

- warnings-as-errors compilation
- 51 focused projection/lane tests
- full integration-enabled test suite
- strict Credo on changed files
- formatting and diff checks
- fixed-scheduler encoder diagnostic: projection encoding ~3.0us to ~1.3us; complete c1 request path ~2-3% faster

No benchmark harnesses, comparison modules, or result artifacts are included.