### PR TITLE
Defer fastest fallback materialization

### DIFF
--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -315,13 +315,25 @@ defmodule Lasso.RPC.RequestPipeline do
   end
 
   defp do_attempt_channels({%Channel{} = channel, rest}, ctx, param_rejected, caller_guard) do
-    do_attempt_channels([channel], ctx, param_rejected, caller_guard, rest)
+    do_attempt_channels(
+      [channel],
+      track_materialized_candidate(ctx, channel),
+      param_rejected,
+      caller_guard,
+      rest
+    )
   end
 
   defp do_attempt_channels(%CandidateCursor{} = cursor, ctx, param_rejected, caller_guard) do
     case CandidateCursor.next(cursor) do
       {:ok, channel, rest} ->
-        do_attempt_channels([channel], ctx, param_rejected, caller_guard, rest)
+        do_attempt_channels(
+          [channel],
+          track_materialized_candidate(ctx, channel),
+          param_rejected,
+          caller_guard,
+          rest
+        )
 
       result when result in [:done, :stale] ->
         do_attempt_channels([], ctx, param_rejected, caller_guard)
@@ -426,6 +438,16 @@ defmodule Lasso.RPC.RequestPipeline do
 
   defp candidate_labels(%CandidateCursor{}, %Channel{} = selected),
     do: ["#{selected.provider_id}:#{selected.transport}"]
