### PR TITLE
Add bounded fastest-route hint

### DIFF
--- a/lib/lasso/core/request/attempt_projection.ex
+++ b/lib/lasso/core/request/attempt_projection.ex
@@ -21,6 +21,7 @@ defmodule Lasso.RPC.AttemptProjection do
   @version 1
   @max_bytes 4_096
   @control_retries 4
+  @fastest_winner_interval 8
   @probation_deliveries 32
   @routing_evidence_max_age_us 300_000_000
   @latency_ewma_weight 8
@@ -60,6 +61,16 @@ defmodule Lasso.RPC.AttemptProjection do
           missing_drops: non_neg_integer(),
           contention_drops: non_neg_integer(),
           availability_degradations: map()
+        }
+
+  @type fastest_winner :: %{
+          generation: non_neg_integer(),
+          revision: non_neg_integer(),
+          route: {binary(), :http | :ws},
+          route_revision: non_neg_integer(),
+          qualified?: true,
+          latency_ms: number(),
+          observed_at_us: integer()
         }
 
   @spec new(AttemptTerminal.t(), binary(), binary()) :: t()
@@ -279,6 +290,46 @@ defmodule Lasso.RPC.AttemptProjection do
     ArgumentError -> nil
   end
 
+  @doc false
+  @spec fastest_winner(scope_state()) :: fastest_winner() | nil
+  def fastest_winner(%{degraded?: true}), do: nil
+
+  def fastest_winner(scope) when is_map(scope) do
+    key = fastest_winner_key(scope.profile, scope.chain_id)
+
+    case :ets.lookup(:lasso_instance_state, key) do
+      [{^key, winner}] ->
+        visible_fastest_winner(scope, winner)
+
+      _other ->
+        nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp visible_fastest_winner(
+         %{generation: generation} = scope,
+         %{
+           generation: generation,
+           qualified?: true,
+           route: {routing_instance_id, transport},
+           observed_at_us: observed_at_us
+         } = winner
+       )
+       when is_binary(routing_instance_id) and transport in [:http, :ws] and
+              is_integer(observed_at_us) do
+    now_us = System.monotonic_time(:microsecond)
+
+    case {visible_after_floor?(scope, observed_at_us),
+          routing_evidence_stale?(observed_at_us, now_us)} do
+      {true, false} -> winner
+      _other -> nil
+    end
+  end
+
+  defp visible_fastest_winner(_scope, _winner), do: nil
+
   @spec batch_summaries(binary(), [Channel.t() | map()], pos_integer(), atom()) :: map()
   def batch_summaries(profile, channels, chain_id, workload_key) do
     scope = scope_state(profile, chain_id)
@@ -432,11 +483,12 @@ defmodule Lasso.RPC.AttemptProjection do
   def prepare_routes(generation, routes)
       when is_integer(generation) and generation >= 0 and is_list(routes) do
     if ConfigStore.route_generation() == generation do
-      {scope_keys, route_keys, system_prior_keys} = route_keys(routes)
+      {scope_keys, route_keys, system_prior_keys, fastest_winner_keys} = route_keys(routes)
 
       Enum.each(scope_keys, &publish_scope(&1, generation))
       Enum.each(route_keys, &publish_route(&1, generation))
       Enum.each(system_prior_keys, &publish_system_prior(&1, generation))
+      Enum.each(fastest_winner_keys, &publish_fastest_winner(&1, generation))
     end
 
     :ok
@@ -448,8 +500,14 @@ defmodule Lasso.RPC.AttemptProjection do
   def commit_routes(generation, routes)
       when is_integer(generation) and generation >= 0 and is_list(routes) do
     if ConfigStore.route_generation() == generation do
-      {scope_keys, route_keys, system_prior_keys} = route_keys(routes)
-      delete_unpublished_control_rows(scope_keys, route_keys, system_prior_keys)
+      {scope_keys, route_keys, system_prior_keys, fastest_winner_keys} = route_keys(routes)
+
+      delete_unpublished_control_rows(
+        scope_keys,
+        route_keys,
+        system_prior_keys,
+        fastest_winner_keys
+      )
     end
 
     :ok
@@ -468,11 +526,12 @@ defmodule Lasso.RPC.AttemptProjection do
   @spec routes_ready?(non_neg_integer(), [map()]) :: boolean()
   def routes_ready?(generation, routes)
       when is_integer(generation) and generation >= 0 and is_list(routes) do
