### PR TITLE
Qualify routes by recent reliability

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -24,6 +24,8 @@ defmodule Lasso.RPC.AttemptProjection do
   @probation_deliveries 32
   @routing_evidence_max_age_us 300_000_000
   @latency_ewma_weight 8
+  @reliability_ewma_weight 8
+  @qualified_reliability 0.75
   @max_count 9_223_372_036_854_775_807
   @default_workload "client"
   @availability_dimensions [
@@ -664,22 +666,35 @@ defmodule Lasso.RPC.AttemptProjection do
         row
         | usable_successes: successes,
           successful_mean_latency_ms: mean,
-          successful_p95_latency_ms: nil
+          successful_p95_latency_ms: nil,
+          recent_success_probability:
+            recent_success_probability(row.recent_success_probability, 1.0)
       }
     else
       %{row | usable_successes: successes}
     end
   end
 
-  defp apply_aggregate(row, %{kind: :failure}),
-    do: %{row | total_failures: increment(row.total_failures)}
+  defp apply_aggregate(row, %{kind: :failure, observed_at_us: observed_at_us}) do
+    row = %{row | total_failures: increment(row.total_failures)}
+
+    if observed_at_us >= row.observed_at_us do
+      %{
+        row
+        | recent_success_probability:
+            recent_success_probability(row.recent_success_probability, 0.0)
+      }
+    else
+      row
+    end
+  end
 
   defp apply_aggregate(row, %{kind: :rate_limit, retry_after_ms: retry_after_ms} = delta) do
     observed_at_us = Map.fetch!(delta, :observed_at_us)
     expiry_ms = div(observed_at_us, 1_000) + retry_after_ms
     replace_expiry? = expiry_ms >= row.rate_limit_expiry_ms
 
-    %{
+    updated = %{
       row
       | rate_limit_expiry_ms: max(row.rate_limit_expiry_ms, expiry_ms),
         rate_limit_retry_after_ms:
@@ -687,9 +702,24 @@ defmodule Lasso.RPC.AttemptProjection do
         rate_limit_observed_at_us: max_floor(row.rate_limit_observed_at_us, observed_at_us),
         total_rate_limits: increment(row.total_rate_limits)
     }
+
+    if observed_at_us >= row.observed_at_us do
+      %{
+        updated
+        | recent_success_probability:
+            recent_success_probability(row.recent_success_probability, 0.0)
+      }
+    else
+      updated
+    end
   end
 
   defp apply_aggregate(row, %{kind: :neutral}), do: row
+
+  defp recent_success_probability(nil, outcome), do: outcome
+
+  defp recent_success_probability(previous, outcome),
+    do: previous + (outcome - previous) / @reliability_ewma_weight
 
   defp apply_latest_state(row, emitted_at_us, delta) do
     if is_nil(row.state_observed_at_us) or emitted_at_us >= row.state_observed_at_us do
@@ -1104,6 +1134,7 @@ defmodule Lasso.RPC.AttemptProjection do
       usable_successes: 0,
       total_failures: 0,
       total_rate_limits: 0,
+      recent_success_probability: nil,
       successful_mean_latency_ms: nil,
       successful_p95_latency_ms: nil
     }
@@ -1342,10 +1373,19 @@ defmodule Lasso.RPC.AttemptProjection do
   defp summary(row, instance_id, transport, chain_id, workload_key, now_us) do
     state =
       cond do
-        routing_evidence_stale?(row.observed_at_us, now_us) -> :stale
-        row.usable_successes >= 3 and row.consecutive_failures < 3 -> :qualified
-        row.comparable_attempts > 0 -> :provisional
-        true -> :unqualified
+        routing_evidence_stale?(row.observed_at_us, now_us) ->
+          :stale
+
+        row.usable_successes >= 3 and row.consecutive_failures < 3 and
+          is_number(row.recent_success_probability) and
+            row.recent_success_probability >= @qualified_reliability ->
+          :qualified
+
+        row.comparable_attempts > 0 ->
+          :provisional
+
+        true ->
+          :unqualified
       end
 
     %Summary{

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -211,6 +211,7 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert row.comparable_attempts == 2
     assert row.usable_successes == 1
     assert row.total_failures == 1
+    assert row.recent_success_probability == 1.0
     assert row.observed_at_us == 200
     assert row.oldest_observed_at_us == 100
     assert row.state_observed_at_us == 200
@@ -390,6 +391,58 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert row.usable_successes == 16
     assert_in_delta row.successful_mean_latency_ms, 47.488, 0.001
     assert row.observed_at_us == 16
+  end
+
+  test "intermittent failures cannot qualify on lifetime success count alone" do
+    generation = publish_routes(["projection-instance"])
+
+    events = [
+      success_event(1, "projection-instance", generation),
+      failure_event(2, "projection-instance", generation),
+      success_event(3, "projection-instance", generation),
+      failure_event(4, "projection-instance", generation),
+      success_event(5, "projection-instance", generation),
+      failure_event(6, "projection-instance", generation),
+      success_event(7, "projection-instance", generation)
+    ]
+
+    Enum.each(events, fn event -> assert :ok = AttemptProjection.apply_control(event) end)
+
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    row = AttemptProjection.route_state(scope, "projection-instance", :http)
+
+    summary =
+      AttemptProjection.summarize_route(
+        scope,
+        row,
+        "projection-instance",
+        :http,
+        @chain_id,
+        :client
+      )
+
+    assert row.usable_successes == 4
+    assert row.total_failures == 3
+    assert row.recent_success_probability < 0.75
+    assert summary.state == :provisional
+
+    assert :ok =
+             AttemptProjection.apply_control(success_event(8, "projection-instance", generation))
+
+    recovered_row = AttemptProjection.route_state(scope, "projection-instance", :http)
+
+    recovered_summary =
+      AttemptProjection.summarize_route(
+        scope,
+        recovered_row,
+        "projection-instance",
+        :http,
+        @chain_id,
+        :client
+      )
+
+    assert recovered_row.recent_success_probability >= 0.75
+    assert recovered_summary.state == :qualified
   end
 
   test "client and system evidence stay isolated while system latency seeds a client prior" do

--- a/test/unit/strategies/evidence_ranking_test.exs
+++ b/test/unit/strategies/evidence_ranking_test.exs
@@ -222,8 +222,16 @@ defmodule Lasso.RPC.Strategies.EvidenceRankingTest do
 
         counts =
           if summary.state == :qualified,
-            do: %{comparable_attempts: 100, usable_successes: 99},
-            else: %{comparable_attempts: 0, usable_successes: 0}
+            do: %{
+              comparable_attempts: 100,
+              usable_successes: 99,
+              recent_success_probability: 1.0
+            },
+            else: %{
+              comparable_attempts: 0,
+              usable_successes: 0,
+              recent_success_probability: nil
+            }
 
         :ets.insert(
           :lasso_instance_state,


### PR DESCRIPTION
## Summary
- maintain a timestamp-fenced bounded recent-success estimate for dispatched route outcomes
- require recent reliability, not lifetime success count alone, before fastest/latency-weighted evidence is qualified
- keep neutral/cancelled observations out of the reliability estimate and preserve conservative fallback behavior

## Validation
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test --include integration` (1479 tests, 0 failures)
- focused routing/request tests (93 tests, 0 failures)
- production-file Credo strict
- development-environment Dialyzer
- `mix format` and `git diff --check`
- fixed `+S 4:4` paired whole-request fixture: 47.589 us baseline vs 47.962 us changed median (+0.8%); reductions flat

No benchmark or eRPC artifacts are included.