### PR TITLE
Defer cold-route evidence ranking

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -377,6 +377,57 @@ defmodule Lasso.RPC.AttemptProjection do
     )
   end
 
+  @doc false
+  @spec summarize_client_partition(
+          map() | nil,
+          binary(),
+          :http | :ws,
+          pos_integer(),
+          integer()
+        ) :: Summary.t() | nil
+  def summarize_client_partition(row, instance_id, transport, chain_id, now_us)
+      when (is_map(row) or is_nil(row)) and is_binary(instance_id) and
+             transport in [:http, :ws] and is_integer(chain_id) and chain_id > 0 and
+             is_integer(now_us) do
+    summary(row, instance_id, transport, chain_id, :client, now_us)
+  end
+
+  @doc false
+  @spec complete_client_summary_bounded(
+          scope_state(),
+          map() | nil,
+          binary(),
+          binary(),
+          :http | :ws,
+          pos_integer(),
+          Summary.t() | nil,
+          integer()
+        ) :: Summary.t() | nil
+  def complete_client_summary_bounded(
+        scope,
+        row,
+        instance_id,
+        routing_instance_id,
+        transport,
+        chain_id,
+        primary,
+        now_us
+      )
+      when is_map(scope) and (is_map(row) or is_nil(row)) and is_binary(instance_id) and
+             is_binary(routing_instance_id) and transport in [:http, :ws] and
+             is_integer(chain_id) and chain_id > 0 and
+             (is_struct(primary, Summary) or is_nil(primary)) and is_integer(now_us) do
+    complete_client_summary(
+      primary,
+      row,
+      {:lookup_bounded, scope, routing_instance_id},
+      instance_id,
+      transport,
+      chain_id,
+      now_us
+    )
+  end
+
   @spec prepare_routes(non_neg_integer(), [map()]) :: :ok
   def prepare_routes(generation, routes)
       when is_integer(generation) and generation >= 0 and is_list(routes) do
@@ -1275,6 +1326,26 @@ defmodule Lasso.RPC.AttemptProjection do
        ) do
     primary = summary(row, instance_id, transport, chain_id, :client, now_us)
 
+    complete_client_summary(
+      primary,
+      row,
+      shared_prior_source,
+      instance_id,
+      transport,
+      chain_id,
+      now_us
+    )
+  end
+
+  defp complete_client_summary(
+         primary,
+         row,
+         shared_prior_source,
+         instance_id,
+         transport,
+         chain_id,
+         now_us
+       ) do
     case primary do
       %Summary{state: :qualified} ->
         primary
@@ -1373,13 +1444,11 @@ defmodule Lasso.RPC.AttemptProjection do
   defp summary(row, instance_id, transport, chain_id, workload_key, now_us) do
     state =
       cond do
+        qualified_row?(row, now_us) ->
+          :qualified
+
         routing_evidence_stale?(row.observed_at_us, now_us) ->
           :stale
-
-        row.usable_successes >= 3 and row.consecutive_failures < 3 and
-          is_number(row.recent_success_probability) and
-            row.recent_success_probability >= @qualified_reliability ->
-          :qualified
 
         row.comparable_attempts > 0 ->
           :provisional
@@ -1403,6 +1472,15 @@ defmodule Lasso.RPC.AttemptProjection do
       support_source: workload_support_source(workload_key),
       generation: row.generation
     }
+  end
+
+  defp qualified_row?(nil, _now_us), do: false
+  defp qualified_row?(%{observed_at_us: nil}, _now_us), do: false
+
+  defp qualified_row?(row, now_us) do
+    not routing_evidence_stale?(row.observed_at_us, now_us) and row.usable_successes >= 3 and
+      row.consecutive_failures < 3 and is_number(row.recent_success_probability) and
+      row.recent_success_probability >= @qualified_reliability
   end
 
   defp attach_system_prior(nil, nil), do: nil

--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -1,6 +1,20 @@
 defmodule Lasso.RPC.Selection.CandidateCursor do
   @moduledoc false
 
+  defmodule DeferredRanking do
+    @moduledoc false
+
+    @enforce_keys [:entries, :scope, :chain_id, :workload_key]
+    defstruct @enforce_keys
+
+    @type t :: %__MODULE__{
+            entries: [{Lasso.RPC.Channel.t(), map(), :http | :ws}],
+            scope: map(),
+            chain_id: pos_integer(),
+            workload_key: atom()
+          }
+  end
+
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.{CandidateListing, Catalog, InstanceState}
 