-    {scope_keys, route_keys, system_prior_keys} = route_keys(routes)
+    {scope_keys, route_keys, system_prior_keys, fastest_winner_keys} = route_keys(routes)
 
     scope_keys
     |> MapSet.union(route_keys)
     |> MapSet.union(system_prior_keys)
+    |> MapSet.union(fastest_winner_keys)
     |> Enum.all?(fn key ->
       case :ets.lookup(:lasso_instance_state, key) do
         [{^key, %{generation: ^generation}}] -> true
@@ -567,7 +626,8 @@ defmodule Lasso.RPC.AttemptProjection do
   defp do_update_route(key, generation, event, delta, retries, barrier) do
     case :ets.lookup(:lasso_instance_state, key) do
       [{^key, %{generation: ^generation} = current}] ->
-        workload = event.fact |> identity() |> Map.fetch!(:workload_key) |> Workload.decode()
+        identity = identity(event.fact)
+        workload = identity |> Map.fetch!(:workload_key) |> Workload.decode()
         updated = apply_delta(current, event, delta, workload)
         await_control_barrier(barrier)
 
@@ -575,8 +635,15 @@ defmodule Lasso.RPC.AttemptProjection do
           1 ->
             if ConfigStore.route_generation() == generation do
               if delta.kind == :success do
-                advance_scope(identity(event.fact), event.emitted_at_us, @control_retries)
+                advance_scope(identity, event.emitted_at_us, @control_retries)
               end
+
+              maybe_update_fastest_winner(
+                identity,
+                updated,
+                Map.put(delta, :observed_at_us, event.emitted_at_us),
+                workload
+              )
 
               :ok
             else
@@ -596,6 +663,112 @@ defmodule Lasso.RPC.AttemptProjection do
       _other ->
         record_missing(identity(event.fact), generation, event.emitted_at_us)
         :stale
+    end
+  end
+
+  defp maybe_update_fastest_winner(identity, row, delta, :client) do
+    if refresh_fastest_winner?(row, delta) do
+      update_fastest_winner(
+        fastest_winner_key(identity.profile, identity.chain_id),
+        identity.route_generation,
+        {identity.upstream_instance_id, identity.transport},
+        row,
+        delta,
+        @control_retries
+      )
+    end
+
+    :ok
+  end
+
+  defp maybe_update_fastest_winner(_identity, _row, _delta, _workload), do: :ok
+
+  defp refresh_fastest_winner?(row, %{kind: :success}) do
+    row.usable_successes <= 3 or rem(row.usable_successes, @fastest_winner_interval) == 0
+  end
+
+  defp refresh_fastest_winner?(_row, %{kind: kind}) when kind in [:failure, :rate_limit],
+    do: true
+
+  defp refresh_fastest_winner?(_row, _delta), do: false
+
+  defp update_fastest_winner(key, generation, route, row, delta, retries) when retries > 0 do
+    if ConfigStore.route_generation() == generation do
+      case :ets.lookup(:lasso_instance_state, key) do
+        [{^key, %{generation: ^generation} = current}] ->
+          updated = next_fastest_winner(current, route, row, delta)
+
+          cond do
+            updated == current -> :ok
+            replace_exact(key, current, updated) == 1 -> :ok
+            true -> update_fastest_winner(key, generation, route, row, delta, retries - 1)
+          end
+
+        _other ->
+          :stale
+      end
+    else
+      :stale
+    end
+  rescue
+    ArgumentError -> :stale
+  end
+
+  defp update_fastest_winner(_key, _generation, _route, _row, _delta, 0), do: :contended
+
+  defp next_fastest_winner(
+         %{route: route} = current,
+         route,
+         %{state_observed_at_us: observed_at_us},
+         %{kind: :failure, observed_at_us: observed_at_us}
+       ) do
+    %{default_fastest_winner(current.generation) | revision: increment(current.revision)}
+  end
+
+  defp next_fastest_winner(
+         %{route: route} = current,
+         route,
+         %{rate_limit_observed_at_us: observed_at_us},
+         %{kind: :rate_limit, observed_at_us: observed_at_us}
+       ) do
+    %{default_fastest_winner(current.generation) | revision: increment(current.revision)}
+  end
+
+  defp next_fastest_winner(current, _route, _row, %{kind: kind})
+       when kind in [:failure, :rate_limit],
+       do: current
+
+  defp next_fastest_winner(current, route, row, %{kind: :success}) do
+    now_us = System.monotonic_time(:microsecond)
+    qualified? = qualified_row?(row, now_us)
+
+    cond do
+      is_integer(current.observed_at_us) and row.observed_at_us < current.observed_at_us ->
+        current
+
+      current.route == route and row.revision <= current.route_revision ->
+        current
+
+      not qualified? and current.route == route ->
+        %{default_fastest_winner(current.generation) | revision: increment(current.revision)}
+
+      not qualified? ->
+        current
+
+      current.route == route or not current.qualified? or
+          row.successful_mean_latency_ms < current.latency_ms ->
+        %{
+          current
+          | revision: increment(current.revision),
+            route: route,
+            route_revision: row.revision,
+            qualified?: true,
+            latency_ms: row.successful_mean_latency_ms,
+            observed_at_us: row.observed_at_us
+        }
+
+      true ->
+        current
     end
   end
 
@@ -1052,6 +1225,24 @@ defmodule Lasso.RPC.AttemptProjection do
     end
   end
 
+  defp publish_fastest_winner(key, generation) do
+    case :ets.lookup(:lasso_instance_state, key) do
+      [{^key, %{generation: ^generation}}] ->
+        :ok
+
+      [{^key, current}] ->
+        if replace_exact(key, current, default_fastest_winner(generation)) == 0,
+          do: publish_fastest_winner(key, generation)
+
+      [] ->
+        if not :ets.insert_new(
+             :lasso_instance_state,
+             {key, default_fastest_winner(generation)}
+           ),
+           do: publish_fastest_winner(key, generation)
+    end
+  end
+
   defp published_scope(profile, chain_id, generation, current) do
     scope = default_scope(profile, chain_id, generation)
 
@@ -1074,7 +1265,12 @@ defmodule Lasso.RPC.AttemptProjection do
     end
   end
 
-  defp delete_unpublished_control_rows(scope_keys, route_keys, system_prior_keys) do
+  defp delete_unpublished_control_rows(
+         scope_keys,
+         route_keys,
+         system_prior_keys,
+         fastest_winner_keys
+       ) do
     scope_rows =
       :ets.match_object(:lasso_instance_state, {{:routing_control_scope, :_, :_}, :_})
 
@@ -1100,6 +1296,13 @@ defmodule Lasso.RPC.AttemptProjection do
 
     Enum.each(system_prior_rows, fn {key, _state} ->
       unless MapSet.member?(system_prior_keys, key), do: :ets.delete(:lasso_instance_state, key)
+    end)
+
+    fastest_winner_rows =
+      :ets.match_object(:lasso_instance_state, {{:routing_fastest_winner, :_, :_}, :_})
+
+    Enum.each(fastest_winner_rows, fn {key, _state} ->
+      unless MapSet.member?(fastest_winner_keys, key), do: :ets.delete(:lasso_instance_state, key)
     end)
   end
 
@@ -1169,6 +1372,18 @@ defmodule Lasso.RPC.AttemptProjection do
     Map.merge(default_partition(), %{generation: generation, revision: 0})
   end
 
+  defp default_fastest_winner(generation) do
+    %{
+      generation: generation,
+      revision: 0,
+      route: nil,
+      route_revision: 0,
+      qualified?: false,
+      latency_ms: nil,
+      observed_at_us: nil
+    }
+  end
+
   defp default_partition do
     %{
       observed_at_us: nil,
@@ -1213,11 +1428,19 @@ defmodule Lasso.RPC.AttemptProjection do
       end)
       |> MapSet.new()
 
-    {scope_keys, route_keys, system_prior_keys}
+    fastest_winner_keys =
+      routes
+      |> Enum.map(&fastest_winner_key(&1.profile, &1.chain_id))
+      |> MapSet.new()
+
+    {scope_keys, route_keys, system_prior_keys, fastest_winner_keys}
   end
 
   defp scope_key(profile, chain_id),
     do: {:routing_control_scope, BoundedIdentifier.encode(profile), chain_id}
+
+  defp fastest_winner_key(profile, chain_id),
+    do: {:routing_fastest_winner, BoundedIdentifier.encode(profile), chain_id}
 
   defp route_key(identity) do
     {:routing_control, identity.profile, identity.chain_id, identity.upstream_instance_id,

--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -117,7 +117,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       method: method,
       filters: filters,
       consensus_height: consensus_height,
-      learned_scope: nil,
+      learned_scope: deferred_scope(deferred_ranking),
       descriptors: descriptors,
       deferred_ranking: deferred_ranking,
       limit: limit,
@@ -284,7 +284,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   end
 
   defp materialize(cursor, {:ranked, candidate, transport}) do
-    routing_state = Map.fetch!(candidate.routing_states, transport)
+    routing_state = ranked_routing_state(cursor, candidate, transport)
 
     {circuit_state, rate_limited?} =
       InstanceState.read_candidate_gate(
@@ -300,6 +300,28 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       {:ok, channel, tier, AdapterFilter.method_supported?(channel, cursor.method)}
     else
       _unavailable -> :skip
+    end
+  end
+
+  defp ranked_routing_state(cursor, candidate, transport) do
+    case Map.fetch!(candidate.routing_states, transport) do
+      nil ->
+        scope =
+          cursor.learned_scope ||
+            AttemptProjection.scope_state(
+              cursor.plan.profile,
+              cursor.plan.chain_id,
+              cursor.plan.generation
+            )
+
+        AttemptProjection.route_record_bounded(
+          scope,
+          candidate.routing_instance_id,
+          transport
+        )
+
+      row ->
+        row
     end
   end
 
@@ -397,6 +419,9 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
   defp deferred_descriptors(_deferred), do: []
 
+  defp deferred_scope(%DeferredRanking{scope: scope}), do: scope
+  defp deferred_scope(_deferred), do: nil
+
   defp reject_deferred_provider(%DeferredRanking{entries: entries} = deferred, provider_id) do
     filtered =
       Enum.reject(entries, fn {_channel, candidate, _transport} -> candidate.id == provider_id end)
@@ -414,7 +439,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
        }) do
     summaries =
       Map.new(entries, fn {channel, candidate, transport} ->
-        row = Map.get(candidate.routing_states, transport)
+        row = candidate_route_record(scope, candidate, transport)
 
         summary =
           AttemptProjection.summarize_route_bounded(
@@ -444,6 +469,20 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
       {:ranked, candidate, transport}
     end)
+  end
+
+  defp candidate_route_record(scope, candidate, transport) do
+    case Map.get(candidate.routing_states, transport) do
+      nil ->
+        AttemptProjection.route_record_bounded(
+          scope,
+          candidate.routing_instance_id,
+          transport
+        )
+
+      row ->
+        row
+    end
   end
 
   defp empty_unsupported do

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -192,10 +192,17 @@ defmodule Lasso.RPC.Selection do
         end
 
       {:fastest, Lasso.RPC.Strategies.Fastest} ->
-        select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod)
+        select_ranked_channel_candidates(
+          profile,
+          chain_id,
+          method,
+          opts,
+          strategy_mod,
+          :fastest_winner
+        )
 
       {:latency_weighted, Lasso.RPC.Strategies.LatencyWeighted} ->
-        select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod)
+        select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod, :full)
 
       _custom_or_unknown ->
         select_channels(profile, chain_id, method, opts)
