### PR TITLE
Reuse learned scope in fastest selection

### DIFF
--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -265,7 +265,7 @@ defmodule Lasso.RPC.Selection do
     case capture_selection_snapshot(profile, chain_id) do
       {:ok, snapshot, plan} ->
         strategy = Keyword.fetch!(opts, :strategy)
-        fastest_winner = fastest_winner(ranking_mode, plan)
+        fastest_hint = fastest_hint(ranking_mode, plan)
         inputs = routing_inputs(plan, method, opts)
 
         case build_hinted_fastest_cursor(
@@ -274,7 +274,7 @@ defmodule Lasso.RPC.Selection do
                method,
                opts,
                strategy_mod,
-               fastest_winner,
+               fastest_hint,
                inputs
              ) do
           {:ok, cursor} ->
@@ -343,14 +343,23 @@ defmodule Lasso.RPC.Selection do
     {transport, workload_key, pool_filters, consensus_height}
   end
 
-  defp candidates_from_inputs(plan, filters, consensus_height, gate_mode) do
+  defp candidates_from_inputs(plan, filters, consensus_height, gate_mode, learned_scope \\ nil) do
     case gate_mode do
       :deferred_fastest ->
-        CandidateListing.list_fastest_candidates_from_plan(
-          plan,
-          filters,
-          consensus_height || :unavailable
-        )
+        if learned_scope do
+          CandidateListing.list_fastest_candidates_from_plan(
+            plan,
+            filters,
+            consensus_height || :unavailable,
+            learned_scope
+          )
+        else
+          CandidateListing.list_fastest_candidates_from_plan(
+            plan,
+            filters,
+            consensus_height || :unavailable
+          )
+        end
 
       :deferred_gates ->
         CandidateListing.list_rankable_candidates_from_plan(
@@ -459,7 +468,7 @@ defmodule Lasso.RPC.Selection do
          method,
          opts,
          strategy_mod,
-         %{route: {routing_instance_id, winner_transport}},
+         {%{route: {routing_instance_id, winner_transport}}, learned_scope},
          {requested_transport, workload_key, filters, consensus_height}
        ) do
     matching_providers =
@@ -479,7 +488,8 @@ defmodule Lasso.RPC.Selection do
                   candidate_plan,
                   filters,
                   consensus_height,
-                  :deferred_fastest
+                  :deferred_fastest,
+                  learned_scope
                 ),
               winner_transport in candidate.transports do
             {ranking_channel(plan, candidate, winner_transport), candidate, winner_transport}
@@ -518,7 +528,7 @@ defmodule Lasso.RPC.Selection do
 
         deferred = %DeferredRanking{
           entries: [],
-          scope: AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation),
+          scope: learned_scope,
           chain_id: plan.chain_id,
           workload_key: workload_key,
           resolver: resolver,
@@ -558,13 +568,16 @@ defmodule Lasso.RPC.Selection do
        ),
        do: :miss
 
-  defp fastest_winner(:fastest_winner, plan) do
-    plan.profile
-    |> AttemptProjection.scope_state(plan.chain_id, plan.generation)
-    |> AttemptProjection.fastest_winner()
+  defp fastest_hint(:fastest_winner, plan) do
+    scope = AttemptProjection.scope_state(plan.profile, plan.chain_id, plan.generation)
+
+    case AttemptProjection.fastest_winner(scope) do
+      nil -> nil
+      winner -> {winner, scope}
+    end
   end
 
-  defp fastest_winner(:full, _plan), do: nil
+  defp fastest_hint(:full, _plan), do: nil
 
   defp ranking_channel(plan, candidate, transport) do
     %Channel{

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -172,6 +172,37 @@ defmodule Lasso.Providers.CandidateListing do
   end
 
   @doc false
+  @spec list_fastest_candidates_from_plan(
+          RoutingPlan.t(),
+          SelectionFilters.t() | map(),
+          non_neg_integer() | :unavailable,
+          AttemptProjection.scope_state()
+        ) :: [map()]
+  def list_fastest_candidates_from_plan(
+        %RoutingPlan{} = plan,
+        %SelectionFilters{} = filters,
+        consensus_height,
+        learned_scope
+      ) do
+    list_fastest_candidates_from_plan(
+      plan,
+      SelectionFilters.to_map(filters),
+      consensus_height,
+      learned_scope
+    )
+  end
+
+  def list_fastest_candidates_from_plan(
+        %RoutingPlan{} = plan,
+        filters,
+        consensus_height,
+        learned_scope
+      )
+      when is_map(filters) and is_map(learned_scope) do
+    do_list_candidates(plan, filters, :fastest_ranked, consensus_height, true, learned_scope)
+  end
+
+  @doc false
   @spec routing_candidate_from_plan(
           RoutingPlan.t(),
           RoutingPlan.provider(),

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -103,6 +103,21 @@ defmodule Lasso.Providers.CandidateListingTest do
                  candidate.circuit_state == %{http: :deferred, ws: :deferred}
              end)
 
+      captured_scope =
+        plan.profile
+        |> AttemptProjection.scope_state(plan.chain_id, plan.generation)
+        |> Map.put(:degraded?, false)
+
+      captured =
+        CandidateListing.list_fastest_candidates_from_plan(
+          plan,
+          %{protocol: :http},
+          :unavailable,
+          captured_scope
+        )
+
+      assert Enum.all?(captured, &(not &1.learned_feedback_degraded?))
+
       [rankable | _] =
         CandidateListing.list_rankable_candidates_from_plan(
           plan,


### PR DESCRIPTION
## Summary
- carry the warmed fastest selection scope through hinted candidate construction
- reuse that scope in the candidate cursor instead of rereading identical scope metadata
- preserve fresh route records and canonical admission checks

## Validation
- `mix test --include integration --seed 314159` (1493 tests)
- warnings-as-errors compilation
- strict Credo
- formatting and diff checks

This is a focused runtime change; it contains no benchmark or comparison artifacts.