@@ -15,6 +29,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
   alias Lasso.RPC.Providers.AdapterFilter
   alias Lasso.RPC.RoutingEvidence.Workload
+  alias Lasso.RPC.Strategies.Fastest
 
   @enforce_keys [
     :snapshot,
@@ -29,6 +44,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   defstruct @enforce_keys ++
               [
                 candidate_labels: [],
+                deferred_ranking: nil,
                 returned: 0,
                 supported?: false,
                 supported_deferred: %{2 => :queue.new(), 3 => :queue.new(), 4 => :queue.new()},
@@ -67,7 +83,8 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
             {map(), :http | :ws}
           ],
           SelectionFilters.t(),
-          non_neg_integer() | :unavailable
+          non_neg_integer() | :unavailable,
+          DeferredRanking.t() | nil
         ) :: t()
   def new_ranked(
         snapshot,
@@ -76,7 +93,8 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
         opts,
         ranked_candidates,
         %SelectionFilters{} = filters,
-        consensus_height
+        consensus_height,
+        deferred_ranking \\ nil
       )
       when is_list(ranked_candidates) and
              (is_integer(consensus_height) or consensus_height == :unavailable) do
@@ -87,6 +105,12 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
     limit = Keyword.get(opts, :limit, 1000)
 
+    candidate_labels =
+      descriptors
+      |> Kernel.++(deferred_descriptors(deferred_ranking))
+      |> Enum.take(max(limit, 0))
+      |> Enum.map(&descriptor_label/1)
+
     %__MODULE__{
       snapshot: snapshot,
       plan: plan,
@@ -95,8 +119,9 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       consensus_height: consensus_height,
       learned_scope: nil,
       descriptors: descriptors,
+      deferred_ranking: deferred_ranking,
       limit: limit,
-      candidate_labels: descriptors |> Enum.take(max(limit, 0)) |> Enum.map(&descriptor_label/1)
+      candidate_labels: candidate_labels
     }
   end
 
@@ -166,7 +191,8 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       | descriptors:
           Enum.reject(cursor.descriptors, &(descriptor_provider_id(&1) == provider_id)),
         supported_deferred: reject_queued_provider(cursor.supported_deferred, provider_id),
-        unsupported_deferred: reject_queued_provider(cursor.unsupported_deferred, provider_id)
+        unsupported_deferred: reject_queued_provider(cursor.unsupported_deferred, provider_id),
+        deferred_ranking: reject_deferred_provider(cursor.deferred_ranking, provider_id)
     }
   end
 
@@ -192,6 +218,17 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
       :skip ->
         scan(cursor)
+    end
+  end
+
+  defp scan(
+         %__MODULE__{descriptors: [], deferred_ranking: %DeferredRanking{} = deferred} = cursor
+       ) do
+    if current?(cursor) do
+      descriptors = rank_deferred(deferred)
+      scan(%{cursor | descriptors: descriptors, deferred_ranking: nil})
+    else
+      :stale
     end
   end
 
@@ -350,6 +387,63 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   defp descriptor_label(descriptor) do
     transport = elem(descriptor, tuple_size(descriptor) - 1)
     "#{descriptor_provider_id(descriptor)}:#{transport}"
+  end
+
+  defp deferred_descriptors(%DeferredRanking{entries: entries}) do
+    Enum.map(entries, fn {_channel, candidate, transport} ->
+      {:ranked, candidate, transport}
+    end)
+  end
+
+  defp deferred_descriptors(_deferred), do: []
+
+  defp reject_deferred_provider(%DeferredRanking{entries: entries} = deferred, provider_id) do
+    filtered =
+      Enum.reject(entries, fn {_channel, candidate, _transport} -> candidate.id == provider_id end)
+
+    %{deferred | entries: filtered}
+  end
+
+  defp reject_deferred_provider(_deferred, _provider_id), do: nil
+
+  defp rank_deferred(%DeferredRanking{
+         entries: entries,
+         scope: scope,
+         chain_id: chain_id,
+         workload_key: workload_key
+       }) do
+    summaries =
+      Map.new(entries, fn {channel, candidate, transport} ->
+        row = Map.get(candidate.routing_states, transport)
+
+        summary =
+          AttemptProjection.summarize_route_bounded(
+            scope,
+            row,
+            candidate.instance_id,
+            candidate.routing_instance_id,
+            transport,
+            chain_id,
+            workload_key
+          )
+
+        {{channel.instance_id, transport}, summary}
+      end)
+
+    entries_by_key =
+      Map.new(entries, fn {channel, candidate, transport} ->
+        {{channel.instance_id, transport}, {candidate, transport}}
+      end)
+
+    entries
+    |> Enum.map(&elem(&1, 0))
+    |> Fastest.rank_unqualified(summaries)
+    |> Enum.map(fn channel ->
+      {candidate, transport} =
+        Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
+
+      {:ranked, candidate, transport}
+    end)
   end
 
   defp empty_unsupported do

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -32,6 +32,7 @@ defmodule Lasso.RPC.Selection do
     TransportRegistry
   }
 