+
+  defp track_materialized_candidate(ctx, channel) do
+    label = "#{channel.provider_id}:#{channel.transport}"
+
+    if label in ctx.candidate_providers do
+      ctx
+    else
+      %{ctx | candidate_providers: ctx.candidate_providers ++ [label]}
+    end
+  end
 
   defp retry_param_rejected(channels, ctx, caller_guard) do
     Logger.warning("All channels rejected by parameter limits, attempting anyway",

--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -5,13 +5,17 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
     @moduledoc false
 
     @enforce_keys [:entries, :scope, :chain_id, :workload_key]
-    defstruct @enforce_keys
+    defstruct @enforce_keys ++
+                [resolver: nil, excluded_routes: MapSet.new(), candidate_labels: nil]
 
     @type t :: %__MODULE__{
             entries: [{Lasso.RPC.Channel.t(), map(), :http | :ws}],
             scope: map(),
             chain_id: pos_integer(),
-            workload_key: atom()
+            workload_key: atom(),
+            resolver: (-> {[{map(), :http | :ws}], t() | nil}) | nil,
+            excluded_routes: MapSet.t({String.t(), :http | :ws}),
+            candidate_labels: [String.t()] | nil
           }
   end
 
@@ -45,6 +49,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
               [
                 candidate_labels: [],
                 deferred_ranking: nil,
+                excluded_provider_ids: MapSet.new(),
                 returned: 0,
                 supported?: false,
                 supported_deferred: %{2 => :queue.new(), 3 => :queue.new(), 4 => :queue.new()},
@@ -106,10 +111,11 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
     limit = Keyword.get(opts, :limit, 1000)
 
     candidate_labels =
-      descriptors
-      |> Kernel.++(deferred_descriptors(deferred_ranking))
-      |> Enum.take(max(limit, 0))
-      |> Enum.map(&descriptor_label/1)
+      deferred_candidate_labels(deferred_ranking) ||
+        descriptors
+        |> Kernel.++(deferred_descriptors(deferred_ranking))
+        |> Enum.take(max(limit, 0))
+        |> Enum.map(&descriptor_label/1)
 
     %__MODULE__{
       snapshot: snapshot,
@@ -192,7 +198,8 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
           Enum.reject(cursor.descriptors, &(descriptor_provider_id(&1) == provider_id)),
         supported_deferred: reject_queued_provider(cursor.supported_deferred, provider_id),
         unsupported_deferred: reject_queued_provider(cursor.unsupported_deferred, provider_id),
-        deferred_ranking: reject_deferred_provider(cursor.deferred_ranking, provider_id)
+        deferred_ranking: reject_deferred_provider(cursor.deferred_ranking, provider_id),
+        excluded_provider_ids: MapSet.put(cursor.excluded_provider_ids, provider_id)
     }
   end
 
@@ -218,6 +225,33 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
 
       :skip ->
         scan(cursor)
+    end
+  end
+
+  defp scan(
+         %{
+           descriptors: [],
+           deferred_ranking: %DeferredRanking{resolver: resolver} = deferred
+         } = cursor
+       )
+       when is_function(resolver, 0) do
+    if current?(cursor) do
+      {ranked_candidates, next_deferred} = resolver.()
+
+      descriptors =
+        ranked_candidates
+        |> Enum.map(fn {candidate, transport} -> {:ranked, candidate, transport} end)
+        |> reject_resolved(cursor, deferred.excluded_routes)
+
+      next_deferred =
+        next_deferred
+        |> reject_deferred_routes(deferred.excluded_routes)
+        |> reject_deferred_providers(cursor.excluded_provider_ids)
+
+      cursor = append_resolved_labels(cursor, descriptors, next_deferred)
+      scan(%{cursor | descriptors: descriptors, deferred_ranking: next_deferred})
+    else
+      :stale
     end
   end
 
@@ -422,6 +456,24 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   defp deferred_scope(%DeferredRanking{scope: scope}), do: scope
   defp deferred_scope(_deferred), do: nil
 
+  defp deferred_candidate_labels(%DeferredRanking{candidate_labels: labels}), do: labels
+  defp deferred_candidate_labels(_deferred), do: nil
+
+  defp append_resolved_labels(cursor, descriptors, deferred) do
+    labels =
+      descriptors
+      |> Kernel.++(deferred_descriptors(deferred))
+      |> Enum.map(&descriptor_label/1)
+
+    candidate_labels =
+      cursor.candidate_labels
+      |> Kernel.++(labels)
+      |> Enum.uniq()
+      |> Enum.take(max(cursor.limit, 0))
+
+    %{cursor | candidate_labels: candidate_labels}
+  end
+
   defp reject_deferred_provider(%DeferredRanking{entries: entries} = deferred, provider_id) do
     filtered =
       Enum.reject(entries, fn {_channel, candidate, _transport} -> candidate.id == provider_id end)
@@ -430,6 +482,37 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   end
 
   defp reject_deferred_provider(_deferred, _provider_id), do: nil
+
+  defp reject_deferred_providers(deferred, provider_ids) do
+    Enum.reduce(provider_ids, deferred, &reject_deferred_provider(&2, &1))
+  end
+
+  defp reject_deferred_routes(%DeferredRanking{entries: entries} = deferred, routes) do
+    filtered =
+      Enum.reject(entries, fn {channel, _candidate, transport} ->
+        MapSet.member?(routes, {channel.instance_id, transport})
+      end)
+
+    %{deferred | entries: filtered}
+  end
+
+  defp reject_deferred_routes(nil, _routes), do: nil
+
+  defp reject_resolved(descriptors, cursor, routes) do
+    Enum.reject(descriptors, fn descriptor ->
+      provider_id = descriptor_provider_id(descriptor)
+      transport = elem(descriptor, tuple_size(descriptor) - 1)
+
+      MapSet.member?(cursor.excluded_provider_ids, provider_id) or
+        resolved_route_member?(descriptor, transport, routes)
+    end)
+  end
+
+  defp resolved_route_member?({:ranked, candidate, _transport}, transport, routes) do
+    MapSet.member?(routes, {candidate.instance_id, transport})
+  end
+
+  defp resolved_route_member?(_descriptor, _transport, _routes), do: false
 
   defp rank_deferred(%DeferredRanking{
          entries: entries,

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -265,59 +265,31 @@ defmodule Lasso.RPC.Selection do
     case capture_selection_snapshot(profile, chain_id) do
       {:ok, snapshot, plan} ->
         strategy = Keyword.fetch!(opts, :strategy)
-
         fastest_winner = fastest_winner(ranking_mode, plan)
+        inputs = routing_inputs(plan, method, opts)
 
-        gate_mode = if fastest_winner, do: :deferred_fastest, else: :deferred_gates
+        case build_hinted_fastest_cursor(
+               snapshot,
+               plan,
+               method,
+               opts,
+               strategy_mod,
+               fastest_winner,
+               inputs
+             ) do
+          {:ok, cursor} ->
+            cursor
 
-        {candidates, _transport, workload_key, filters, consensus_height} =
-          routing_candidates(plan, method, opts, gate_mode)
-
-        entries =
-          for candidate <- candidates,
-              transport <- candidate.transports do
-            {ranking_channel(plan, candidate, transport), candidate, transport}
-          end
-
-        capable_channels =
-          entries
-          |> Enum.map(&elem(&1, 0))
-          |> filter_capable_channels(method)
-
-        entries_by_key =
-          Map.new(entries, fn {channel, candidate, transport} ->
-            {{channel.instance_id, transport}, {candidate, transport}}
-          end)
-
-        {ranked_candidates, deferred_ranking} =
-          rank_candidate_channels(
-            capable_channels,
-            entries_by_key,
-            %{
-              candidates: candidates,
-              strategy: strategy,
-              method: method,
-              plan: plan,
-              timeout: Keyword.get(opts, :timeout, 30_000),
-              workload_key: workload_key,
-              strategy_mod: strategy_mod,
-              fastest_winner: fastest_winner
-            }
-          )
-
-        if selection_snapshot_current?(snapshot, candidates) do
-          CandidateCursor.new_ranked(
-            snapshot,
-            plan,
-            method,
-            opts,
-            ranked_candidates,
-            filters,
-            consensus_height || :unavailable,
-            deferred_ranking
-          )
-        else
-          []
+          :miss ->
+            build_ranked_cursor(
+              snapshot,
+              plan,
+              method,
+              opts,
+              strategy_mod,
+              strategy,
+              inputs
+            )
         end
 
       :unavailable ->
@@ -326,6 +298,16 @@ defmodule Lasso.RPC.Selection do
   end
 
   defp routing_candidates(plan, method, opts, gate_mode \\ :captured_gates) do
+    {transport, workload_key, pool_filters, consensus_height} =
+      routing_inputs(plan, method, opts)
+
+    candidates =
+      candidates_from_inputs(plan, pool_filters, consensus_height, gate_mode)
+
+    {candidates, transport, workload_key, pool_filters, consensus_height}
+  end
+
+  defp routing_inputs(plan, method, opts) do
     transport = Keyword.get(opts, :transport, :both)
     workload_key = workload_for_origin(Keyword.get(opts, :request_origin, :client))
 
@@ -358,32 +340,223 @@ defmodule Lasso.RPC.Selection do
         workload_key: workload_key
       )
 
-    candidates =
-      case gate_mode do
-        :deferred_fastest ->
-          CandidateListing.list_fastest_candidates_from_plan(
-            plan,
-            pool_filters,
-            consensus_height || :unavailable
-          )
+    {transport, workload_key, pool_filters, consensus_height}
+  end
 
-        :deferred_gates ->
-          CandidateListing.list_rankable_candidates_from_plan(
-            plan,
-            pool_filters,
-            consensus_height || :unavailable
-          )
+  defp candidates_from_inputs(plan, filters, consensus_height, gate_mode) do
+    case gate_mode do
+      :deferred_fastest ->
+        CandidateListing.list_fastest_candidates_from_plan(
+          plan,
+          filters,
+          consensus_height || :unavailable
+        )
 
-        :captured_gates ->
-          CandidateListing.list_routing_candidates_from_plan(
-            plan,
-            pool_filters,
-            consensus_height || :unavailable
-          )
+      :deferred_gates ->
+        CandidateListing.list_rankable_candidates_from_plan(
+          plan,
+          filters,
+          consensus_height || :unavailable
+        )
+
+      :captured_gates ->
+        CandidateListing.list_routing_candidates_from_plan(
+          plan,
+          filters,
+          consensus_height || :unavailable
+        )
+    end
+  end
+
+  defp build_ranked_cursor(
+         snapshot,
+         plan,
+         method,
+         opts,
+         strategy_mod,
+         strategy,
+         {_, workload_key, filters, consensus_height}
+       ) do
+    timeout = Keyword.get(opts, :timeout, 30_000)
+
+    {ranked_candidates, deferred_ranking, candidates} =
+      ranked_candidate_state(
+        plan,
+        method,
+        timeout,
+        strategy_mod,
+        strategy,
+        workload_key,
+        filters,
+        consensus_height
+      )
+
+    if selection_snapshot_current?(snapshot, candidates) do
+      CandidateCursor.new_ranked(
+        snapshot,
+        plan,
+        method,
+        opts,
+        ranked_candidates,
+        filters,
+        consensus_height || :unavailable,
+        deferred_ranking
+      )
+    else
+      []
+    end
+  end
+
+  defp ranked_candidate_state(
+         plan,
+         method,
+         timeout,
+         strategy_mod,
+         strategy,
+         workload_key,
+         filters,
+         consensus_height
+       ) do
+    candidates = candidates_from_inputs(plan, filters, consensus_height, :deferred_gates)
+
+    entries =
+      for candidate <- candidates,
+          transport <- candidate.transports do
+        {ranking_channel(plan, candidate, transport), candidate, transport}
       end
 
-    {candidates, transport, workload_key, pool_filters, consensus_height}
+    capable_channels =
+      entries
+      |> Enum.map(&elem(&1, 0))
+      |> filter_capable_channels(method)
+
+    entries_by_key =
+      Map.new(entries, fn {channel, candidate, transport} ->
+        {{channel.instance_id, transport}, {candidate, transport}}
+      end)
+
+    {ranked_candidates, deferred_ranking} =
+      rank_candidate_channels(
+        capable_channels,
+        entries_by_key,
+        %{
+          candidates: candidates,
+          strategy: strategy,
+          method: method,
+          plan: plan,
+          timeout: timeout,
+          workload_key: workload_key,
+          strategy_mod: strategy_mod
+        }
+      )
+
+    {ranked_candidates, deferred_ranking, candidates}
   end
+
+  defp build_hinted_fastest_cursor(
+         snapshot,
+         plan,
+         method,
+         opts,
+         strategy_mod,
+         %{route: {routing_instance_id, winner_transport}},
+         {requested_transport, workload_key, filters, consensus_height}
+       ) do
+    matching_providers =
+      Enum.filter(plan.providers, fn provider ->
+        provider.routing_instance_id == routing_instance_id and
+          winner_transport in transports_to_check(requested_transport) and
+          winner_transport in provider.transports
+      end)
+
+    candidate_entries =
+      case matching_providers do
+        [provider] ->
+          candidate_plan = %{plan | providers: [provider]}
+
+          for candidate <-
+                candidates_from_inputs(
+                  candidate_plan,
+                  filters,
+                  consensus_height,
+                  :deferred_fastest
+                ),
+              winner_transport in candidate.transports do
+            {ranking_channel(plan, candidate, winner_transport), candidate, winner_transport}
+          end
+
+        _ambiguous_or_missing ->
+          []
+      end
+
+    capable_entries =
+      candidate_entries
+      |> Enum.filter(fn {channel, _candidate, _transport} ->
+        filter_capable_channels([channel], method) == [channel]
+      end)
+
+    case capable_entries do
+      [{_channel, candidate, transport}] ->
+        timeout = Keyword.get(opts, :timeout, 30_000)
+        limit = Keyword.get(opts, :limit, 1000)
+
+        resolver = fn ->
+          {ranked, deferred, _candidates} =
+            ranked_candidate_state(
+              plan,
+              method,
+              timeout,
+              strategy_mod,
+              :fastest,
+              workload_key,
+              filters,
+              consensus_height
+            )
+
+          {ranked, deferred}
+        end
+
+        deferred = %DeferredRanking{
+          entries: [],
+          scope: AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation),
+          chain_id: plan.chain_id,
+          workload_key: workload_key,
+          resolver: resolver,
+          excluded_routes: MapSet.new([{candidate.instance_id, transport}]),
+          candidate_labels: if(limit > 0, do: ["#{candidate.id}:#{transport}"], else: [])
+        }
+
+        if selection_snapshot_current?(snapshot, [candidate]) do
+          {:ok,
+           CandidateCursor.new_ranked(
+             snapshot,
+             plan,
+             method,
+             opts,
+             [{candidate, transport}],
+             filters,
+             consensus_height || :unavailable,
+             deferred
+           )}
+        else
+          :miss
+        end
+
+      _missing_or_unsupported ->
+        :miss
+    end
+  end
+
+  defp build_hinted_fastest_cursor(
+         _snapshot,
+         _plan,
+         _method,
+         _opts,
+         _strategy_mod,
+         _winner,
+         _inputs
+       ),
+       do: :miss
 
   defp fastest_winner(:fastest_winner, plan) do
     plan.profile
@@ -515,25 +688,6 @@ defmodule Lasso.RPC.Selection do
   defp rank_candidate_channels(
          channels,
          entries_by_key,
-         %{fastest_winner: %{route: {_routing_instance_id, _transport}} = winner, plan: plan} =
-           ranking
-       ) do
-    case cached_fastest_ranking(channels, entries_by_key, winner, plan) do
-      {:ok, ranked, deferred} ->
-        {ranked, deferred}
-
-      :miss ->
-        rank_candidate_channels(
-          channels,
-          entries_by_key,
-          %{ranking | fastest_winner: nil}
-        )
-    end
-  end
-
-  defp rank_candidate_channels(
-         channels,
-         entries_by_key,
          %{
            candidates: candidates,
            strategy: :fastest,
@@ -541,8 +695,7 @@ defmodule Lasso.RPC.Selection do
            plan: plan,
            timeout: timeout,
            workload_key: :client,
-           strategy_mod: Lasso.RPC.Strategies.Fastest = strategy_mod,
-           fastest_winner: nil
+           strategy_mod: Lasso.RPC.Strategies.Fastest = strategy_mod
          } = ranking
        ) do
     if Enum.any?(candidates, & &1.learned_feedback_degraded?) do
@@ -614,46 +767,6 @@ defmodule Lasso.RPC.Selection do
          ranking
        ) do
     {rank_channels_eager(channels, entries_by_key, ranking), nil}
-  end
-
-  defp cached_fastest_ranking(
-         channels,
-         entries_by_key,
-         %{route: {routing_instance_id, transport}},
-         plan
-       ) do
-    {winner_channels, remaining} =
-      Enum.split_with(channels, fn channel ->
-        {candidate, candidate_transport} =
-          Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
-
-        candidate.routing_instance_id == routing_instance_id and
-          candidate_transport == transport
-      end)
-
-    case winner_channels do
-      [winner] ->
-        {candidate, winner_transport} =
-          Map.fetch!(entries_by_key, {winner.instance_id, winner.transport})
-
-        deferred = %DeferredRanking{
-          entries:
-            Enum.map(remaining, fn channel ->
-              {remaining_candidate, remaining_transport} =
-                Map.fetch!(entries_by_key, {channel.instance_id, channel.transport})
-
-              {channel, remaining_candidate, remaining_transport}
-            end),
-          scope: AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation),
-          chain_id: plan.chain_id,
-          workload_key: :client
-        }
-
-        {:ok, [{candidate, winner_transport}], deferred}
-
-      _other ->
-        :miss
-    end
   end
 
   defp split_client_qualified(channels, entries_by_key, chain_id, now_us) do

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -727,6 +727,87 @@ defmodule Lasso.RPC.SelectionTest do
       assert :done = CandidateCursor.next(cursor)
     end
 
