### PR TITLE
Precompute bounded routing identities

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -252,9 +252,18 @@ defmodule Lasso.RPC.AttemptProjection do
   @spec route_record(scope_state(), binary(), :http | :ws) :: map() | nil
   def route_record(scope, instance_id, transport)
       when is_binary(instance_id) and transport in [:http, :ws] do
+    route_record_bounded(scope, BoundedIdentifier.encode(instance_id), transport)
+  rescue
+    ArgumentError -> nil
+  end
+
+  @doc false
+  @spec route_record_bounded(scope_state(), binary(), :http | :ws) :: map() | nil
+  def route_record_bounded(scope, routing_instance_id, transport)
+      when is_binary(routing_instance_id) and transport in [:http, :ws] do
     key =
-      {:routing_control, scope.profile, scope.chain_id, BoundedIdentifier.encode(instance_id),
-       transport, @default_workload}
+      {:routing_control, scope.profile, scope.chain_id, routing_instance_id, transport,
+       @default_workload}
 
     case :ets.lookup(:lasso_instance_state, key) do
       [{^key, %{generation: generation} = row}] when generation == scope.generation ->
@@ -322,8 +331,43 @@ defmodule Lasso.RPC.AttemptProjection do
   def summarize_route(scope, row, instance_id, transport, chain_id, workload_key)
       when is_map(scope) and is_binary(instance_id) and transport in [:http, :ws] and
              is_integer(chain_id) and chain_id > 0 and is_atom(workload_key) do
+    summarize_route_bounded(
+      scope,
+      row,
+      instance_id,
+      BoundedIdentifier.encode(instance_id),
+      transport,
+      chain_id,
+      workload_key
+    )
+  end
+
+  @doc false
+  @spec summarize_route_bounded(
+          scope_state(),
+          map() | nil,
+          binary(),
+          binary(),
+          :http | :ws,
+          pos_integer(),
+          atom()
+        ) :: Summary.t() | nil
+  def summarize_route_bounded(
+        scope,
+        row,
+        instance_id,
+        routing_instance_id,
+        transport,
+        chain_id,
+        workload_key
+      )
+      when is_map(scope) and is_binary(instance_id) and is_binary(routing_instance_id) and
+             transport in [:http, :ws] and is_integer(chain_id) and chain_id > 0 and
+             is_atom(workload_key) do
     now_us = System.monotonic_time(:microsecond)
