### PR TITLE
Materialize ranked channels on demand

### DIFF
--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -418,6 +418,10 @@ defmodule Lasso.RPC.RequestPipeline do
   defp candidate_labels(channels, _selected) when is_list(channels),
     do: Enum.map(channels, &"#{&1.provider_id}:#{&1.transport}")
 
+  defp candidate_labels(%CandidateCursor{candidate_labels: labels}, _selected)
+       when labels != [],
+       do: labels
+
   defp candidate_labels(%CandidateCursor{}, nil), do: []
 
   defp candidate_labels(%CandidateCursor{}, %Channel{} = selected),

--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -28,6 +28,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   ]
   defstruct @enforce_keys ++
               [
+                candidate_labels: [],
                 returned: 0,
                 supported?: false,
                 supported_deferred: %{2 => :queue.new(), 3 => :queue.new(), 4 => :queue.new()},
@@ -39,11 +40,54 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
                 }
               ]
 
-  @type descriptor :: {RoutingPlan.provider(), :http | :ws}
+  @type descriptor ::
+          {RoutingPlan.provider(), :http | :ws}
+          | {:ranked, map(), :http | :ws}
   @type t :: %__MODULE__{}
 
   @spec new(Catalog.snapshot(), RoutingPlan.t(), String.t(), keyword()) :: t()
   def new(snapshot, %RoutingPlan{} = plan, method, opts) do
+    build(
+      snapshot,
+      plan,
+      method,
+      opts,
+      &build_descriptors/4,
+      fn -> AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation) end,
+      false
+    )
+  end
+
+  @doc false
+  @spec new_ranked(Catalog.snapshot(), RoutingPlan.t(), String.t(), keyword(), [
+          {map(), :http | :ws}
+        ]) :: t()
+  def new_ranked(snapshot, %RoutingPlan{} = plan, method, opts, ranked_candidates)
+      when is_list(ranked_candidates) do
+    build(
+      snapshot,
+      plan,
+      method,
+      opts,
+      fn _plan, _strategy, _transport, _filters ->
+        Enum.map(ranked_candidates, fn {candidate, transport} ->
+          {:ranked, candidate, transport}
+        end)
+      end,
+      fn -> nil end,
+      true
+    )
+  end
+
+  defp build(
+         snapshot,
+         plan,
+         method,
+         opts,
+         descriptors_fun,
+         learned_scope_fun,
+         include_labels?
+       ) do
     transport = Keyword.get(opts, :transport, :both)
     strategy = Keyword.get(opts, :strategy, :load_balanced)
     consensus_height = consensus_height(plan.chain_id)
@@ -68,7 +112,8 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
         workload_key: workload_for_origin(Keyword.get(opts, :request_origin, :client))
       )
 
-    descriptors = build_descriptors(plan, strategy, transport, filters)
+    descriptors = descriptors_fun.(plan, strategy, transport, filters)
+    limit = Keyword.get(opts, :limit, 1000)
 
     %__MODULE__{
       snapshot: snapshot,
@@ -76,9 +121,14 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       method: method,
       filters: filters,
       consensus_height: consensus_height,
-      learned_scope: AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation),
+      learned_scope: learned_scope_fun.(),
       descriptors: descriptors,
-      limit: Keyword.get(opts, :limit, 1000)
+      limit: limit,
+      candidate_labels:
+        if(include_labels?,
+          do: descriptors |> Enum.take(max(limit, 0)) |> Enum.map(&descriptor_label/1),
+          else: []
+        )
     }
   end
 
@@ -98,9 +148,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
     %{
       cursor
       | descriptors:
-          Enum.reject(cursor.descriptors, fn {provider, _transport} ->
-            provider.id == provider_id
-          end),
+          Enum.reject(cursor.descriptors, &(descriptor_provider_id(&1) == provider_id)),
         supported_deferred: reject_queued_provider(cursor.supported_deferred, provider_id),
         unsupported_deferred: reject_queued_provider(cursor.unsupported_deferred, provider_id)
     }
