### PR TITLE
Track recent routing latency

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -23,6 +23,7 @@ defmodule Lasso.RPC.AttemptProjection do
   @control_retries 4
   @probation_deliveries 32
   @routing_evidence_max_age_us 300_000_000
+  @latency_ewma_weight 8
   @max_count 9_223_372_036_854_775_807
   @default_workload "client"
   @availability_dimensions [
@@ -646,23 +647,28 @@ defmodule Lasso.RPC.AttemptProjection do
 
   defp apply_shared_admission(row, _delta), do: row
 
-  defp apply_aggregate(row, %{kind: :success, latency_ms: latency_ms}) do
+  defp apply_aggregate(
+         row,
+         %{kind: :success, latency_ms: latency_ms, observed_at_us: observed_at_us}
+       ) do
     successes = increment(row.usable_successes)
-    old_count = max(row.usable_successes, 0)
 
-    mean =
-      if old_count == 0,
-        do: latency_ms,
-        else:
-          row.successful_mean_latency_ms +
-            (latency_ms - row.successful_mean_latency_ms) / successes
+    if observed_at_us >= row.observed_at_us do
+      mean =
+        case row.successful_mean_latency_ms do
+          nil -> latency_ms
+          previous -> previous + (latency_ms - previous) / @latency_ewma_weight
+        end
 
-    %{
-      row
-      | usable_successes: successes,
-        successful_mean_latency_ms: mean,
-        successful_p95_latency_ms: nil
-    }
+      %{
+        row
+        | usable_successes: successes,
+          successful_mean_latency_ms: mean,
+          successful_p95_latency_ms: nil
+      }
+    else
+      %{row | usable_successes: successes}
+    end
   end
 
   defp apply_aggregate(row, %{kind: :failure}),

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -316,7 +316,7 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert recovered.probation_remaining == 0
   end
 
-  test "success summaries do not mislabel a lifetime maximum as p95" do
+  test "success summaries track recent latency without mislabeling a p95" do
     generation = publish_routes(["projection-instance"])
 
     assert :ok =
@@ -332,8 +332,64 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     scope = AttemptProjection.scope_state(@profile, @chain_id)
     row = AttemptProjection.route_state(scope, "projection-instance", :http)
 
-    assert row.successful_mean_latency_ms == 505.0
+    assert row.successful_mean_latency_ms == 133.75
     assert row.successful_p95_latency_ms == nil
+  end
+
+  test "an older success delivered later cannot rewrite recent latency" do
+    generation = publish_routes(["projection-instance"])
+
+    assert :ok =
+             AttemptProjection.apply_control(
+               success_event_with_latency(200, 100_000, "projection-instance", generation)
+             )
+
+    assert :ok =
+             AttemptProjection.apply_control(
+               success_event_with_latency(199, 1_000_000, "projection-instance", generation)
+             )
+
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    row = AttemptProjection.route_state(scope, "projection-instance", :http)
+
+    assert row.usable_successes == 2
+    assert row.successful_mean_latency_ms == 100.0
+    assert row.observed_at_us == 200
+  end
+
+  test "recent sustained improvement replaces old latency without retaining samples" do
+    generation = publish_routes(["projection-instance"])
+
+    Enum.each(1..8, fn emitted_at_us ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   emitted_at_us,
+                   100_000,
+                   "projection-instance",
+                   generation
+                 )
+               )
+    end)
+
+    Enum.each(9..16, fn emitted_at_us ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   emitted_at_us,
+                   20_000,
+                   "projection-instance",
+                   generation
+                 )
+               )
+    end)
+
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    row = AttemptProjection.route_state(scope, "projection-instance", :http)
+
+    assert row.usable_successes == 16
+    assert_in_delta row.successful_mean_latency_ms, 47.488, 0.001
+    assert row.observed_at_us == 16
   end
 
   test "client and system evidence stay isolated while system latency seeds a client prior" do


### PR DESCRIPTION
## Summary
- replace lifetime successful-latency averaging with a bounded 1/8 recent estimate
- fence latency updates by the existing monotonic observation timestamp so late older events cannot rewrite current routing evidence
- retain the existing success counters and scalar-only route state

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test --include integration` (1478 tests, 0 failures)
- focused routing/request tests (92 tests, 0 failures)
- production-file Credo strict
- development-environment Dialyzer
- `git diff --check`
- fixed `+S 4:4` paired whole-request fixture: 47.183 us baseline vs 47.184 us changed median; reductions flat

No benchmark or eRPC comparison artifacts are included.