-    shared_prior = shared_system_prior(scope, row, instance_id, transport, now_us)
+
+    shared_prior =
+      shared_system_prior_bounded(scope, row, routing_instance_id, transport, now_us)
 
     summary_for_workload(
       row,
@@ -1216,6 +1260,16 @@ defmodule Lasso.RPC.AttemptProjection do
     do: nil
 
   defp shared_system_prior(scope, row, instance_id, transport, now_us) do
+    shared_system_prior_bounded(
+      scope,
+      row,
+      BoundedIdentifier.encode(instance_id),
+      transport,
+      now_us
+    )
+  end
+
+  defp shared_system_prior_bounded(scope, row, routing_instance_id, transport, now_us) do
     local_observed_at_us = partition_observed_at(row, :system)
 
     if is_integer(local_observed_at_us) and
@@ -1223,7 +1277,7 @@ defmodule Lasso.RPC.AttemptProjection do
       nil
     else
       key =
-        {:routing_system_prior, scope.chain_id, BoundedIdentifier.encode(instance_id), transport}
+        {:routing_system_prior, scope.chain_id, routing_instance_id, transport}
 
       case :ets.lookup(:lasso_instance_state, key) do
         [{^key, %{generation: generation, observed_at_us: observed_at_us} = prior}]

--- a/lib/lasso/core/selection/routing_plan.ex
+++ b/lib/lasso/core/selection/routing_plan.ex
@@ -15,6 +15,7 @@ defmodule Lasso.RPC.RoutingPlan do
   @type provider :: %{
           required(:id) => String.t(),
           required(:instance_id) => String.t(),
+          required(:routing_instance_id) => String.t(),
           required(:config) => map(),
           required(:priority) => non_neg_integer(),
           required(:capabilities) => map() | nil,

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -386,10 +386,11 @@ defmodule Lasso.RPC.Selection do
   defp single_channel_summary(candidate, channel, plan, workload_key) do
     scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
 
-    AttemptProjection.summarize_route(
+    AttemptProjection.summarize_route_bounded(
       scope,
       Map.get(candidate.routing_states, channel.transport),
       candidate.instance_id,
+      candidate.routing_instance_id,
       channel.transport,
       plan.chain_id,
       workload_key
@@ -579,10 +580,11 @@ defmodule Lasso.RPC.Selection do
           row = Map.get(candidate.routing_states, transport)
 
           summary =
-            AttemptProjection.summarize_route(
+            AttemptProjection.summarize_route_bounded(
               scope,
               row,
               candidate.instance_id,
+              candidate.routing_instance_id,
               transport,
               plan.chain_id,
               ctx.workload_key

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -280,11 +280,12 @@ defmodule Lasso.Providers.CandidateListing do
 
   defp build_candidate(provider, learned_scope, plan, protocol, workload_key, mode) do
     instance_id = provider.instance_id
+    routing_instance_id = provider.routing_instance_id
     transports = live_transports(provider, protocol, plan.profile, plan.chain_id)
 
     include_learned? = not learned_scope.degraded?
-    http_routing = route_record(learned_scope, instance_id, :http, transports)
-    ws_routing = route_record(learned_scope, instance_id, :ws, transports)
+    http_routing = route_record(learned_scope, routing_instance_id, :http, transports)
+    ws_routing = route_record(learned_scope, routing_instance_id, :ws, transports)
 
     {http_cb, http_rl} =
       candidate_gate(instance_id, :http, transports, include_learned?, http_routing)
@@ -305,8 +306,9 @@ defmodule Lasso.Providers.CandidateListing do
       learned_feedback_degraded?: learned_scope.degraded?
     }
 
-    maybe_add_availability(
-      candidate,
+    candidate
+    |> maybe_add_routing_identity(mode, routing_instance_id)
+    |> maybe_add_availability(
       mode,
       instance_id,
       http_routing,
@@ -314,6 +316,11 @@ defmodule Lasso.Providers.CandidateListing do
       include_learned?
     )
   end
+
+  defp maybe_add_routing_identity(candidate, :routing, routing_instance_id),
+    do: Map.put(candidate, :routing_instance_id, routing_instance_id)
+
+  defp maybe_add_routing_identity(candidate, :full, _routing_instance_id), do: candidate
 
   defp maybe_add_availability(candidate, :routing, _instance_id, _http, _ws, _include_learned?),
     do: candidate
@@ -347,9 +354,9 @@ defmodule Lasso.Providers.CandidateListing do
     end)
   end
 
-  defp route_record(scope, instance_id, transport, transports) do
+  defp route_record(scope, routing_instance_id, transport, transports) do
     if transport in transports,
-      do: AttemptProjection.route_record(scope, instance_id, transport),
+      do: AttemptProjection.route_record_bounded(scope, routing_instance_id, transport),
       else: nil
   end
 

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -36,7 +36,7 @@ defmodule Lasso.Providers.Catalog do
 
   alias Lasso.Config.{ChainConfig, ConfigStore}
   alias Lasso.Providers.{InstanceId, ProviderHeaders}
-  alias Lasso.RPC.RoutingPlan
+  alias Lasso.RPC.{BoundedIdentifier, RoutingPlan}
 
   @persistent_term_key :lasso_catalog_active
 
@@ -410,6 +410,7 @@ defmodule Lasso.Providers.Catalog do
         %{
           id: provider.provider_id,
           instance_id: provider.instance_id,
+          routing_instance_id: BoundedIdentifier.encode(provider.instance_id),
           config: config,
           priority: provider.priority,
           capabilities: provider.capabilities,

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -9,6 +9,7 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     AttemptIdentity,
     AttemptProjection,
     AttemptTerminal,
+    BoundedIdentifier,
     RequestTerminal
   }
 
@@ -357,8 +358,26 @@ defmodule Lasso.RPC.AttemptProjectionTest do
 
     row = AttemptProjection.route_record(scope, "projection-instance", :http)
 
+    assert row ==
+             AttemptProjection.route_record_bounded(
+               scope,
+               BoundedIdentifier.encode("projection-instance"),
+               :http
+             )
+
     prior =
       AttemptProjection.summarize_route(row, "projection-instance", :http, @chain_id, :client)
+
+    assert prior ==
+             AttemptProjection.summarize_route_bounded(
+               scope,
+               row,
+               "projection-instance",
+               BoundedIdentifier.encode("projection-instance"),
+               :http,
+               @chain_id,
+               :client
+             )
 
     assert prior.state == :unqualified
     assert prior.support_source == :system_prior

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -78,6 +78,10 @@ defmodule Lasso.Providers.CandidateListingTest do
       refute Map.has_key?(candidate, :availability)
       refute Map.has_key?(candidate, :transport_availability)
       assert Map.has_key?(candidate, :routing_states)
+
+      assert candidate.routing_instance_id ==
+               Lasso.RPC.BoundedIdentifier.encode(candidate.instance_id)
+
       assert Map.has_key?(candidate, :circuit_state)
       assert Map.has_key?(candidate, :rate_limited)
     end

--- a/test/lasso/providers/catalog_test.exs
+++ b/test/lasso/providers/catalog_test.exs
@@ -3,6 +3,7 @@ defmodule Lasso.Providers.CatalogTest do
 
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.Catalog
+  alias Lasso.RPC.BoundedIdentifier
 
   @profile_a "catalog_test_a"
   @profile_b "catalog_test_b"
@@ -252,6 +253,7 @@ defmodule Lasso.Providers.CatalogTest do
 
       assert [provider] = plan.providers
       assert provider.id == "compiled"
+      assert provider.routing_instance_id == BoundedIdentifier.encode(provider.instance_id)
       assert provider.priority == 3
       assert provider.transports == [:http]
       assert provider.config.capabilities == %{methods: ["eth_blockNumber"]}


### PR DESCRIPTION
## Summary

- compile bounded provider-instance identities into immutable routing plans
- reuse those identities for learned-route and shared-prior lookups
- keep public projection lookup APIs defensive while avoiding repeated normalization on catalog-derived values

## Validation

- `mix compile --warnings-as-errors`
- `mix test --include integration --seed 314159` (1471 tests, 0 failures)
- focused routing/catalog/projection selection suite (99 tests, 0 failures)
- `mix credo --strict` on changed production files
- `mix format --check-formatted`
- `git diff --check`