+  alias Lasso.RPC.Selection.CandidateCursor.DeferredRanking
   alias Lasso.RPC.Strategies.Registry, as: StrategyRegistry
   # Selection should be transport-policy agnostic. Transport constraints
   # should be provided by the caller via opts.
@@ -270,18 +271,20 @@ defmodule Lasso.RPC.Selection do
             {{channel.instance_id, transport}, {candidate, transport}}
           end)
 
-        ranked_candidates =
-          capable_channels
-          |> rank_capable_channels(
-            candidates,
-            strategy,
-            method,
-            plan,
-            Keyword.get(opts, :timeout, 30_000),
-            workload_key,
-            strategy_mod
+        {ranked_candidates, deferred_ranking} =
+          rank_candidate_channels(
+            capable_channels,
+            entries_by_key,
+            %{
+              candidates: candidates,
+              strategy: strategy,
+              method: method,
+              plan: plan,
+              timeout: Keyword.get(opts, :timeout, 30_000),
+              workload_key: workload_key,
+              strategy_mod: strategy_mod
+            }
           )
-          |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
 
         if selection_snapshot_current?(snapshot, candidates) do
           CandidateCursor.new_ranked(
@@ -291,7 +294,8 @@ defmodule Lasso.RPC.Selection do
             opts,
             ranked_candidates,
             filters,
-            consensus_height || :unavailable
+            consensus_height || :unavailable,
+            deferred_ranking
           )
         else
           []
@@ -472,6 +476,179 @@ defmodule Lasso.RPC.Selection do
         plan.chain_id
       )
     end
