### PR TITLE
Tighten diagnostic projection bounds

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -182,7 +182,7 @@ defmodule Lasso.RPC.AttemptProjection do
       diagnostics:
         lane_options(
           &__MODULE__.deliver_diagnostics/2,
-          [capacity: 2_048, scope_capacity: 64, max_age_ms: 2_000],
+          [capacity: 128, scope_capacity: 32, max_age_ms: 2_000],
           Keyword.get(configured, :diagnostics, [])
         )
     ]

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -37,8 +37,8 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     lanes = AttemptProjection.lane_configs()
 
     assert Keyword.keys(lanes) == [:diagnostics]
-    assert lanes[:diagnostics][:capacity] == 2_048
-    assert lanes[:diagnostics][:scope_capacity] == 64
+    assert lanes[:diagnostics][:capacity] == 128
+    assert lanes[:diagnostics][:scope_capacity] == 32
   end
 
   test "projection payload round trips as one bounded canonical fact" do


### PR DESCRIPTION
## Summary

- reduce the optional diagnostics lane global capacity from 2,048 to 128 items
- retain 32 slots per scope to avoid hot-scope producer contention
- reduce bounded diagnostic retention from 8 MiB to 512 KiB globally and from 256 KiB to 128 KiB per scope
- preserve explicit, counted shedding and the existing two-second maximum age

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test --include integration` (1,459 tests, 0 failures)
- `mix credo --strict`
- CI-equivalent dev `mix dialyzer --format github`
- paired real HTTP loopback checks at c32 and c128 showed no contention regression with the 32-slot scope geometry

This PR contains only the runtime bound adjustment and its contract test.