### PR TITLE
Defer ranked candidate gate reads

### DIFF
--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -2,7 +2,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   @moduledoc false
 
   alias Lasso.Config.ConfigStore
-  alias Lasso.Providers.{CandidateListing, Catalog}
+  alias Lasso.Providers.{CandidateListing, Catalog, InstanceState}
 
   alias Lasso.RPC.{
     AttemptProjection,
@@ -231,9 +231,19 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   end
 
   defp materialize(cursor, {:ranked, candidate, transport}) do
-    with {:ok, channel} <- channel(cursor, candidate, transport),
-         tier when tier in 1..4 <-
-           tier(candidate.circuit_state, candidate.rate_limited, transport) do
+    routing_state = Map.fetch!(candidate.routing_states, transport)
+
+    {circuit_state, rate_limited?} =
+      InstanceState.read_candidate_gate(
+        candidate.instance_id,
+        transport,
+        routing_state,
+        not candidate.learned_feedback_degraded?
+      )
+
+    with true <- gate_allowed?(cursor.filters, circuit_state, rate_limited?),
+         tier when tier in 1..4 <- tier(circuit_state, rate_limited?),
+         {:ok, channel} <- channel(cursor, candidate, transport) do
       {:ok, channel, tier, AdapterFilter.method_supported?(channel, cursor.method)}
     else
       _unavailable -> :skip
@@ -246,12 +256,24 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
   defp tier(circuit_state, rate_limited, transport) do
     case {Map.fetch!(circuit_state, transport), Map.fetch!(rate_limited, transport)} do
-      {:closed, false} -> 1
-      {:half_open, false} -> 2
-      {:closed, true} -> 3
-      {:half_open, true} -> 4
-      _unavailable -> nil
+      {state, limited?} -> tier(state, limited?)
     end
+  end
+
+  defp tier(:closed, false), do: 1
+  defp tier(:half_open, false), do: 2
+  defp tier(:closed, true), do: 3
+  defp tier(:half_open, true), do: 4
+  defp tier(_state, _limited?), do: nil
+
+  defp gate_allowed?(filters, circuit_state, rate_limited?) do
+    circuit_allowed? =
+      circuit_state == :closed or
+        (circuit_state == :half_open and filters.include_half_open)
+
+    rate_limit_allowed? = not filters.exclude_rate_limited or not rate_limited?
+
+    circuit_allowed? and rate_limit_allowed?
   end
 
   defp defer(cursor, field, tier, channel) do

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -248,7 +248,9 @@ defmodule Lasso.RPC.Selection do
     case capture_selection_snapshot(profile, chain_id) do
       {:ok, snapshot, plan} ->
         strategy = Keyword.fetch!(opts, :strategy)
-        {candidates, _transport, workload_key} = routing_candidates(plan, method, opts)
+
+        {candidates, _transport, workload_key} =
+          routing_candidates(plan, method, opts, :deferred_gates)
 
         entries =
           for candidate <- candidates,
@@ -290,7 +292,7 @@ defmodule Lasso.RPC.Selection do
     end
   end
 
-  defp routing_candidates(plan, method, opts) do
+  defp routing_candidates(plan, method, opts, gate_mode \\ :captured_gates) do
     transport = Keyword.get(opts, :transport, :both)
     workload_key = workload_for_origin(Keyword.get(opts, :request_origin, :client))
 
@@ -324,11 +326,21 @@ defmodule Lasso.RPC.Selection do
       )
 
     candidates =
-      CandidateListing.list_routing_candidates_from_plan(
-        plan,
-        pool_filters,
-        consensus_height || :unavailable
-      )
+      case gate_mode do
+        :deferred_gates ->
+          CandidateListing.list_rankable_candidates_from_plan(
+            plan,
+            pool_filters,
+            consensus_height || :unavailable
+          )
+
+        :captured_gates ->
+          CandidateListing.list_routing_candidates_from_plan(
+            plan,
+            pool_filters,
+            consensus_height || :unavailable
+          )
+      end
 
     {candidates, transport, workload_key}
   end

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -126,6 +126,29 @@ defmodule Lasso.Providers.CandidateListing do
   end
 
   @doc false
