### PR TITLE
Bound successful routing detail delivery

### DIFF
--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -18,6 +18,8 @@ defmodule Lasso.RPC.RequestProjection do
   @version 1
   @max_bytes 4_096
   @dispatcher Lasso.ExecutionProjectionDispatcher
+  @routing_decisions_per_second 256
+  @routing_budget_buckets 256
 
   @enforce_keys [:version, :fact, :method, :request_origin, :failover_count, :emitted_at_ms]
   defstruct @enforce_keys ++ [:provider_id, :instance_id, :transport]
@@ -306,12 +308,51 @@ defmodule Lasso.RPC.RequestProjection do
   end
 
   defp publish_routing_decision(event) do
-    with {:ok, decision} <- routing_decision(event) do
+    with {:ok, decision} <- routing_decision(event),
+         true <- publish_routing_decision?(event, decision) do
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
         Lasso.Topics.routing_decision(decision.profile),
         decision
       )
+    end
+  end
+
+  defp publish_routing_decision?(event, decision) do
+    if result(event.fact) == :error do
+      true
+    else
+      bucket =
+        :erlang.phash2(
+          {decision.profile, decision.chain_id, decision.request_origin},
+          @routing_budget_buckets
+        )
+
+      key = {__MODULE__, :routing_budget, bucket}
+      second = div(decision.ts, 1_000)
+
+      case Process.get(key) do
+        {^second, count} when count >= @routing_decisions_per_second ->
+          :telemetry.execute(
+            [:lasso, :rpc, :routing_decision, :sampled_out],
+            %{count: 1},
+            %{
+              profile: decision.profile,
+              chain_id: decision.chain_id,
+              request_origin: decision.request_origin
+            }
+          )
+
+          false
+
+        {^second, count} ->
+          Process.put(key, {second, count + 1})
+          true
+
+        _previous_window ->
+          Process.put(key, {second, 1})
+          true
+      end
     end
   end
 

--- a/lib/lasso/events/routing_decision.ex
+++ b/lib/lasso/events/routing_decision.ex
@@ -2,7 +2,9 @@ defmodule Lasso.Events.RoutingDecision do
   @moduledoc """
   Typed struct for routing decision events.
 
-  Published to profile-scoped PubSub topics for the read-only dashboard.
+  Published to profile-scoped PubSub topics for the read-only dashboard. Successful
+  detail is rate-bounded per profile, chain, and request origin. Error decisions are
+  always published by this delivery stage; request terminal telemetry is not sampled.
 
   ## Event Source Fields
 

--- a/lib/lasso/observability/telemetry.ex
+++ b/lib/lasso/observability/telemetry.ex
@@ -79,6 +79,11 @@ defmodule Lasso.Telemetry do
         description: "RPC request count",
         tags: [:chain, :method, :provider_id, :transport, :status]
       ),
+      counter("lasso.rpc.routing_decision.sampled_out.count",
+        event_name: [:lasso, :rpc, :routing_decision, :sampled_out],
+        description: "Successful routing details omitted from the bounded live feed",
+        tags: [:profile, :chain_id, :request_origin]
+      ),
 
       # Circuit breaker state changes (individual events for each transition type)
       counter("lasso.circuit_breaker.open.count",

--- a/test/lasso/core/request/request_projection_test.exs
+++ b/test/lasso/core/request/request_projection_test.exs
@@ -123,6 +123,55 @@ defmodule Lasso.RPC.RequestProjectionTest do
     assert {:ok, ^event} = RequestProjection.decode(legacy_payload)
   end
 
+  test "successful routing detail is bounded without sampling terminal telemetry" do
+    topic = Lasso.Topics.routing_decision("public")
+    :ok = Phoenix.PubSub.subscribe(Lasso.PubSub, topic)
+
+    handler_id = "routing-sampled-out-#{System.unique_integer([:positive])}"
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        [
+          [:lasso, :rpc, :routing_decision, :sampled_out],
+          [:lasso, :rpc, :request, :terminal]
+        ],
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+
+    event = request_projection()
+
+    for _index <- 1..258 do
+      assert :ok = RequestProjection.deliver(event)
+    end
+
+    decisions =
+      for _index <- 1..256 do
+        assert_receive %RoutingDecision{}
+      end
+
+    assert length(decisions) == 256
+    refute_receive %RoutingDecision{}
+
+    for _index <- 1..258 do
+      assert_receive {[:lasso, :rpc, :request, :terminal], %{count: 1, elapsed_us: _}, _}
+    end
+
+    for _index <- 1..2 do
+      assert_receive {
+        [:lasso, :rpc, :routing_decision, :sampled_out],
+        %{count: 1},
+        %{profile: "public", chain_id: 1, request_origin: :client}
+      }
+    end
+  end
+
   test "application errors retain their complete native classification" do
     attempt =
       AttemptTerminal.Response.new(identity(), :application_error, 7_000,

--- a/test/lasso/observability/telemetry_contract_test.exs
+++ b/test/lasso/observability/telemetry_contract_test.exs
@@ -188,6 +188,7 @@ defmodule Lasso.Observability.TelemetryContractTest do
           [:lasso, :http, :request, :io],
           [:lasso, :ws, :request, :io],
           [:lasso, :rpc, :request, :stop],
+          [:lasso, :rpc, :routing_decision, :sampled_out],
           [:lasso, :websocket, :connected],
           [:lasso, :websocket, :disconnected],
           [:lasso, :websocket, :request, :completed],


### PR DESCRIPTION
## Summary
- cap successful routing-decision PubSub detail at 256 events/second per profile, chain, and request origin on the fixed diagnostic worker
- keep error decisions unsampled and leave canonical request terminal telemetry unchanged by the detail budget
- expose every omitted success detail through a telemetry counter
- document the bounded live-feed contract

## Why
At high request rates, per-request PubSub fanout dominates diagnostic delivery even when no dashboard consumer is present. Compact decoding costs roughly 2–3 microseconds in the local diagnostic, while PubSub fanout costs roughly 13–16 microseconds. The bounded feed keeps low-rate traffic exact and retains a dense high-rate activity sample without changing routing, dispatch, retries, responses, or exact aggregate metrics.

## Verification
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test --include integration` — 1464 tests, 0 failures
- focused request projection and telemetry contract tests — 19 tests, 0 failures
- `mix credo --strict`
- `git diff --check`

No benchmark harness, eRPC comparison, or Cloud-specific code is included.