### PR TITLE
Use shared system priors during selection

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -310,6 +310,32 @@ defmodule Lasso.RPC.AttemptProjection do
     )
   end
 
+  @doc false
+  @spec summarize_route(
+          scope_state(),
+          map() | nil,
+          binary(),
+          :http | :ws,
+          pos_integer(),
+          atom()
+        ) :: Summary.t() | nil
+  def summarize_route(scope, row, instance_id, transport, chain_id, workload_key)
+      when is_map(scope) and is_binary(instance_id) and transport in [:http, :ws] and
+             is_integer(chain_id) and chain_id > 0 and is_atom(workload_key) do
+    now_us = System.monotonic_time(:microsecond)
+    shared_prior = shared_system_prior(scope, row, instance_id, transport, now_us)
+
+    summary_for_workload(
+      row,
+      shared_prior,
+      instance_id,
+      transport,
+      chain_id,
+      workload_key,
+      now_us
+    )
+  end
+
   @spec prepare_routes(non_neg_integer(), [map()]) :: :ok
   def prepare_routes(generation, routes)
       when is_integer(generation) and generation >= 0 and is_list(routes) do

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -384,7 +384,10 @@ defmodule Lasso.RPC.Selection do
   defp single_channel_summary(nil, _channel, _plan, _workload_key), do: nil
 
   defp single_channel_summary(candidate, channel, plan, workload_key) do
+    scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
+
     AttemptProjection.summarize_route(
+      scope,
       Map.get(candidate.routing_states, channel.transport),
       candidate.instance_id,
       channel.transport,
@@ -568,6 +571,8 @@ defmodule Lasso.RPC.Selection do
        do: ctx
 
   defp enrich_strategy_context(ctx, candidates, %RoutingPlan{} = plan, _strategy_mod) do
+    scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
+
     summaries =
       Enum.reduce(candidates, %{}, fn candidate, acc ->
         Enum.reduce(candidate.transports, acc, fn transport, route_acc ->
@@ -575,6 +580,7 @@ defmodule Lasso.RPC.Selection do
 
           summary =
             AttemptProjection.summarize_route(
+              scope,
               row,
               candidate.instance_id,
               transport,

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -17,7 +17,7 @@ defmodule Lasso.RPC.SelectionTest do
   use Lasso.Test.LassoIntegrationCase
 
   alias Lasso.Providers.Catalog
-  alias Lasso.RPC.{AttemptProjection, Selection}
+  alias Lasso.RPC.{AttemptIdentity, AttemptProjection, AttemptTerminal, Selection}
   alias Lasso.RPC.Selection.CandidateCursor
 
   defmodule CatalogSwapStrategy do
@@ -243,6 +243,63 @@ defmodule Lasso.RPC.SelectionTest do
                :fastest,
                :default
              ) == before_count + 1
+    end
+
+    test "fastest selection consumes a shared physical system prior", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "a_slow", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "z_fast", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      generation = Catalog.active_generation()
+      instance_id = Catalog.lookup_instance_id(profile, chain, "z_fast")
+
+      source_route = %{
+        profile: "poller-profile",
+        chain_id: chain,
+        instance_id: instance_id,
+        transport: :http
+      }
+
+      :ok =
+        AttemptProjection.prepare_routes(
+          generation,
+          [source_route | Catalog.routing_control_routes()]
+        )
+
+      now_us = System.monotonic_time(:microsecond)
+
+      for offset <- 0..2 do
+        event =
+          system_success_event(
+            chain,
+            instance_id,
+            generation,
+            now_us + offset,
+            10_000
+          )
+
+        assert :ok = AttemptProjection.apply_control(event)
+      end
+
+      public_scope = AttemptProjection.scope_state(profile, chain, generation)
+      assert is_nil(AttemptProjection.route_state(public_scope, instance_id, :http, "system"))
+
+      assert {:ok, "z_fast"} =
+               Selection.select_provider(profile, chain, "eth_blockNumber",
+                 strategy: :fastest,
+                 protocol: :http,
+                 request_origin: :client
+               )
+
+      assert [%{provider_id: "z_fast"} | _rest] =
+               Selection.select_channels(profile, chain, "eth_blockNumber",
+                 strategy: :fastest,
+                 transport: :http,
+                 request_origin: :client
+               )
     end
 
     test "same-generation catalog swaps during ranking fail both entrypoints closed", %{
@@ -514,4 +571,28 @@ defmodule Lasso.RPC.SelectionTest do
 
   defp restore_env(key, nil), do: Application.delete_env(:lasso, key)
   defp restore_env(key, value), do: Application.put_env(:lasso, key, value)
+
+  defp system_success_event(chain, instance_id, generation, emitted_at_us, duration_us) do
+    identity =
+      AttemptIdentity.new(
+        request_id: "selection-system-request",
+        attempt_id: "selection-system-attempt-#{emitted_at_us}",
+        profile: "poller-profile",
+        chain_id: chain,
+        upstream_instance_id: instance_id,
+        transport: :http,
+        route_generation: generation,
+        circuit_scope: :broad,
+        circuit_epoch: 1,
+        execution_safety: :replay_safe,
+        routing_intent: "fastest",
+        workload_key: "system",
+        request_budget_ms: 100,
+        candidate_admission_count: 1,
+        dispatch_count: 1
+      )
+
+    fact = AttemptTerminal.Response.new(identity, :success, duration_us)
+    %{AttemptProjection.new(fact, "z_fast", "eth_blockNumber") | emitted_at_us: emitted_at_us}
+  end
 end


### PR DESCRIPTION
## Summary

- make evidence-driven selection consume the generation-fenced physical system prior
- preserve profile-local client evidence as authoritative
- cover both provider and channel selection with a cross-profile regression

## Validation

- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test --include integration` (1469 tests, 0 failures)
- `mix credo --strict`
- `mix format --check-formatted`
- `git diff --check`