+  @spec list_rankable_candidates_from_plan(
+          RoutingPlan.t(),
+          SelectionFilters.t() | map(),
+          non_neg_integer() | :unavailable
+        ) :: [map()]
+  def list_rankable_candidates_from_plan(
+        %RoutingPlan{} = plan,
+        %SelectionFilters{} = filters,
+        consensus_height
+      ) do
+    list_rankable_candidates_from_plan(
+      plan,
+      SelectionFilters.to_map(filters),
+      consensus_height
+    )
+  end
+
+  def list_rankable_candidates_from_plan(%RoutingPlan{} = plan, filters, consensus_height)
+      when is_map(filters) do
+    do_list_candidates(plan, filters, :ranked, consensus_height)
+  end
+
+  @doc false
   @spec routing_candidate_from_plan(
           RoutingPlan.t(),
           RoutingPlan.provider(),
@@ -222,8 +245,7 @@ defmodule Lasso.Providers.CandidateListing do
       |> Enum.map(&build_candidate(&1, learned_scope, plan, protocol, workload_key, mode))
       |> Enum.filter(fn c ->
         transport_available?(c, protocol) and
-          circuit_breaker_ready?(c, protocol, include_half_open) and
-          rate_limit_ok?(c, protocol, filters)
+          candidate_gate_ready?(c, protocol, include_half_open, filters, mode)
       end)
       |> filter_by_lag(
         plan.profile,
@@ -287,11 +309,15 @@ defmodule Lasso.Providers.CandidateListing do
     http_routing = route_record(learned_scope, routing_instance_id, :http, transports)
     ws_routing = route_record(learned_scope, routing_instance_id, :ws, transports)
 
-    {http_cb, http_rl} =
-      candidate_gate(instance_id, :http, transports, include_learned?, http_routing)
-
-    {ws_cb, ws_rl} =
-      candidate_gate(instance_id, :ws, transports, include_learned?, ws_routing)
+    {circuit_state, rate_limited} =
+      candidate_gates(
+        mode,
+        instance_id,
+        transports,
+        include_learned?,
+        http_routing,
+        ws_routing
+      )
 
     candidate = %{
       id: provider.id,
@@ -301,8 +327,8 @@ defmodule Lasso.Providers.CandidateListing do
       transports: transports,
       routing_states: %{http: http_routing, ws: ws_routing},
       workload_key: workload_key,
-      circuit_state: %{http: http_cb, ws: ws_cb},
-      rate_limited: %{http: http_rl, ws: ws_rl},
+      circuit_state: circuit_state,
+      rate_limited: rate_limited,
       learned_feedback_degraded?: learned_scope.degraded?
     }
 
@@ -317,13 +343,15 @@ defmodule Lasso.Providers.CandidateListing do
     )
   end
 
-  defp maybe_add_routing_identity(candidate, :routing, routing_instance_id),
-    do: Map.put(candidate, :routing_instance_id, routing_instance_id)
+  defp maybe_add_routing_identity(candidate, mode, routing_instance_id)
+       when mode in [:routing, :ranked],
+       do: Map.put(candidate, :routing_instance_id, routing_instance_id)
 
   defp maybe_add_routing_identity(candidate, :full, _routing_instance_id), do: candidate
 
-  defp maybe_add_availability(candidate, :routing, _instance_id, _http, _ws, _include_learned?),
-    do: candidate
+  defp maybe_add_availability(candidate, mode, _instance_id, _http, _ws, _include_learned?)
+       when mode in [:routing, :ranked],
+       do: candidate
 
   defp maybe_add_availability(candidate, :full, instance_id, http, ws, include_learned?) do
     health = InstanceState.read_candidate_health(instance_id, http, ws, include_learned?)
@@ -366,6 +394,42 @@ defmodule Lasso.Providers.CandidateListing do
     else
       {:unavailable, false}
     end
+  end
+
+  defp candidate_gates(
+         :ranked,
+         _instance_id,
+         _transports,
+         _include_learned?,
+         _http_routing,
+         _ws_routing
+       ) do
+    {%{http: :deferred, ws: :deferred}, %{http: false, ws: false}}
+  end
+
+  defp candidate_gates(
+         _mode,
+         instance_id,
+         transports,
+         include_learned?,
+         http_routing,
+         ws_routing
+       ) do
+    {http_cb, http_rl} =
+      candidate_gate(instance_id, :http, transports, include_learned?, http_routing)
+
+    {ws_cb, ws_rl} =
+      candidate_gate(instance_id, :ws, transports, include_learned?, ws_routing)
+
+    {%{http: http_cb, ws: ws_cb}, %{http: http_rl, ws: ws_rl}}
+  end
+
+  defp candidate_gate_ready?(_candidate, _protocol, _include_half_open, _filters, :ranked),
+    do: true
+
+  defp candidate_gate_ready?(candidate, protocol, include_half_open, filters, _mode) do
+    circuit_breaker_ready?(candidate, protocol, include_half_open) and
+      rate_limit_ok?(candidate, protocol, filters)
   end
 
   defp ws_channel_live?(profile, chain_id, provider_id) do

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -636,6 +636,71 @@ defmodule Lasso.RPC.SelectionTest do
       assert :done = CandidateCursor.next(limited)
     end
 
+    test "ranked cursors apply live circuit state when candidates are requested", %{
+      chain: chain
+    } do
+      profile = "public"
+
+      setup_providers([
+        %{id: "provider_a", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "provider_b", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      for strategy <- [:fastest, :latency_weighted] do
+        cursor =
+          Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+            strategy: strategy,
+            transport: :http,
+            include_half_open: false
+          )
+
+        [first_label, _second_label] = cursor.candidate_labels
+        first_provider = String.replace_suffix(first_label, ":http", "")
+        first_instance = Catalog.lookup_instance_id(profile, chain, first_provider)
+        set_circuit_snapshot(first_instance, :open)
+
+        assert {:ok, %{provider_id: selected_provider}, cursor} = CandidateCursor.next(cursor)
+        refute selected_provider == first_provider
+        assert :done = CandidateCursor.next(cursor)
+
+        set_circuit_snapshot(first_instance, :closed)
+      end
+    end
+
+    test "ranked cursors tier a provider rate-limited after ranking", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "provider_a", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "provider_b", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http
+        )
+
+      [first_label, _second_label] = cursor.candidate_labels
+      first_provider = String.replace_suffix(first_label, ":http", "")
+      first_instance = Catalog.lookup_instance_id(profile, chain, first_provider)
+
+      :ets.insert(
+        :lasso_instance_state,
+        {{:rate_limit, first_instance, :http},
+         %{expiry_ms: System.monotonic_time(:millisecond) + 60_000}}
+      )
+
+      on_exit(fn ->
+        :ets.delete(:lasso_instance_state, {:rate_limit, first_instance, :http})
+      end)
+
+      assert {:ok, %{provider_id: selected_provider}, cursor} = CandidateCursor.next(cursor)
+      refute selected_provider == first_provider
+      assert {:ok, %{provider_id: ^first_provider}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+    end
+
     test "strategy overrides retain the eager channel contract", %{chain: chain} do
       profile = "public"
 


### PR DESCRIPTION
## Summary
- rank fastest and latency-weighted candidates without pre-reading live circuit and rate-limit gates for every provider
- apply live gate state only when each ranked candidate is requested
- preserve tiering, half-open filtering, fallback order, and eager custom-strategy behavior

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- `PORT=44129 MIX_ENV=test mix test --include integration --seed 314159` (1476 tests, 0 failures)
- `mix credo --strict`
- `mix dialyzer`
- `mix format --check-formatted`
- `git diff --check`

## Scope
Runtime selection changes and regression tests only.