+  end
+
+  defp rank_candidate_channels(
+         channels,
+         entries_by_key,
+         %{
+           candidates: candidates,
+           strategy: :fastest,
+           method: method,
+           plan: plan,
+           timeout: timeout,
+           workload_key: :client,
+           strategy_mod: Lasso.RPC.Strategies.Fastest = strategy_mod
+         } = ranking
+       ) do
+    if Enum.any?(candidates, & &1.learned_feedback_degraded?) do
+      {rank_channels_eager(channels, entries_by_key, ranking), nil}
+    else
+      scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
+      now_us = System.monotonic_time(:microsecond)
+
+      {qualified, remaining} =
+        split_client_qualified(channels, entries_by_key, plan.chain_id, now_us)
+
+      case qualified do
+        [] ->
+          {rank_cold_fastest_channels(
+             remaining,
+             entries_by_key,
+             method,
+             plan,
+             timeout,
+             strategy_mod,
+             scope,
+             now_us
+           ), nil}
+
+        _qualified ->
+          summaries =
+            Map.new(qualified, fn {channel, summary} ->
+              {{channel.instance_id, channel.transport}, summary}
+            end)
+
+          prepared_ctx =
+            strategy_mod.prepare_context(plan.profile, plan.chain_id, method, timeout)
+            |> Map.put(:workload_key, :client)
+            |> Map.put(:routing_summaries, summaries)
+            |> Map.put(:provider_priorities, plan.provider_priorities)
+
+          ranked =
+            qualified
+            |> Enum.map(&elem(&1, 0))
+            |> strategy_mod.rank_channels(
+              method,
+              prepared_ctx,
+              plan.profile,
+              plan.chain_id
+            )
+            |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
+
+          deferred = %DeferredRanking{
+            entries:
+              Enum.map(remaining, fn {channel, _summary} ->
+                {candidate, transport} =
+                  Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
+
+                {channel, candidate, transport}
+              end),
+            scope: scope,
+            chain_id: plan.chain_id,
+            workload_key: :client
+          }
+
+          {ranked, deferred}
+      end
+    end
+  end
+
+  defp rank_candidate_channels(
+         channels,
+         entries_by_key,
+         ranking
+       ) do
+    {rank_channels_eager(channels, entries_by_key, ranking), nil}
+  end
+
+  defp split_client_qualified(channels, entries_by_key, chain_id, now_us) do
+    channels
+    |> Enum.map(fn channel ->
+      {candidate, transport} =
+        Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
+
+      summary =
+        candidate.routing_states
+        |> Map.get(transport)
+        |> AttemptProjection.summarize_client_partition(
+          candidate.instance_id,
+          transport,
+          chain_id,
+          now_us
+        )
+
+      {channel, summary}
+    end)
+    |> Enum.split_with(fn {_channel, summary} -> RoutingEvidence.qualified?(summary) end)
+  end
+
+  defp rank_cold_fastest_channels(
+         channels_with_summaries,
+         entries_by_key,
+         method,
+         plan,
+         timeout,
+         strategy_mod,
+         scope,
+         now_us
+       ) do
+    summaries =
+      Map.new(channels_with_summaries, fn {channel, primary} ->
+        {candidate, transport} =
+          Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
+
+        summary =
+          AttemptProjection.complete_client_summary_bounded(
+            scope,
+            Map.get(candidate.routing_states, transport),
+            candidate.instance_id,
+            candidate.routing_instance_id,
+            transport,
+            plan.chain_id,
+            primary,
+            now_us
+          )
+
+        {{channel.instance_id, transport}, summary}
+      end)
+
+    prepared_ctx =
+      strategy_mod.prepare_context(plan.profile, plan.chain_id, method, timeout)
+      |> Map.put(:workload_key, :client)
+      |> Map.put(:routing_summaries, summaries)
+      |> Map.put(:provider_priorities, plan.provider_priorities)
+
+    channels_with_summaries
+    |> Enum.map(&elem(&1, 0))
+    |> strategy_mod.rank_channels(method, prepared_ctx, plan.profile, plan.chain_id)
+    |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
+  end
+
+  defp rank_channels_eager(
+         channels,
+         entries_by_key,
+         %{
+           candidates: candidates,
+           strategy: strategy,
+           method: method,
+           plan: plan,
+           timeout: timeout,
+           workload_key: workload_key,
+           strategy_mod: strategy_mod
+         }
+       ) do
+    channels
+    |> rank_capable_channels(
+      candidates,
+      strategy,
+      method,
+      plan,
+      timeout,
+      workload_key,
+      strategy_mod
+    )
+    |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
   end
 
   defp maybe_record_single_channel_degradation(

--- a/lib/lasso/core/selection/strategies/fastest.ex
+++ b/lib/lasso/core/selection/strategies/fastest.ex
@@ -45,6 +45,12 @@ defmodule Lasso.RPC.Strategies.Fastest do
     end
   end
 
+  @doc false
+  @spec rank_unqualified([map()], map()) :: [map()]
+  def rank_unqualified(channels, summaries) when is_list(channels) and is_map(summaries) do
+    Enum.sort_by(channels, &prior_key(&1, summaries))
+  end
+
   defp prior_key(channel, summaries) do
     summary = RoutingEvidence.summary_for_channel(summaries, channel)
 

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -701,6 +701,138 @@ defmodule Lasso.RPC.SelectionTest do
       assert :done = CandidateCursor.next(cursor)
     end
 
+    test "fastest defers cold-route priors until qualified candidates are exhausted", %{
+      chain: chain
+    } do
+      profile = "public"
+
+      setup_providers([
+        %{id: "qualified", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "cold_slow", priority: 20, behavior: :healthy, profile: profile},
+        %{id: "cold_fast", priority: 30, behavior: :healthy, profile: profile}
+      ])
+
+      generation = Catalog.active_generation()
+      now_us = System.monotonic_time(:microsecond)
+
+      record_selection_successes(
+        chain,
+        profile,
+        "qualified",
+        generation,
+        now_us,
+        20_000,
+        "client"
+      )
+
+      record_selection_successes(
+        chain,
+        profile,
+        "cold_slow",
+        generation,
+        now_us + 10,
+        80_000,
+        "system"
+      )
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          request_origin: :client
+        )
+
+      assert cursor.candidate_labels == [
+               "qualified:http",
+               "cold_slow:http",
+               "cold_fast:http"
+             ]
+
+      assert {:ok, %{provider_id: "qualified"}, cursor} = CandidateCursor.next(cursor)
+
+      record_selection_successes(
+        chain,
+        profile,
+        "cold_fast",
+        generation,
+        now_us + 20,
+        10_000,
+        "system"
+      )
+
+      assert {:ok, %{provider_id: "cold_fast"}, cursor} = CandidateCursor.next(cursor)
+      assert {:ok, %{provider_id: "cold_slow"}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+
+      gated_cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          request_origin: :client
+        )
+
+      assert {:ok, %{provider_id: "qualified"}, gated_cursor} =
+               CandidateCursor.next(gated_cursor)
+
+      cold_fast_instance = Catalog.lookup_instance_id(profile, chain, "cold_fast")
+      set_circuit_snapshot(cold_fast_instance, :open)
+
+      assert {:ok, %{provider_id: "cold_slow"}, gated_cursor} =
+               CandidateCursor.next(gated_cursor)
+
+      assert :done = CandidateCursor.next(gated_cursor)
+      set_circuit_snapshot(cold_fast_instance, :closed)
+    end
+
+    test "fastest deferred routes retain exclusion and snapshot fences", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "qualified", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "excluded", priority: 20, behavior: :healthy, profile: profile},
+        %{id: "remaining", priority: 30, behavior: :healthy, profile: profile}
+      ])
+
+      generation = Catalog.active_generation()
+      now_us = System.monotonic_time(:microsecond)
+
+      record_selection_successes(
+        chain,
+        profile,
+        "qualified",
+        generation,
+        now_us,
+        20_000,
+        "client"
+      )
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          request_origin: :client
+        )
+
+      assert {:ok, %{provider_id: "qualified"}, cursor} = CandidateCursor.next(cursor)
+
+      cursor = CandidateCursor.exclude_provider(cursor, "excluded")
+      assert {:ok, %{provider_id: "remaining"}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+
+      stale_cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          request_origin: :client
+        )
+
+      assert {:ok, %{provider_id: "qualified"}, stale_cursor} =
+               CandidateCursor.next(stale_cursor)
+
+      :ok = Catalog.build_from_config()
+      assert :stale = CandidateCursor.next(stale_cursor)
+    end
+
     test "strategy overrides retain the eager channel contract", %{chain: chain} do
       profile = "public"
 