@@ -182,6 +230,16 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
     end
   end
 
+  defp materialize(cursor, {:ranked, candidate, transport}) do
+    with {:ok, channel} <- channel(cursor, candidate, transport),
+         tier when tier in 1..4 <-
+           tier(candidate.circuit_state, candidate.rate_limited, transport) do
+      {:ok, channel, tier, AdapterFilter.method_supported?(channel, cursor.method)}
+    else
+      _unavailable -> :skip
+    end
+  end
+
   defp channel(cursor, candidate, transport) do
     TransportRegistry.get_channel_from_plan(cursor.plan, candidate, transport, cursor.method)
   end
@@ -247,6 +305,14 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
   defp workload_for_origin(:system), do: Workload.normalize(:system)
   defp workload_for_origin(_origin), do: Workload.normalize(:client)
+
+  defp descriptor_provider_id({provider, _transport}), do: provider.id
+  defp descriptor_provider_id({:ranked, candidate, _transport}), do: candidate.id
+
+  defp descriptor_label(descriptor) do
+    transport = elem(descriptor, tuple_size(descriptor) - 1)
+    "#{descriptor_provider_id(descriptor)}:#{transport}"
+  end
 
   defp empty_unsupported do
     %{1 => :queue.new(), 2 => :queue.new(), 3 => :queue.new(), 4 => :queue.new()}

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -180,60 +180,31 @@ defmodule Lasso.RPC.Selection do
           [Channel.t()] | CandidateCursor.t()
   def select_channel_candidates(profile, chain_id, method, opts)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and is_binary(method) do
-    if Keyword.get(opts, :strategy, :load_balanced) in [:priority, :load_balanced] do
-      case capture_selection_snapshot(profile, chain_id) do
-        {:ok, snapshot, plan} -> CandidateCursor.new(snapshot, plan, method, opts)
-        :unavailable -> []
-      end
-    else
-      select_channels(profile, chain_id, method, opts)
+    strategy = Keyword.get(opts, :strategy, :load_balanced)
+    strategy_mod = StrategyRegistry.resolve(strategy)
+
+    case {strategy, strategy_mod} do
+      {strategy, _module} when strategy in [:priority, :load_balanced] ->
+        case capture_selection_snapshot(profile, chain_id) do
+          {:ok, snapshot, plan} -> CandidateCursor.new(snapshot, plan, method, opts)
+          :unavailable -> []
+        end
+
+      {:fastest, Lasso.RPC.Strategies.Fastest} ->
+        select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod)
+
+      {:latency_weighted, Lasso.RPC.Strategies.LatencyWeighted} ->
+        select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod)
+
+      _custom_or_unknown ->
+        select_channels(profile, chain_id, method, opts)
     end
   end
 
   defp select_channels_from_plan(snapshot, plan, method, opts) do
     strategy = Keyword.get(opts, :strategy, :load_balanced)
-    transport = Keyword.get(opts, :transport, :both)
-    exclude = Keyword.get(opts, :exclude, [])
     limit = Keyword.get(opts, :limit, 1000)
-    include_half_open = Keyword.get(opts, :include_half_open, true)
-    params = Keyword.get(opts, :params, [])
-    workload_key = workload_for_origin(Keyword.get(opts, :request_origin, :client))
-
-    pool_protocol =
-      case transport do
-        :http -> :http
-        :ws -> :ws
-        _ -> nil
-      end
-
-    consensus_height = get_consensus_height(plan.chain_id)
-
-    requirements =
-      Lasso.RPC.RequestAnalysis.analyze(
-        method,
-        params,
-        consensus_height: consensus_height,
-        archival_threshold: plan.archival_threshold
-      )
-
-    pool_filters =
-      SelectionFilters.new(
-        protocol: pool_protocol,
-        exclude: exclude,
-        include_half_open: include_half_open,
-        max_lag_blocks: plan.max_lag_blocks,
-        min_block: requirements.requested_block,
-        requires_archival: requirements.requires_archival,
-        requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false),
-        workload_key: workload_key
-      )
-
-    provider_candidates =
-      CandidateListing.list_routing_candidates_from_plan(
-        plan,
-        pool_filters,
-        consensus_height || :unavailable
-      )
+    {provider_candidates, transport, workload_key} = routing_candidates(plan, method, opts)
 
     # Build channel candidates via TransportRegistry (enforces channel-level health/capabilities)
     # Map provider list into channels, lazily opening as needed
