### PR TITLE
Compact successful request diagnostics

### DIFF
--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -5,6 +5,8 @@ defmodule Lasso.RPC.RequestProjection do
   alias Lasso.Events.RoutingDecision
 
   alias Lasso.RPC.{
+    AttemptIdentity,
+    AttemptTerminal,
     ExecutionFact,
     ExecutionProjector,
     RequestTerminal
@@ -106,7 +108,7 @@ defmodule Lasso.RPC.RequestProjection do
       :erlang.term_to_binary({
         @schema,
         @version,
-        event.fact,
+        encode_fact_payload(event.fact),
         event.method,
         event.provider_id,
         event.instance_id,
@@ -175,9 +177,100 @@ defmodule Lasso.RPC.RequestProjection do
   defp decode_fact_payload(fact_payload) when is_binary(fact_payload),
     do: Codec.decode(fact_payload)
 
+  defp decode_fact_payload({
+         :compact_success_v1,
+         request_id,
+         attempt_id,
+         profile,
+         subject_token,
+         chain_id,
+         upstream_instance_id,
+         transport,
+         route_generation,
+         circuit_scope,
+         circuit_epoch,
+         execution_safety,
+         routing_intent,
+         workload_key,
+         request_budget_ms,
+         candidate_admission_count,
+         dispatch_count,
+         elapsed_us,
+         io_duration_us,
+         observed_at
+       }) do
+    identity =
+      AttemptIdentity.new_runtime(%{
+        request_id: request_id,
+        attempt_id: attempt_id,
+        profile: profile,
+        subject_token: subject_token,
+        chain_id: chain_id,
+        upstream_instance_id: upstream_instance_id,
+        transport: transport,
+        route_generation: route_generation,
+        circuit_scope: circuit_scope,
+        circuit_epoch: circuit_epoch,
+        execution_safety: execution_safety,
+        routing_intent: routing_intent,
+        workload_key: workload_key,
+        request_budget_ms: request_budget_ms,
+        candidate_admission_count: candidate_admission_count,
+        dispatch_count: dispatch_count
+      })
+
+    attempt = AttemptTerminal.Response.new(identity, :success, io_duration_us)
+
+    {:ok,
+     RequestTerminal.UpstreamResponse.new_runtime(
+       attempt,
+       elapsed_us,
+       candidate_admission_count,
+       dispatch_count,
+       observed_at
+     )}
+  rescue
+    ArgumentError -> {:error, :invalid_fact}
+  end
+
   defp decode_fact_payload(%_module{} = fact), do: {:ok, fact}
 
   defp decode_fact_payload(_fact_payload), do: {:error, :invalid_fact}
+
+  defp encode_fact_payload(
+         %RequestTerminal.UpstreamResponse{
+           attempt: %AttemptTerminal.Response{
+             kind: :success,
+             identity: %AttemptIdentity{} = identity,
+             io_duration_us: io_duration_us
+           }
+         } = fact
+       ) do
+    {
+      :compact_success_v1,
+      identity.request_id,
+      identity.attempt_id,
+      identity.profile,
+      identity.subject_token,
+      identity.chain_id,
+      identity.upstream_instance_id,
+      identity.transport,
+      identity.route_generation,
+      identity.circuit_scope,
+      identity.circuit_epoch,
+      identity.execution_safety,
+      identity.routing_intent,
+      identity.workload_key,
+      identity.request_budget_ms,
+      identity.candidate_admission_count,
+      identity.dispatch_count,
+      fact.elapsed_us,
+      io_duration_us,
+      fact.observed_at
+    }
+  end
+
+  defp encode_fact_payload(fact), do: fact
 
   @spec routing_decision(t()) :: {:ok, RoutingDecision.t()} | :not_routed
   def routing_decision(%__MODULE__{provider_id: provider_id, transport: transport} = event)

--- a/test/lasso/core/request/request_projection_test.exs
+++ b/test/lasso/core/request/request_projection_test.exs
@@ -70,15 +70,38 @@ defmodule Lasso.RPC.RequestProjectionTest do
     assert {:ok, ^event} = RequestProjection.decode(payload)
   end
 
-  test "native facts avoid a JSON round trip while queued JSON facts remain compatible" do
+  test "successful facts use the compact envelope while legacy facts remain compatible" do
     event = request_projection()
 
     assert {:ok, native_payload} = RequestProjection.encode(event)
 
-    assert {:lasso_request_projection, 1, %RequestTerminal.UpstreamResponse{}, _method,
-            _provider_id, _instance_id, _transport, _origin, _failovers,
+    assert {:lasso_request_projection, 1, compact_fact, _method, _provider_id, _instance_id,
+            _transport, _origin, _failovers,
             _emitted_at_ms} =
              :erlang.binary_to_term(native_payload, [:safe])
+
+    assert elem(compact_fact, 0) == :compact_success_v1
+    assert tuple_size(compact_fact) == 20
+    assert byte_size(native_payload) <= 384
+
+    native_fact_payload =
+      :erlang.term_to_binary(
+        {
+          :lasso_request_projection,
+          1,
+          event.fact,
+          event.method,
+          event.provider_id,
+          event.instance_id,
+          event.transport,
+          event.request_origin,
+          event.failover_count,
+          event.emitted_at_ms
+        },
+        [:deterministic]
+      )
+
+    assert {:ok, ^event} = RequestProjection.decode(native_fact_payload)
 
     legacy_payload =
       :erlang.term_to_binary(
@@ -98,6 +121,76 @@ defmodule Lasso.RPC.RequestProjectionTest do
       )
 
     assert {:ok, ^event} = RequestProjection.decode(legacy_payload)
+  end
+
+  test "application errors retain their complete native classification" do
+    attempt =
+      AttemptTerminal.Response.new(identity(), :application_error, 7_000,
+        error_code: -32_005,
+        error_category: :provider_failure,
+        retry_after_ms: 250
+      )
+
+    fact =
+      RequestTerminal.UpstreamResponse.new(
+        [
+          request_id: attempt.identity.request_id,
+          profile: attempt.identity.profile,
+          subject_token: nil,
+          chain_id: attempt.identity.chain_id,
+          execution_safety: attempt.identity.execution_safety,
+          routing_intent: attempt.identity.routing_intent,
+          workload_key: attempt.identity.workload_key,
+          elapsed_us: 12_345,
+          candidate_admission_count: attempt.identity.candidate_admission_count,
+          dispatch_count: attempt.identity.dispatch_count,
+          observed_at: nil
+        ],
+        attempt
+      )
+
+    event =
+      RequestProjection.new(
+        fact,
+        "eth_blockNumber",
+        %{provider_id: "provider-a", instance_id: "instance-a", transport: :http},
+        2
+      )
+
+    assert {:ok, payload} = RequestProjection.encode(event)
+
+    assert {:lasso_request_projection, 1, %RequestTerminal.UpstreamResponse{}, _, _, _, _, _, _,
+            _} =
+             :erlang.binary_to_term(payload, [:safe])
+
+    assert {:ok, ^event} = RequestProjection.decode(payload)
+  end
+
+  test "malformed compact success facts fail closed" do
+    event = request_projection()
+    assert {:ok, payload} = RequestProjection.encode(event)
+
+    {:lasso_request_projection, 1, compact_fact, method, provider_id, instance_id, transport,
+     origin, failovers, emitted_at_ms} = :erlang.binary_to_term(payload, [:safe])
+
+    payload =
+      :erlang.term_to_binary(
+        {
+          :lasso_request_projection,
+          1,
+          put_elem(compact_fact, 5, 0),
+          method,
+          provider_id,
+          instance_id,
+          transport,
+          origin,
+          failovers,
+          emitted_at_ms
+        },
+        [:deterministic]
+      )
+
+    assert {:error, :invalid_fact} = RequestProjection.decode(payload)
   end
 
   test "routing decision preserves canonical request and final route identity" do


### PR DESCRIPTION
## Summary
- encode successful request-terminal diagnostics as a compact validated tuple
- preserve native non-success facts and both legacy native/codec decode paths
- reject malformed compact facts through canonical constructors

## Validation
- `MIX_ENV=test mix test --include integration` (1,461 tests, 0 failures)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix credo --strict`
- `MIX_ENV=dev mix dialyzer --format short`
- `git diff --check`