@@ -754,11 +886,61 @@ defmodule Lasso.RPC.SelectionTest do
   defp restore_env(key, value), do: Application.put_env(:lasso, key, value)
 
   defp system_success_event(chain, instance_id, generation, emitted_at_us, duration_us) do
+    selection_success_event(
+      chain,
+      "poller-profile",
+      "z_fast",
+      instance_id,
+      generation,
+      emitted_at_us,
+      duration_us,
+      "system"
+    )
+  end
+
+  defp record_selection_successes(
+         chain,
+         profile,
+         provider_id,
+         generation,
+         emitted_at_us,
+         duration_us,
+         workload_key
+       ) do
+    instance_id = Catalog.lookup_instance_id(profile, chain, provider_id)
+
+    Enum.each(0..2, fn offset ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 selection_success_event(
+                   chain,
+                   profile,
+                   provider_id,
+                   instance_id,
+                   generation,
+                   emitted_at_us + offset,
+                   duration_us,
+                   workload_key
+                 )
+               )
+    end)
+  end
+
+  defp selection_success_event(
+         chain,
+         profile,
+         provider_id,
+         instance_id,
+         generation,
+         emitted_at_us,
+         duration_us,
+         workload_key
+       ) do
     identity =
       AttemptIdentity.new(
         request_id: "selection-system-request",
         attempt_id: "selection-system-attempt-#{emitted_at_us}",
-        profile: "poller-profile",
+        profile: profile,
         chain_id: chain,
         upstream_instance_id: instance_id,
         transport: :http,
@@ -767,13 +949,13 @@ defmodule Lasso.RPC.SelectionTest do
         circuit_epoch: 1,
         execution_safety: :replay_safe,
         routing_intent: "fastest",
-        workload_key: "system",
+        workload_key: workload_key,
         request_budget_ms: 100,
         candidate_admission_count: 1,
         dispatch_count: 1
       )
 
     fact = AttemptTerminal.Response.new(identity, :success, duration_us)
-    %{AttemptProjection.new(fact, "z_fast", "eth_blockNumber") | emitted_at_us: emitted_at_us}
+    %{AttemptProjection.new(fact, provider_id, "eth_blockNumber") | emitted_at_us: emitted_at_us}
   end
 end


### PR DESCRIPTION
## Summary
- rank client-qualified fastest candidates immediately
- defer system-prior work for cold fallback routes until the cursor needs them
- preserve live admission gates, exclusions, catalog snapshot fencing, and eager behavior for degraded/custom/system paths

## Validation
- 1,485 integration-enabled tests pass
- warnings-as-errors compilation, strict Credo, Dialyzer, formatting, and diff checks pass
- paired prepared-request diagnostics show about 6% fewer reductions on the qualified healthy path; cold unqualified wall/CPU remains effectively neutral

No benchmark harnesses or comparison artifacts are included.