@@ -273,6 +244,123 @@ defmodule Lasso.RPC.Selection do
       else: []
   end
 
+  defp select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod) do
+    case capture_selection_snapshot(profile, chain_id) do
+      {:ok, snapshot, plan} ->
+        strategy = Keyword.fetch!(opts, :strategy)
+        {candidates, _transport, workload_key} = routing_candidates(plan, method, opts)
+
+        entries =
+          for candidate <- candidates,
+              transport <- candidate.transports do
+            {ranking_channel(plan, candidate, transport), candidate, transport}
+          end
+
+        capable_channels =
+          entries
+          |> Enum.map(&elem(&1, 0))
+          |> filter_capable_channels(method)
+
+        entries_by_key =
+          Map.new(entries, fn {channel, candidate, transport} ->
+            {{channel.instance_id, transport}, {candidate, transport}}
+          end)
+
+        ranked_candidates =
+          capable_channels
+          |> rank_capable_channels(
+            candidates,
+            strategy,
+            method,
+            plan,
+            Keyword.get(opts, :timeout, 30_000),
+            workload_key,
+            strategy_mod
+          )
+          |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
+
+        if selection_snapshot_current?(snapshot, candidates) do
+          CandidateCursor.new_ranked(snapshot, plan, method, opts, ranked_candidates)
+        else
+          []
+        end
+
+      :unavailable ->
+        []
+    end
+  end
+
+  defp routing_candidates(plan, method, opts) do
+    transport = Keyword.get(opts, :transport, :both)
+    workload_key = workload_for_origin(Keyword.get(opts, :request_origin, :client))
+
+    pool_protocol =
+      case transport do
+        :http -> :http
+        :ws -> :ws
+        _ -> nil
+      end
+
+    consensus_height = get_consensus_height(plan.chain_id)
+
+    requirements =
+      Lasso.RPC.RequestAnalysis.analyze(
+        method,
+        Keyword.get(opts, :params, []),
+        consensus_height: consensus_height,
+        archival_threshold: plan.archival_threshold
+      )
+
+    pool_filters =
+      SelectionFilters.new(
+        protocol: pool_protocol,
+        exclude: Keyword.get(opts, :exclude, []),
+        include_half_open: Keyword.get(opts, :include_half_open, true),
+        max_lag_blocks: plan.max_lag_blocks,
+        min_block: requirements.requested_block,
+        requires_archival: requirements.requires_archival,
+        requires_subscribe_new_heads: Keyword.get(opts, :requires_subscribe_new_heads, false),
+        workload_key: workload_key
+      )
+
+    candidates =
+      CandidateListing.list_routing_candidates_from_plan(
+        plan,
+        pool_filters,
+        consensus_height || :unavailable
+      )
+
+    {candidates, transport, workload_key}
+  end
+
+  defp ranking_channel(plan, candidate, transport) do
+    %Channel{
+      profile: plan.profile,
+      chain_id: plan.chain_id,
+      provider_id: candidate.id,
+      instance_id: candidate.instance_id,
+      route_generation: plan.generation,
+      transport: transport,
+      raw_channel: nil,
+      transport_module: nil,
+      capabilities: nil,
+      provider_capabilities: Map.get(candidate.config, :capabilities)
+    }
+  end
+
+  defp filter_capable_channels(channels, method) do
+    case Lasso.RPC.Providers.AdapterFilter.filter_channels(channels, method) do
+      {:ok, capable, filtered} ->
+        if filtered != [] do
+          Logger.debug(
+            "Filtered #{length(filtered)} channels for #{method}: #{inspect(Enum.map(filtered, & &1.provider_id))}"
+          )
+        end
+
+        capable
+    end
+  end
+
   defp order_capable_channels(
          [channel],
          candidates,
@@ -305,28 +393,63 @@ defmodule Lasso.RPC.Selection do
         {id, rate_limited}
       end)
 
