### PR TITLE
Avoid reanalyzing ranked requests

### DIFF
--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -53,30 +53,51 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       method,
       opts,
       &build_descriptors/4,
-      fn -> AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation) end,
-      false
+      fn -> AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation) end
     )
   end
 
   @doc false
-  @spec new_ranked(Catalog.snapshot(), RoutingPlan.t(), String.t(), keyword(), [
-          {map(), :http | :ws}
-        ]) :: t()
-  def new_ranked(snapshot, %RoutingPlan{} = plan, method, opts, ranked_candidates)
-      when is_list(ranked_candidates) do
-    build(
-      snapshot,
-      plan,
-      method,
-      opts,
-      fn _plan, _strategy, _transport, _filters ->
-        Enum.map(ranked_candidates, fn {candidate, transport} ->
-          {:ranked, candidate, transport}
-        end)
-      end,
-      fn -> nil end,
-      true
-    )
+  @spec new_ranked(
+          Catalog.snapshot(),
+          RoutingPlan.t(),
+          String.t(),
+          keyword(),
+          [
+            {map(), :http | :ws}
+          ],
+          SelectionFilters.t(),
+          non_neg_integer() | :unavailable
+        ) :: t()
+  def new_ranked(
+        snapshot,
+        %RoutingPlan{} = plan,
+        method,
+        opts,
+        ranked_candidates,
+        %SelectionFilters{} = filters,
+        consensus_height
+      )
+      when is_list(ranked_candidates) and
+             (is_integer(consensus_height) or consensus_height == :unavailable) do
+    descriptors =
+      Enum.map(ranked_candidates, fn {candidate, transport} ->
+        {:ranked, candidate, transport}
+      end)
+
+    limit = Keyword.get(opts, :limit, 1000)
+
+    %__MODULE__{
+      snapshot: snapshot,
+      plan: plan,
+      method: method,
+      filters: filters,
+      consensus_height: consensus_height,
+      learned_scope: nil,
+      descriptors: descriptors,
+      limit: limit,
+      candidate_labels: descriptors |> Enum.take(max(limit, 0)) |> Enum.map(&descriptor_label/1)
+    }
   end
 
   defp build(
@@ -85,8 +106,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
          method,
          opts,
          descriptors_fun,
-         learned_scope_fun,
-         include_labels?
+         learned_scope_fun
        ) do
     transport = Keyword.get(opts, :transport, :both)
     strategy = Keyword.get(opts, :strategy, :load_balanced)
@@ -124,11 +144,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       learned_scope: learned_scope_fun.(),
       descriptors: descriptors,
       limit: limit,
-      candidate_labels:
-        if(include_labels?,
-          do: descriptors |> Enum.take(max(limit, 0)) |> Enum.map(&descriptor_label/1),
-          else: []
-        )
+      candidate_labels: []
     }
   end
 

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -204,7 +204,9 @@ defmodule Lasso.RPC.Selection do
   defp select_channels_from_plan(snapshot, plan, method, opts) do
     strategy = Keyword.get(opts, :strategy, :load_balanced)
     limit = Keyword.get(opts, :limit, 1000)
-    {provider_candidates, transport, workload_key} = routing_candidates(plan, method, opts)
+
+    {provider_candidates, transport, workload_key, _filters, _consensus_height} =
+      routing_candidates(plan, method, opts)
 
     # Build channel candidates via TransportRegistry (enforces channel-level health/capabilities)
     # Map provider list into channels, lazily opening as needed
@@ -249,7 +251,7 @@ defmodule Lasso.RPC.Selection do
       {:ok, snapshot, plan} ->
         strategy = Keyword.fetch!(opts, :strategy)
 
-        {candidates, _transport, workload_key} =
+        {candidates, _transport, workload_key, filters, consensus_height} =
           routing_candidates(plan, method, opts, :deferred_gates)
 
         entries =
@@ -282,7 +284,15 @@ defmodule Lasso.RPC.Selection do
           |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
 
         if selection_snapshot_current?(snapshot, candidates) do
-          CandidateCursor.new_ranked(snapshot, plan, method, opts, ranked_candidates)
+          CandidateCursor.new_ranked(
+            snapshot,
+            plan,
+            method,
+            opts,
+            ranked_candidates,
+            filters,
+            consensus_height || :unavailable
+          )
         else
           []
         end
@@ -342,7 +352,7 @@ defmodule Lasso.RPC.Selection do
           )
       end
 
-    {candidates, transport, workload_key}
+    {candidates, transport, workload_key, pool_filters, consensus_height}
   end
 
   defp ranking_channel(plan, candidate, transport) do


### PR DESCRIPTION
## Summary
- carry the already-computed selection filters and consensus snapshot into ranked cursors
- avoid repeating consensus-height lookup and request analysis after ranking
- preserve live circuit/rate admission at lazy materialization

## Validation
- warnings-as-errors compile
- 1,476 integration-enabled tests
- focused selection/candidate/pipeline tests (119)
- Credo strict
- Dialyzer
- format and diff checks

## Performance
Local fixed-4-scheduler, 8-provider fastest selection plus first materialization (7 rounds): median 15.45us -> 13.51us (~12.6% lower); reductions 2303 -> 2185 (~5.1% lower). This is a routing-selection diagnostic, not a transport or launch benchmark.