+    test "fastest winner defers construction of fallback candidates", %{chain: chain} do
+      profile = "public"
+
+      setup_providers([
+        %{id: "winner", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "fallback_a", priority: 20, behavior: :healthy, profile: profile},
+        %{id: "fallback_b", priority: 30, behavior: :healthy, profile: profile}
+      ])
+
+      generation = Catalog.active_generation()
+      now_us = System.monotonic_time(:microsecond)
+
+      record_selection_successes(
+        chain,
+        profile,
+        "winner",
+        generation,
+        now_us,
+        10_000,
+        "client"
+      )
+
+      record_selection_successes(
+        chain,
+        profile,
+        "fallback_a",
+        generation,
+        now_us + 10,
+        20_000,
+        "client"
+      )
+
+      record_selection_successes(
+        chain,
+        profile,
+        "fallback_b",
+        generation,
+        now_us + 20,
+        30_000,
+        "client"
+      )
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http
+        )
+
+      assert cursor.candidate_labels == ["winner:http"]
+      assert length(cursor.descriptors) == 1
+      assert cursor.deferred_ranking.entries == []
+      assert is_function(cursor.deferred_ranking.resolver, 0)
+
+      large_params = Enum.to_list(1..50_000)
+
+      large_cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          params: large_params
+        )
+
+      {:env, resolver_environment} =
+        Function.info(large_cursor.deferred_ranking.resolver, :env)
+
+      refute Enum.any?(resolver_environment, &(&1 == large_params))
+      assert :erts_debug.flat_size(resolver_environment) < 5_000
+
+      assert {:ok, %{provider_id: "winner"}, cursor} = CandidateCursor.next(cursor)
+      assert {:ok, %{provider_id: "fallback_a"}, cursor} = CandidateCursor.next(cursor)
+
+      assert cursor.candidate_labels == [
+               "winner:http",
+               "fallback_a:http",
+               "fallback_b:http"
+             ]
+
+      assert {:ok, %{provider_id: "fallback_b"}, cursor} = CandidateCursor.next(cursor)
+      assert :done = CandidateCursor.next(cursor)
+    end
+
     test "ranked cursors tier a provider rate-limited after ranking", %{chain: chain} do
       profile = "public"
 
@@ -802,11 +883,7 @@ defmodule Lasso.RPC.SelectionTest do
           request_origin: :client
         )
 
-      assert cursor.candidate_labels == [
-               "qualified:http",
-               "cold_slow:http",
-               "cold_fast:http"
-             ]
+      assert cursor.candidate_labels == ["qualified:http"]
 
       assert {:ok, %{provider_id: "qualified"}, cursor} = CandidateCursor.next(cursor)
 


### PR DESCRIPTION
## Summary
- materialize only the learned fastest winner on the healthy path
- resolve and canonically rank fallback candidates only when the cursor needs them
- preserve snapshot, exclusion, admission, rate-limit, and fallback semantics
- keep candidate metadata truthful as deferred candidates materialize without retaining decoded request params

## Validation
- `mix test --include integration --seed 314159`: 1493 tests, 0 failures
- warnings-as-errors compile, strict Credo, formatting, and diff check pass
- paired `+S 4:4` diagnostic: reductions/request -14.7% c1 and -14.8% c32; throughput +4.1% c1 and +7.1% c32
- c32 sampled tail median improved from p95 741us / p99 863us to p95 713us / p99 785us

Benchmark scripts and output are intentionally excluded from this PR.