### PR TITLE
Resolve channels from compiled routing plans

### DIFF
--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -183,16 +183,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   end
 
   defp channel(cursor, candidate, transport) do
-    TransportRegistry.get_channel(
-      cursor.plan.profile,
-      cursor.plan.chain_id,
-      candidate.id,
-      transport,
-      method: cursor.method,
-      provider_config: candidate.config,
-      instance_id: candidate.instance_id,
-      route_generation: candidate.route_generation
-    )
+    TransportRegistry.get_channel_from_plan(cursor.plan, candidate, transport, cursor.method)
   end
 
   defp tier(circuit_state, rate_limited, transport) do

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -115,13 +115,7 @@ defmodule Lasso.RPC.Selection do
 
         channels =
           candidates
-          |> Enum.flat_map(fn %{
-                                id: provider_id,
-                                instance_id: instance_id,
-                                config: provider_config,
-                                route_generation: route_generation,
-                                transports: available_transports
-                              } ->
+          |> Enum.flat_map(fn %{transports: available_transports} = candidate ->
             transports =
               Enum.filter(
                 available_transports,
@@ -129,12 +123,7 @@ defmodule Lasso.RPC.Selection do
               )
 
             Enum.flat_map(transports, fn t ->
-              case TransportRegistry.get_channel(plan.profile, plan.chain_id, provider_id, t,
-                     method: method,
-                     provider_config: provider_config,
-                     instance_id: instance_id,
-                     route_generation: route_generation
-                   ) do
+              case TransportRegistry.get_channel_from_plan(plan, candidate, t, method) do
                 {:ok, ch} -> [ch]
                 _ -> []
               end
@@ -250,9 +239,7 @@ defmodule Lasso.RPC.Selection do
     # Map provider list into channels, lazily opening as needed
     channels =
       provider_candidates
-      |> Enum.flat_map(
-        &build_provider_channels(&1, transport, plan.profile, plan.chain_id, method)
-      )
+      |> Enum.flat_map(&build_provider_channels(&1, transport, plan, method))
       |> Enum.reject(&is_nil/1)
 
     # Filter channels by method capability (adapter-based filtering)
@@ -439,32 +426,16 @@ defmodule Lasso.RPC.Selection do
   # Channel building helpers
 
   defp build_provider_channels(
-         %{
-           id: provider_id,
-           instance_id: instance_id,
-           config: config,
-           route_generation: route_generation,
-           transports: available_transports
-         },
+         %{transports: available_transports} = candidate,
          transport,
-         profile,
-         chain_id,
+         plan,
          method
        ) do
     transport
     |> transports_to_check()
     |> Enum.filter(&(&1 in available_transports))
     |> Enum.flat_map(fn t ->
-      fetch_channel(
-        profile,
-        chain_id,
-        provider_id,
-        t,
-        method,
-        config,
-        route_generation,
-        instance_id
-      )
+      fetch_channel(plan, candidate, t, method)
     end)
   end
 
@@ -472,22 +443,8 @@ defmodule Lasso.RPC.Selection do
   defp transports_to_check(:ws), do: [:ws]
   defp transports_to_check(_), do: [:http, :ws]
 
-  defp fetch_channel(
-         profile,
-         chain_id,
-         provider_id,
-         transport,
-         method,
-         provider_config,
-         route_generation,
-         instance_id
-       ) do
-    case TransportRegistry.get_channel(profile, chain_id, provider_id, transport,
-           method: method,
-           provider_config: provider_config,
-           instance_id: instance_id,
-           route_generation: route_generation
-         ) do
+  defp fetch_channel(plan, candidate, transport, method) do
+    case TransportRegistry.get_channel_from_plan(plan, candidate, transport, method) do
       {:ok, channel} -> [channel]
       _ -> []
     end

--- a/lib/lasso/core/transport/registry.ex
+++ b/lib/lasso/core/transport/registry.ex
@@ -62,7 +62,7 @@ defmodule Lasso.RPC.TransportRegistry do
   alias Lasso.Config.ConfigStore
   alias Lasso.JSONRPC.Error, as: JError
   alias Lasso.Providers.InstanceId
-  alias Lasso.RPC.Channel
+  alias Lasso.RPC.{Channel, RoutingPlan}
 
   # ETS table for lockless channel lookups in hot path
   @channel_cache_table :transport_channel_cache
@@ -152,6 +152,44 @@ defmodule Lasso.RPC.TransportRegistry do
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
              is_binary(provider_id) and is_atom(transport) do
     profile = canonical_profile(profile)
+    get_canonical_channel(profile, chain_id, provider_id, transport, opts)
+  end
+
+  def get_channel(profile, chain_identifier, provider_id, transport, opts)
+      when is_binary(profile) and is_binary(chain_identifier) and is_binary(provider_id) and
+             is_atom(transport) do
+    profile = canonical_profile(profile)
+
+    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
+      get_channel(profile, chain_id, provider_id, transport, opts)
+    end
+  end
+
+  @doc false
+  @spec get_channel_from_plan(RoutingPlan.t(), map(), transport(), binary()) ::
+          {:ok, Channel.t()} | {:error, term()}
+  def get_channel_from_plan(
+        %RoutingPlan{} = plan,
+        %{
+          id: provider_id,
+          instance_id: instance_id,
+          config: provider_config,
+          route_generation: generation
+        },
+        transport,
+        method
+      )
+      when is_binary(provider_id) and is_binary(instance_id) and is_map(provider_config) and
+             generation == plan.generation and transport in [:http, :ws] and is_binary(method) do
+    get_canonical_channel(plan.profile, plan.chain_id, provider_id, transport,
+      method: method,
+      provider_config: provider_config,
+      instance_id: instance_id,
+      route_generation: generation
+    )
+  end
+
+  defp get_canonical_channel(profile, chain_id, provider_id, transport, opts) do
     cache_key = {profile, chain_id, provider_id, transport}
 
     case :ets.lookup(@channel_cache_table, cache_key) do
@@ -165,18 +203,11 @@ defmodule Lasso.RPC.TransportRegistry do
     end
   end
 
-  def get_channel(profile, chain_identifier, provider_id, transport, opts)
-      when is_binary(profile) and is_binary(chain_identifier) and is_binary(provider_id) and
-             is_atom(transport) do
-    profile = canonical_profile(profile)
-
-    with {:ok, chain_id} <- resolve_chain_id(profile, chain_identifier) do
-      get_channel(profile, chain_id, provider_id, transport, opts)
-    end
-  end
-
   defp do_get_channel(profile, chain_id, provider_id, transport, opts) do
-    GenServer.call(via_name(profile, chain_id), {:get_channel, provider_id, transport, opts})
+    GenServer.call(
+      canonical_via_name(profile, chain_id),
+      {:get_channel, provider_id, transport, opts}
+    )
   catch
     :exit, {:noproc, _} -> {:error, :registry_unavailable}
     :exit, {:timeout, _} -> {:error, :registry_timeout}
@@ -787,8 +818,7 @@ defmodule Lasso.RPC.TransportRegistry do
   @spec via_name(String.t(), pos_integer()) :: {:via, Registry, {atom(), tuple()}}
   def via_name(profile, chain_id)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
-    {:via, Registry,
-     {Lasso.Registry, {:transport_registry, canonical_profile(profile), chain_id}}}
+    profile |> canonical_profile() |> canonical_via_name(chain_id)
   end
 
   @spec via_name(String.t(), String.t()) :: {:via, Registry, {atom(), tuple()}}
@@ -807,6 +837,10 @@ defmodule Lasso.RPC.TransportRegistry do
 
   @spec via_name(pos_integer() | String.t()) :: {:via, Registry, {atom(), tuple()}}
   def via_name(chain_identifier), do: via_name(@default_profile, chain_identifier)
+
+  defp canonical_via_name(profile, chain_id) do
+    {:via, Registry, {Lasso.Registry, {:transport_registry, profile, chain_id}}}
+  end
 
   defp canonical_profile(profile), do: Lasso.Config.ProfileValidator.resolve_alias(profile)
 

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -16,8 +16,16 @@ defmodule Lasso.RPC.SelectionTest do
 
   use Lasso.Test.LassoIntegrationCase
 
-  alias Lasso.Providers.Catalog
-  alias Lasso.RPC.{AttemptIdentity, AttemptProjection, AttemptTerminal, Selection}
+  alias Lasso.Providers.{CandidateListing, Catalog}
+
+  alias Lasso.RPC.{
+    AttemptIdentity,
+    AttemptProjection,
+    AttemptTerminal,
+    Selection,
+    TransportRegistry
+  }
+
   alias Lasso.RPC.Selection.CandidateCursor
 
   defmodule CatalogSwapStrategy do
@@ -402,6 +410,51 @@ defmodule Lasso.RPC.SelectionTest do
 
       assert map_size(summaries) == 1
       assert priorities == %{"context_provider" => 10}
+    end
+  end
+
+  describe "compiled channel resolution" do
+    test "uses the routing plan profile without reapplying mutable aliases", %{chain: chain} do
+      setup_providers([
+        %{id: "provider_1", priority: 10, behavior: :healthy, profile: "public"}
+      ])
+
+      snapshot = Catalog.snapshot()
+      assert {:ok, plan} = Catalog.get_routing_plan(snapshot, "public", chain)
+      assert [candidate] = CandidateListing.list_routing_candidates_from_plan(plan, %{})
+
+      assert {:ok, _channel} =
+               TransportRegistry.get_channel_from_plan(
+                 plan,
+                 candidate,
+                 :http,
+                 "eth_blockNumber"
+               )
+
+      previous_aliases = Application.get_env(:lasso, :profile_aliases)
+
+      on_exit(fn ->
+        if is_nil(previous_aliases) do
+          Application.delete_env(:lasso, :profile_aliases)
+        else
+          Application.put_env(:lasso, :profile_aliases, previous_aliases)
+        end
+      end)
+
+      Application.put_env(:lasso, :profile_aliases, %{"public" => "redirected"})
+
+      :ets.delete(
+        :transport_channel_cache,
+        {"public", chain, candidate.id, :http}
+      )
+
+      assert {:ok, %{profile: "public"}} =
+               TransportRegistry.get_channel_from_plan(
+                 plan,
+                 candidate,
+                 :http,
+                 "eth_blockNumber"
+               )
     end
   end
 


### PR DESCRIPTION
## Summary

- resolve candidate channels directly from captured routing plans
- preserve exact catalog profile identity across cache hits and misses
- centralize route-generation and physical-instance binding for adaptive and cursor selection

## Validation

- `mix compile --warnings-as-errors`
- `mix test --include integration --seed 314159` (1472 tests, 0 failures)
- focused selection/evidence/generation integration suite (32 tests, 0 failures)
- mutable-alias cache-miss regression
- `mix credo --strict` on changed production files
- `mix format --check-formatted`
- `git diff --check`