@@ -247,13 +254,24 @@ defmodule Lasso.RPC.Selection do
       else: []
   end
 
-  defp select_ranked_channel_candidates(profile, chain_id, method, opts, strategy_mod) do
+  defp select_ranked_channel_candidates(
+         profile,
+         chain_id,
+         method,
+         opts,
+         strategy_mod,
+         ranking_mode
+       ) do
     case capture_selection_snapshot(profile, chain_id) do
       {:ok, snapshot, plan} ->
         strategy = Keyword.fetch!(opts, :strategy)
 
+        fastest_winner = fastest_winner(ranking_mode, plan)
+
+        gate_mode = if fastest_winner, do: :deferred_fastest, else: :deferred_gates
+
         {candidates, _transport, workload_key, filters, consensus_height} =
-          routing_candidates(plan, method, opts, :deferred_gates)
+          routing_candidates(plan, method, opts, gate_mode)
 
         entries =
           for candidate <- candidates,
@@ -282,7 +300,8 @@ defmodule Lasso.RPC.Selection do
               plan: plan,
               timeout: Keyword.get(opts, :timeout, 30_000),
               workload_key: workload_key,
-              strategy_mod: strategy_mod
+              strategy_mod: strategy_mod,
+              fastest_winner: fastest_winner
             }
           )
 
