### PR TITLE
Prepare request contexts once

### DIFF
--- a/lib/lasso/core/request/request_context.ex
+++ b/lib/lasso/core/request/request_context.ex
@@ -150,8 +150,10 @@ defmodule Lasso.RPC.RequestContext do
   If :request_id is provided in opts, it will be used (typically from Phoenix's Plug.RequestId).
   Otherwise, a new request_id will be generated.
   """
-  @spec new(pos_integer(), String.t(), list(), keyword()) :: t()
-  def new(chain_id, method, params, opts \\ []) do
+  @spec new(pos_integer(), String.t(), list(), keyword() | RequestOptions.t()) :: t()
+  def new(chain_id, method, params, opts \\ [])
+
+  def new(chain_id, method, params, opts) when is_list(opts) do
     request_id = bounded_request_id(Keyword.get(opts, :request_id))
 
     plug_start = Keyword.get(opts, :plug_start_time)
@@ -169,6 +171,21 @@ defmodule Lasso.RPC.RequestContext do
       user_agent: Keyword.get(opts, :user_agent),
       plug_start_time: plug_start,
       start_time: start_time
+    }
+  end
+
+  def new(chain_id, method, params, %RequestOptions{} = opts) do
+    plug_start = opts.plug_start_time
+
+    %__MODULE__{
+      request_id: bounded_request_id(opts.request_id),
+      chain_id: chain_id,
+      method: method,
+      params: params,
+      transport: opts.transport || :http,
+      strategy: opts.strategy,
+      plug_start_time: plug_start,
+      start_time: plug_start || System.monotonic_time(:microsecond)
     }
   end
 
@@ -207,8 +224,25 @@ defmodule Lasso.RPC.RequestContext do
         deadline_us
       )
       when is_map(rpc_request) and is_integer(timeout_ms) do
-    ctx = %{ctx | request_id: bounded_request_id(ctx.request_id)}
+    ctx
+    |> bound_request_id()
+    |> put_execution_params(rpc_request, timeout_ms, opts, deadline_us)
+  end
 
+  @doc false
+  @spec initialize_execution(t(), map(), integer(), RequestOptions.t(), integer() | nil) :: t()
+  def initialize_execution(
+        %__MODULE__{} = ctx,
+        rpc_request,
+        timeout_ms,
+        %RequestOptions{} = opts,
+        deadline_us
+      )
+      when is_map(rpc_request) and is_integer(timeout_ms) do
+    put_execution_params(ctx, rpc_request, timeout_ms, opts, deadline_us)
+  end
+
+  defp put_execution_params(ctx, rpc_request, timeout_ms, opts, deadline_us) do
     envelope =
       case ctx.execution_envelope do
         %ExecutionEnvelope{} = envelope ->

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -131,13 +131,12 @@ defmodule Lasso.RPC.RequestPipeline do
   end
 
   defp execute_owned_request(execution_scope, caller_guard, chain_id, method, params, opts) do
-    ctx =
-      chain_id |> initialize_context(method, params, opts) |> RequestContext.bound_request_id()
+    ctx = initialize_context(chain_id, method, params, opts)
 
     rpc_request = build_rpc_request(method, params, ctx, opts)
 
     ctx =
-      RequestContext.set_execution_params(
+      RequestContext.initialize_execution(
         ctx,
         rpc_request,
         opts.timeout_ms,
@@ -1249,13 +1248,10 @@ defmodule Lasso.RPC.RequestPipeline do
   @spec initialize_context(chain_id(), method(), params(), RequestOptions.t()) ::
           RequestContext.t()
   defp initialize_context(chain_id, method, params, opts) do
-    opts.request_context ||
-      RequestContext.new(chain_id, method, params,
-        transport: opts.transport || :http,
-        strategy: opts.strategy,
-        request_id: opts.request_id,
-        plug_start_time: opts.plug_start_time
-      )
+    case opts.request_context do
+      %RequestContext{} = ctx -> RequestContext.bound_request_id(ctx)
+      nil -> RequestContext.new(chain_id, method, params, opts)
+    end
   end
 
   @spec build_rpc_request(method(), params(), RequestContext.t(), RequestOptions.t()) :: map()

--- a/test/lasso/core/request/byte_budget_test.exs
+++ b/test/lasso/core/request/byte_budget_test.exs
@@ -47,7 +47,8 @@ defmodule Lasso.Core.Request.ByteBudgetTest do
 
     monitor = Process.monitor(owner)
     assert_receive {:reserved, _reservation}
-    assert_receive {:DOWN, ^monitor, :process, ^owner, :normal}
+    assert_receive {:DOWN, ^monitor, :process, ^owner, reason}
+    assert reason in [:normal, :noproc]
 
     send(ByteBudget, :audit)
     await_empty()

--- a/test/lasso/core/request/request_context_test.exs
+++ b/test/lasso/core/request/request_context_test.exs
@@ -1,7 +1,27 @@
 defmodule Lasso.RPC.RequestContextTest do
   use ExUnit.Case, async: true
 
-  alias Lasso.RPC.{BoundedIdentifier, Channel, RequestContext}
+  alias Lasso.RPC.{BoundedIdentifier, Channel, RequestContext, RequestOptions}
+
+  test "typed options initialize a bounded request context directly" do
+    request_id = String.duplicate("request-id", 100)
+    plug_start = System.monotonic_time(:microsecond)
+
+    context =
+      RequestContext.new(1, "eth_chainId", [], %RequestOptions{
+        timeout_ms: 100,
+        request_id: request_id,
+        transport: nil,
+        strategy: :fastest,
+        plug_start_time: plug_start
+      })
+
+    assert context.request_id == BoundedIdentifier.encode(request_id)
+    assert context.transport == :http
+    assert context.strategy == :fastest
+    assert context.start_time == plug_start
+    assert context.plug_start_time == plug_start
+  end
 
   test "selection stores a bounded channel identity before any attempt executes" do
     provider_id = String.duplicate("provider-a", 32)

--- a/test/lasso/core/request/request_pipeline_test.exs
+++ b/test/lasso/core/request/request_pipeline_test.exs
@@ -77,6 +77,22 @@ defmodule Lasso.RPC.RequestPipelineTest do
       assert returned_ctx.strategy == :fastest
     end
 
+    test "bounds a provided RequestContext before execution" do
+      request_id = String.duplicate("external-request", 100)
+      custom_ctx = %{RequestContext.new(1, "eth_call", []) | request_id: request_id}
+
+      result =
+        RequestPipeline.execute_via_channels(1, "eth_call", [], %RequestOptions{
+          profile: "public",
+          strategy: :fastest,
+          timeout_ms: 30_000,
+          request_context: custom_ctx
+        })
+
+      returned_ctx = extract_context(result)
+      assert returned_ctx.request_id == Lasso.RPC.BoundedIdentifier.encode(request_id)
+    end
+
     test "handles empty params" do
       result =
         RequestPipeline.execute_via_channels(1, "eth_blockNumber", [], %RequestOptions{


### PR DESCRIPTION
## Summary
- initialize request contexts directly from typed request options
- bound request identifiers once before the pipeline initializes its execution envelope
- harden the byte-budget owner-death test against the valid monitor-after-exit `:noproc` race

## Validation
- `mix test --include integration` (1,463 tests, 0 failures)
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix dialyzer`
- `git diff --check`

## Scope
Runtime and focused regression coverage only. No benchmark harnesses or eRPC comparison material are included.