-    strategy_mod = StrategyRegistry.resolve(strategy)
+    ordered_channels =
+      rank_capable_channels(
+        channels,
+        candidates,
+        strategy,
+        method,
+        plan,
+        timeout,
+        workload_key,
+        StrategyRegistry.resolve(strategy)
+      )
 
+    tier_channels(ordered_channels, circuit_state_map, rate_limit_map)
+  end
+
+  defp rank_capable_channels(
+         [channel],
+         candidates,
+         strategy,
+         _method,
+         plan,
+         _timeout,
+         workload_key,
+         _strategy_mod
+       )
+       when strategy in [:fastest, :priority, :load_balanced, :latency_weighted] do
+    maybe_record_single_channel_degradation(channel, candidates, strategy, plan, workload_key)
+    [channel]
+  end
+
+  defp rank_capable_channels(
+         channels,
+         candidates,
+         strategy,
+         method,
+         plan,
+         timeout,
+         workload_key,
+         strategy_mod
+       ) do
     prepared_ctx =
       strategy_mod.prepare_context(plan.profile, plan.chain_id, method, timeout)
       |> Map.put(:workload_key, workload_key)
       |> enrich_strategy_context(candidates, plan, strategy_mod)
 
-    ordered_channels =
-      if Enum.any?(candidates, & &1.learned_feedback_degraded?) and
-           strategy in [:fastest, :latency_weighted] do
-        Enum.sort_by(channels, &{&1.provider_id, &1.transport})
-      else
-        strategy_mod.rank_channels(
-          channels,
-          method,
-          prepared_ctx,
-          plan.profile,
-          plan.chain_id
-        )
-      end
-
-    tier_channels(ordered_channels, circuit_state_map, rate_limit_map)
+    if Enum.any?(candidates, & &1.learned_feedback_degraded?) and
+         strategy in [:fastest, :latency_weighted] do
+      Enum.sort_by(channels, &{&1.provider_id, &1.transport})
+    else
+      strategy_mod.rank_channels(
+        channels,
+        method,
+        prepared_ctx,
+        plan.profile,
+        plan.chain_id
+      )
+    end
   end
 
   defp maybe_record_single_channel_degradation(

--- a/test/integration/request_pipeline_integration_test.exs
+++ b/test/integration/request_pipeline_integration_test.exs
@@ -5,7 +5,7 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
   @moduletag timeout: 10_000
 
   alias Lasso.Events.RoutingDecision
-  alias Lasso.RPC.{RequestPipeline, RequestOptions, Response}
+  alias Lasso.RPC.{RequestOptions, RequestPipeline, Response}
   alias Lasso.Test.CircuitBreakerHelper
   alias Lasso.Testing.MockProviderBehavior
   alias LassoWeb.Dashboard.EventStream
@@ -220,6 +220,32 @@ defmodule Lasso.RPC.RequestPipelineIntegrationTest do
       assert String.starts_with?(block_number, "0x")
       assert ctx.executed_channel.provider_id == "backup"
       assert Enum.map(ctx.attempted_channels, & &1.channel.provider_id) == ["primary", "backup"]
+    end
+
+    test "fastest preserves ranked fallback and full candidate metadata", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "a_failing", priority: 10, behavior: :always_fail, profile: profile},
+        %{id: "z_backup", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      assert {:ok, %Response.Success{}, ctx} =
+               RequestPipeline.execute_via_channels(
+                 chain,
+                 "eth_blockNumber",
+                 [],
+                 %RequestOptions{strategy: :fastest, timeout_ms: 30_000}
+               )
+
+      assert ctx.executed_channel.provider_id == "z_backup"
+
+      assert Enum.map(ctx.attempted_channels, & &1.channel.provider_id) == [
+               "a_failing",
+               "z_backup"
+             ]
+
+      assert ctx.candidate_providers == ["a_failing:http", "z_backup:http"]
     end
 
     test "respects provider override without failover", %{chain: chain} do

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -567,7 +567,8 @@ defmodule Lasso.RPC.SelectionTest do
       profile = "public"
 
       setup_providers([
-        %{id: "provider", priority: 10, behavior: :healthy, profile: profile}
+        %{id: "provider_a", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "provider_b", priority: 20, behavior: :healthy, profile: profile}
       ])
 
       cursor =
@@ -600,18 +601,80 @@ defmodule Lasso.RPC.SelectionTest do
       assert :done = CandidateCursor.next(cursor)
     end
 
-    test "evidence-driven strategies retain the eager channel list", %{chain: chain} do
+    test "built-in evidence strategies return lazily materialized ranked candidates", %{
+      chain: chain
+    } do
       profile = "public"
 
       setup_providers([
         %{id: "provider", priority: 10, behavior: :healthy, profile: profile}
       ])
 
-      assert [%Lasso.RPC.Channel{}] =
+      for strategy <- [:fastest, :latency_weighted] do
+        cursor =
+          Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+            strategy: strategy,
+            transport: :http
+          )
+
+        assert %CandidateCursor{candidate_labels: ["provider:http"]} = cursor
+
+        assert {:ok, %Lasso.RPC.Channel{provider_id: "provider"}, cursor} =
+                 CandidateCursor.next(cursor)
+
+        assert :done = CandidateCursor.next(cursor)
+      end
+
+      limited =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          limit: 0
+        )
+
+      assert %CandidateCursor{candidate_labels: []} = limited
+      assert :done = CandidateCursor.next(limited)
+    end
+
+    test "strategy overrides retain the eager channel contract", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "provider_a", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "provider_b", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      previous_registry = Application.get_env(:lasso, :strategy_registry)
+
+      Application.put_env(
+        :lasso,
+        :strategy_registry,
+        Map.put(
+          Lasso.RPC.Strategies.Registry.default_registry(),
+          :fastest,
+          ContextCaptureStrategy
+        )
+      )
+
+      Application.put_env(:lasso, :selection_context_test_pid, self())
+
+      on_exit(fn ->
+        if previous_registry,
+          do: Application.put_env(:lasso, :strategy_registry, previous_registry),
+          else: Application.delete_env(:lasso, :strategy_registry)
+
+        Application.delete_env(:lasso, :selection_context_test_pid)
+      end)
+
+      assert [%Lasso.RPC.Channel{}, %Lasso.RPC.Channel{}] =
+               channels =
                Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
                  strategy: :fastest,
                  transport: :http
                )
+
+      assert Enum.sort(Enum.map(channels, & &1.provider_id)) == ["provider_a", "provider_b"]
+      assert_receive {:strategy_context, _context}
     end
   end
 


### PR DESCRIPTION
## Summary
- rank built-in fastest and latency-weighted candidates using immutable lightweight channel descriptors
- materialize transport channels only as execution reaches each ranked candidate
- preserve snapshot fencing, health tiers, fallback order, full candidate metadata, and custom strategy behavior

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test --include integration` (1,474 tests, 0 failures)
- `mix dialyzer`
- `MIX_ENV=test mix credo --strict` on changed production files
- `mix format` and `git diff --check`
- exact request trace: transport channel-cache reads reduced from 8 to 1 in the eight-provider fastest path