@@ -341,6 +360,13 @@ defmodule Lasso.RPC.Selection do
 
     candidates =
       case gate_mode do
+        :deferred_fastest ->
+          CandidateListing.list_fastest_candidates_from_plan(
+            plan,
+            pool_filters,
+            consensus_height || :unavailable
+          )
+
         :deferred_gates ->
           CandidateListing.list_rankable_candidates_from_plan(
             plan,
@@ -358,6 +384,14 @@ defmodule Lasso.RPC.Selection do
 
     {candidates, transport, workload_key, pool_filters, consensus_height}
   end
+
+  defp fastest_winner(:fastest_winner, plan) do
+    plan.profile
+    |> AttemptProjection.scope_state(plan.chain_id, plan.generation)
+    |> AttemptProjection.fastest_winner()
+  end
+
+  defp fastest_winner(:full, _plan), do: nil
 
   defp ranking_channel(plan, candidate, transport) do
     %Channel{
@@ -481,6 +515,25 @@ defmodule Lasso.RPC.Selection do
   defp rank_candidate_channels(
          channels,
          entries_by_key,
+         %{fastest_winner: %{route: {_routing_instance_id, _transport}} = winner, plan: plan} =
+           ranking
+       ) do
+    case cached_fastest_ranking(channels, entries_by_key, winner, plan) do
+      {:ok, ranked, deferred} ->
+        {ranked, deferred}
+
+      :miss ->
+        rank_candidate_channels(
+          channels,
+          entries_by_key,
+          %{ranking | fastest_winner: nil}
+        )
+    end
+  end
+
+  defp rank_candidate_channels(
+         channels,
+         entries_by_key,
          %{
            candidates: candidates,
            strategy: :fastest,
@@ -488,7 +541,8 @@ defmodule Lasso.RPC.Selection do
            plan: plan,
            timeout: timeout,
            workload_key: :client,
-           strategy_mod: Lasso.RPC.Strategies.Fastest = strategy_mod
+           strategy_mod: Lasso.RPC.Strategies.Fastest = strategy_mod,
+           fastest_winner: nil
          } = ranking
        ) do
     if Enum.any?(candidates, & &1.learned_feedback_degraded?) do
@@ -562,6 +616,46 @@ defmodule Lasso.RPC.Selection do
     {rank_channels_eager(channels, entries_by_key, ranking), nil}
   end
 
+  defp cached_fastest_ranking(
+         channels,
+         entries_by_key,
+         %{route: {routing_instance_id, transport}},
+         plan
+       ) do
+    {winner_channels, remaining} =
+      Enum.split_with(channels, fn channel ->
+        {candidate, candidate_transport} =
+          Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
+
+        candidate.routing_instance_id == routing_instance_id and
+          candidate_transport == transport
+      end)
+
+    case winner_channels do
+      [winner] ->
+        {candidate, winner_transport} =
+          Map.fetch!(entries_by_key, {winner.instance_id, winner.transport})
+
+        deferred = %DeferredRanking{
+          entries:
+            Enum.map(remaining, fn channel ->
+              {remaining_candidate, remaining_transport} =
+                Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
+
+              {channel, remaining_candidate, remaining_transport}
+            end),
+          scope: AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation),
+          chain_id: plan.chain_id,
+          workload_key: :client
+        }
+
+        {:ok, [{candidate, winner_transport}], deferred}
+
+      _other ->
+        :miss
+    end
+  end
+
   defp split_client_qualified(channels, entries_by_key, chain_id, now_us) do
     channels
     |> Enum.map(fn channel ->
@@ -601,7 +695,7 @@ defmodule Lasso.RPC.Selection do
         summary =
           AttemptProjection.complete_client_summary_bounded(
             scope,
-            Map.get(candidate.routing_states, transport),
+            candidate_route_record(scope, candidate, transport),
             candidate.instance_id,
             candidate.routing_instance_id,
             transport,
@@ -623,6 +717,20 @@ defmodule Lasso.RPC.Selection do
     |> Enum.map(&elem(&1, 0))
     |> strategy_mod.rank_channels(method, prepared_ctx, plan.profile, plan.chain_id)
     |> Enum.map(&Map.fetch!(entries_by_key, {&1.instance_id, &1.transport}))
+  end
+
+  defp candidate_route_record(scope, candidate, transport) do
+    case Map.get(candidate.routing_states, transport) do
+      nil ->
+        AttemptProjection.route_record_bounded(
+          scope,
+          candidate.routing_instance_id,
+          transport
+        )
+
+      row ->
+        row
+    end
   end
 
   defp rank_channels_eager(

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -149,6 +149,29 @@ defmodule Lasso.Providers.CandidateListing do
   end
 
   @doc false
+  @spec list_fastest_candidates_from_plan(
+          RoutingPlan.t(),
+          SelectionFilters.t() | map(),
+          non_neg_integer() | :unavailable
+        ) :: [map()]
+  def list_fastest_candidates_from_plan(
+        %RoutingPlan{} = plan,
+        %SelectionFilters{} = filters,
+        consensus_height
+      ) do
+    list_fastest_candidates_from_plan(
+      plan,
+      SelectionFilters.to_map(filters),
+      consensus_height
+    )
+  end
+
+  def list_fastest_candidates_from_plan(%RoutingPlan{} = plan, filters, consensus_height)
+      when is_map(filters) do
+    do_list_candidates(plan, filters, :fastest_ranked, consensus_height)
+  end
+
+  @doc false
   @spec routing_candidate_from_plan(
           RoutingPlan.t(),
           RoutingPlan.provider(),
@@ -306,8 +329,16 @@ defmodule Lasso.Providers.CandidateListing do
     transports = live_transports(provider, protocol, plan.profile, plan.chain_id)
 
     include_learned? = not learned_scope.degraded?
-    http_routing = route_record(learned_scope, routing_instance_id, :http, transports)
-    ws_routing = route_record(learned_scope, routing_instance_id, :ws, transports)
+
+    {http_routing, ws_routing} =
+      if mode == :fastest_ranked do
+        {nil, nil}
+      else
+        {
+          route_record(learned_scope, routing_instance_id, :http, transports),
+          route_record(learned_scope, routing_instance_id, :ws, transports)
+        }
+      end
 
     {circuit_state, rate_limited} =
       candidate_gates(
@@ -344,13 +375,13 @@ defmodule Lasso.Providers.CandidateListing do
   end
 
   defp maybe_add_routing_identity(candidate, mode, routing_instance_id)
-       when mode in [:routing, :ranked],
+       when mode in [:routing, :ranked, :fastest_ranked],
        do: Map.put(candidate, :routing_instance_id, routing_instance_id)
 
   defp maybe_add_routing_identity(candidate, :full, _routing_instance_id), do: candidate
 
   defp maybe_add_availability(candidate, mode, _instance_id, _http, _ws, _include_learned?)
-       when mode in [:routing, :ranked],
+       when mode in [:routing, :ranked, :fastest_ranked],
        do: candidate
 
   defp maybe_add_availability(candidate, :full, instance_id, http, ws, include_learned?) do
@@ -397,13 +428,14 @@ defmodule Lasso.Providers.CandidateListing do
   end
 
   defp candidate_gates(
-         :ranked,
+         mode,
          _instance_id,
          _transports,
          _include_learned?,
          _http_routing,
          _ws_routing
-       ) do
+       )
+       when mode in [:ranked, :fastest_ranked] do
     {%{http: :deferred, ws: :deferred}, %{http: false, ws: false}}
   end
 
@@ -424,8 +456,9 @@ defmodule Lasso.Providers.CandidateListing do
     {%{http: http_cb, ws: ws_cb}, %{http: http_rl, ws: ws_rl}}
   end
 
-  defp candidate_gate_ready?(_candidate, _protocol, _include_half_open, _filters, :ranked),
-    do: true
+  defp candidate_gate_ready?(_candidate, _protocol, _include_half_open, _filters, mode)
+       when mode in [:ranked, :fastest_ranked],
+       do: true
 
   defp candidate_gate_ready?(candidate, protocol, include_half_open, filters, _mode) do
     circuit_breaker_ready?(candidate, protocol, include_half_open) and

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -667,6 +667,66 @@ defmodule Lasso.RPC.SelectionTest do
       end
     end
 
+    test "fastest winner is rechecked against learned rate limits at cursor admission", %{
+      chain: chain
+    } do
+      profile = "public"
+
+      setup_providers([
+        %{id: "winner", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "fallback", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      generation = Catalog.active_generation()
+      now_us = System.monotonic_time(:microsecond)
+
+      record_selection_successes(
+        chain,
+        profile,
+        "winner",
+        generation,
+        now_us,
+        10_000,
+        "client"
+      )
+
+      record_selection_successes(
+        chain,
+        profile,
+        "fallback",
+        generation,
+        now_us + 10,
+        20_000,
+        "client"
+      )
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http
+        )
+
+      assert hd(cursor.candidate_labels) == "winner:http"
+
+      winner_instance = Catalog.lookup_instance_id(profile, chain, "winner")
+
+      assert :ok =
+               AttemptProjection.apply_control(
+                 selection_quota_event(
+                   chain,
+                   profile,
+                   "winner",
+                   winner_instance,
+                   generation,
+                   now_us + 20
+                 )
+               )
+
+      assert {:ok, %{provider_id: "fallback"}, cursor} = CandidateCursor.next(cursor)
+      assert {:ok, %{provider_id: "winner"}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+    end
+
     test "ranked cursors tier a provider rate-limited after ranking", %{chain: chain} do
       profile = "public"
 
@@ -956,6 +1016,43 @@ defmodule Lasso.RPC.SelectionTest do
       )
 
     fact = AttemptTerminal.Response.new(identity, :success, duration_us)
+    %{AttemptProjection.new(fact, provider_id, "eth_blockNumber") | emitted_at_us: emitted_at_us}
+  end
+
+  defp selection_quota_event(
+         chain,
+         profile,
+         provider_id,
+         instance_id,
+         generation,
+         emitted_at_us
+       ) do
+    identity =
+      AttemptIdentity.new(
+        request_id: "selection-quota-request",
+        attempt_id: "selection-quota-attempt-#{emitted_at_us}",
+        profile: profile,
+        chain_id: chain,
+        upstream_instance_id: instance_id,
+        transport: :http,
+        route_generation: generation,
+        circuit_scope: :broad,
+        circuit_epoch: 1,
+        execution_safety: :replay_safe,
+        routing_intent: "fastest",
+        workload_key: "client",
+        request_budget_ms: 100,
+        candidate_admission_count: 1,
+        dispatch_count: 1
+      )
+
+    fact =
+      AttemptTerminal.Response.new(identity, :application_error, 10,
+        error_code: -32_005,
+        error_category: :quota,
+        retry_after_ms: 60_000
+      )
+
     %{AttemptProjection.new(fact, provider_id, "eth_blockNumber") | emitted_at_us: emitted_at_us}
   end
 end

--- a/test/lasso/core/request/attempt_projection_test.exs
+++ b/test/lasso/core/request/attempt_projection_test.exs
@@ -337,6 +337,152 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert row.successful_p95_latency_ms == nil
   end
 
+  test "fastest winner is qualified, generation-local, and cleared by its own failure" do
+    generation = publish_routes(["projection-slow", "projection-fast"])
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    started_at_us = System.monotonic_time(:microsecond)
+
+    Enum.each(1..3, fn offset ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   started_at_us + offset,
+                   100_000,
+                   "projection-slow",
+                   generation
+                 )
+               )
+    end)
+
+    assert %{route: {"projection-slow", :http}} = AttemptProjection.fastest_winner(scope)
+
+    Enum.each(4..6, fn offset ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   started_at_us + offset,
+                   10_000,
+                   "projection-fast",
+                   generation
+                 )
+               )
+    end)
+
+    assert %{route: {"projection-fast", :http}, latency_ms: 10.0} =
+             AttemptProjection.fastest_winner(scope)
+
+    assert :ok =
+             AttemptProjection.apply_control(
+               failure_event(started_at_us + 7, "projection-slow", generation)
+             )
+
+    assert %{route: {"projection-fast", :http}} = AttemptProjection.fastest_winner(scope)
+
+    assert :ok =
+             AttemptProjection.apply_control(
+               failure_event(started_at_us + 8, "projection-fast", generation)
+             )
+
+    assert AttemptProjection.fastest_winner(scope) == nil
+  end
+
+  test "fastest winner rows have fixed scope cardinality and reconcile removed scopes" do
+    generation = ConfigStore.route_generation()
+
+    routes = [
+      %{profile: @profile, chain_id: @chain_id, instance_id: "projection-a", transport: :http},
+      %{profile: @profile, chain_id: @chain_id, instance_id: "projection-b", transport: :ws},
+      %{
+        profile: "projection-peer",
+        chain_id: @chain_id,
+        instance_id: "projection-c",
+        transport: :http
+      }
+    ]
+
+    assert :ok = AttemptProjection.reconcile_routes(generation, routes)
+
+    assert 2 ==
+             :ets.match_object(
+               :lasso_instance_state,
+               {{:routing_fastest_winner, :_, @chain_id}, :_}
+             )
+             |> length()
+
+    assert :ok = AttemptProjection.reconcile_routes(generation, [List.last(routes)])
+
+    assert [{{:routing_fastest_winner, "projection-peer", @chain_id}, _state}] =
+             :ets.match_object(
+               :lasso_instance_state,
+               {{:routing_fastest_winner, :_, @chain_id}, :_}
+             )
+  end
+
+  test "older cross-route evidence cannot replace a newer fastest winner" do
+    generation = publish_routes(["projection-newer", "projection-older"])
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    started_at_us = System.monotonic_time(:microsecond)
+
+    Enum.each(1..3, fn offset ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   started_at_us + 100 + offset,
+                   20_000,
+                   "projection-newer",
+                   generation
+                 )
+               )
+    end)
+
+    assert %{route: {"projection-newer", :http}, latency_ms: 20.0} =
+             AttemptProjection.fastest_winner(scope)
+
+    Enum.each(1..3, fn offset ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   started_at_us + offset,
+                   1_000,
+                   "projection-older",
+                   generation
+                 )
+               )
+    end)
+
+    assert %{route: {"projection-newer", :http}, latency_ms: 20.0} =
+             AttemptProjection.fastest_winner(scope)
+  end
+
+  test "an older failure cannot clear a newer fastest winner" do
+    generation = publish_routes(["projection-instance"])
+    scope = AttemptProjection.scope_state(@profile, @chain_id)
+    started_at_us = System.monotonic_time(:microsecond)
+
+    Enum.each(1..3, fn offset ->
+      assert :ok =
+               AttemptProjection.apply_control(
+                 success_event_with_latency(
+                   started_at_us + 100 + offset,
+                   10_000,
+                   "projection-instance",
+                   generation
+                 )
+               )
+    end)
+
+    assert %{route: {"projection-instance", :http}} =
+             AttemptProjection.fastest_winner(scope)
+
+    assert :ok =
+             AttemptProjection.apply_control(
+               failure_event(started_at_us + 1, "projection-instance", generation)
+             )
+
+    assert %{route: {"projection-instance", :http}} =
+             AttemptProjection.fastest_winner(scope)
+  end
+
   test "an older success delivered later cannot rewrite recent latency" do
     generation = publish_routes(["projection-instance"])
 
@@ -916,6 +1062,7 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     assert row.stale_drops == 1
     assert row.comparable_attempts == 0
     assert is_nil(row.observed_at_us)
+    assert AttemptProjection.fastest_winner(scope) == nil
   end
 
   test "a missing scope is conservatively degraded and neutral" do
@@ -1072,6 +1219,16 @@ defmodule Lasso.RPC.AttemptProjectionTest do
     )
 
     :ets.match_delete(:lasso_instance_state, {{:routing_system_prior, :_, :_, :_}, :_})
+
+    :ets.match_delete(
+      :lasso_instance_state,
+      {{:routing_fastest_winner, @profile, :_}, :_}
+    )
+
+    :ets.match_delete(
+      :lasso_instance_state,
+      {{:routing_fastest_winner, "projection-peer", :_}, :_}
+    )
   rescue
     ArgumentError -> :ok
   end

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -86,6 +86,33 @@ defmodule Lasso.Providers.CandidateListingTest do
       assert Map.has_key?(candidate, :rate_limited)
     end
 
+    test "fastest winner candidates defer canonical route reads until cursor admission" do
+      {:ok, plan} = Catalog.get_routing_plan(Catalog.snapshot(), @profile, @chain)
+
+      fastest =
+        CandidateListing.list_fastest_candidates_from_plan(
+          plan,
+          %{protocol: :http},
+          :unavailable
+        )
+
+      assert length(fastest) == 3
+
+      assert Enum.all?(fastest, fn candidate ->
+               candidate.routing_states == %{http: nil, ws: nil} and
+                 candidate.circuit_state == %{http: :deferred, ws: :deferred}
+             end)
+
+      [rankable | _] =
+        CandidateListing.list_rankable_candidates_from_plan(
+          plan,
+          %{protocol: :http},
+          :unavailable
+        )
+
+      assert is_map(rankable.routing_states.http)
+    end
+
     test "lag filtering uses the request's captured consensus" do
       {:ok, plan} = Catalog.get_routing_plan(Catalog.snapshot(), @profile, @chain)
       providers = Map.new(plan.providers, &{&1.id, &1.instance_id})


### PR DESCRIPTION
## Summary
- maintain one generation-fenced fastest-route hint per profile and chain
- avoid scanning every learned route on the warmed built-in fastest path
- revalidate hinted and deferred candidates against canonical circuit, rate-limit, and learned state at cursor admission

## Safety
- hints are fixed-cardinality, advisory, generation-local, and disabled while learned feedback is degraded
- failures and quotas clear the affected winner; stale evidence cannot overwrite newer evidence
- cold, missing, stale, or contended hints fall back to the existing canonical ranking path

## Validation
- `mix test --include integration --seed 8675309` (1,491 tests, 0 failures)
- focused selection/projection suite across six seeds (558 tests, 0 failures)
- warnings-as-errors compile, strict Credo, formatting, and diff check
- no new Dialyzer findings in changed production modules

## Diagnostic performance
Fixed `+S 4:4`, 8-provider healthy fastest-routing kernel versus exact main: roughly 7-8% fewer reductions/request; clean paired runs improved throughput about 6% at c1 and 11-20% at c32, with generally lower concurrent CPU/request and p95. These are local routing diagnostics, not an eRPC or launch claim.