### PR TITLE
Aggregate request diagnostics before sampling

### DIFF
--- a/lib/lasso/core/request/request_aggregate.ex
+++ b/lib/lasso/core/request/request_aggregate.ex
@@ -1,0 +1,180 @@
+defmodule Lasso.RPC.RequestAggregate do
+  @moduledoc """
+  Fixed-cardinality request outcome counters for active routing scopes.
+
+  Counter references are built with a catalog generation and published inside
+  the same immutable catalog snapshot as its routing plans. Request processes
+  update atomics directly; optional detailed diagnostics are admitted through a
+  per-origin, per-scope rate budget.
+  """
+
+  alias Lasso.Providers.Catalog
+  alias Lasso.RPC.{AttemptTerminal, RequestTerminal}
+
+  @details_per_second 256
+  @budget_base 512
+  @budget_retries 8
+
+  @client_total 1
+  @client_success 2
+  @client_elapsed_us 3
+  @client_sampled_out 4
+  @system_total 5
+  @system_success 6
+  @system_elapsed_us 7
+  @system_sampled_out 8
+
+  @type origin :: :client | :system
+  @type counter_set :: %{required(:counters) => term(), required(:budgets) => term()}
+
+  @doc false
+  @spec prepare(non_neg_integer(), map(), Catalog.snapshot() | nil) ::
+          %{{binary(), pos_integer()} => counter_set()}
+  def prepare(generation, routing_plans, previous_snapshot)
+      when is_integer(generation) and generation >= 0 and is_map(routing_plans) do
+    reusable = reusable_aggregates(generation, previous_snapshot)
+
+    Map.new(routing_plans, fn {{profile, chain_id}, _plan} ->
+      key = {profile, chain_id}
+
+      {key,
+       Map.get_lazy(reusable, key, fn ->
+         %{
+           counters: :atomics.new(8, signed: true),
+           budgets: :atomics.new(2, signed: true)
+         }
+       end)}
+    end)
+  end
+
+  @doc false
+  @spec record_and_reserve_detail(RequestTerminal.t(), origin(), integer()) ::
+          :detail | :aggregate_only | :untracked
+  def record_and_reserve_detail(fact, origin, now_ms \\ System.system_time(:millisecond))
+      when origin in [:client, :system] and is_integer(now_ms) and now_ms >= 0 do
+    with %{request_aggregates: aggregates} <- Catalog.snapshot(),
+         %{profile: profile, chain_id: chain_id} <- fact,
+         %{counters: counters, budgets: budgets} <- Map.get(aggregates, {profile, chain_id}) do
+      record(counters, fact, origin)
+
+      if not success?(fact) or
+           reserve_detail(budgets, origin, div(now_ms, 1_000), @budget_retries) do
+        :detail
+      else
+        :atomics.add(counters, sampled_out_index(origin), 1)
+        :aggregate_only
+      end
+    else
+      _unavailable -> :untracked
+    end
+  rescue
+    ArgumentError -> :untracked
+  end
+
+  @spec snapshot(binary(), pos_integer()) :: {:ok, map()} | {:error, :not_found}
+  def snapshot(profile, chain_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    with %{generation: generation, request_aggregates: aggregates} <- Catalog.snapshot(),
+         %{counters: counters} <- Map.get(aggregates, {profile, chain_id}) do
+      {:ok,
+       %{
+         generation: generation,
+         client: read_origin(counters, :client),
+         system: read_origin(counters, :system)
+       }}
+    else
+      _unavailable -> {:error, :not_found}
+    end
+  rescue
+    ArgumentError -> {:error, :not_found}
+  end
+
+  defp record(counters, fact, origin) do
+    :atomics.add(counters, total_index(origin), 1)
+    :atomics.add(counters, elapsed_index(origin), Map.fetch!(fact, :elapsed_us))
+
+    if success?(fact), do: :atomics.add(counters, success_index(origin), 1)
+    :ok
+  end
+
+  defp reserve_detail(_budgets, _origin, _second, 0), do: false
+
+  defp reserve_detail(budgets, origin, second, retries) do
+    index = budget_index(origin)
+    current = :atomics.get(budgets, index)
+    current_second = div(current, @budget_base)
+    current_count = rem(current, @budget_base)
+
+    cond do
+      current_second == second and current_count >= @details_per_second ->
+        false
+
+      current_second == second ->
+        reserve_detail_cas(
+          budgets,
+          origin,
+          second,
+          current,
+          current + 1,
+          retries
+        )
+
+      true ->
+        reserve_detail_cas(
+          budgets,
+          origin,
+          second,
+          current,
+          second * @budget_base + 1,
+          retries
+        )
+    end
+  end
+
+  defp reserve_detail_cas(budgets, origin, second, current, desired, retries) do
+    case :atomics.compare_exchange(budgets, budget_index(origin), current, desired) do
+      :ok -> true
+      _changed -> reserve_detail(budgets, origin, second, retries - 1)
+    end
+  end
+
+  defp read_origin(counters, origin) do
+    total = :atomics.get(counters, total_index(origin))
+    successes = :atomics.get(counters, success_index(origin))
+
+    %{
+      total: total,
+      successes: successes,
+      failures: total - successes,
+      elapsed_us: :atomics.get(counters, elapsed_index(origin)),
+      sampled_out: :atomics.get(counters, sampled_out_index(origin))
+    }
+  end
+
+  defp success?(%RequestTerminal.UpstreamResponse{
+         attempt: %AttemptTerminal.Response{kind: :success}
+       }),
+       do: true
+
+  defp success?(_fact), do: false
+
+  defp reusable_aggregates(
+         generation,
+         %{generation: generation, request_aggregates: aggregates}
+       )
+       when is_map(aggregates),
+       do: aggregates
+
+  defp reusable_aggregates(_generation, _snapshot), do: %{}
+
+  defp total_index(:client), do: @client_total
+  defp total_index(:system), do: @system_total
+  defp success_index(:client), do: @client_success
+  defp success_index(:system), do: @system_success
+  defp elapsed_index(:client), do: @client_elapsed_us
+  defp elapsed_index(:system), do: @system_elapsed_us
+  defp sampled_out_index(:client), do: @client_sampled_out
+  defp sampled_out_index(:system), do: @system_sampled_out
+  defp budget_index(:client), do: 1
+  defp budget_index(:system), do: 2
+end

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -1065,7 +1065,7 @@ defmodule Lasso.RPC.RequestPipeline do
     request_terminal = build_request_terminal(status, value, ctx)
 
     _enqueue_result =
-      RequestProjection.new_and_enqueue(
+      RequestProjection.record_and_enqueue(
         request_terminal,
         ctx.method,
         request_projection_route(ctx),

--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -9,6 +9,7 @@ defmodule Lasso.RPC.RequestProjection do
     AttemptTerminal,
     ExecutionFact,
     ExecutionProjector,
+    RequestAggregate,
     RequestTerminal
   }
 
@@ -89,6 +90,49 @@ defmodule Lasso.RPC.RequestProjection do
       when is_atom(dispatcher) do
     event = new(fact, method, route_identity, failover_count, request_origin)
     enqueue_lazy(event, dispatcher, fn -> encode_validated(event) end)
+  end
+
+  @spec record_and_enqueue(
+          RequestTerminal.t(),
+          binary(),
+          route_identity() | nil,
+          non_neg_integer(),
+          :client | :system,
+          atom()
+        ) :: term()
+  def record_and_enqueue(
+        fact,
+        method,
+        route_identity,
+        failover_count,
+        request_origin \\ :client,
+        dispatcher \\ @dispatcher
+      )
+      when is_atom(dispatcher) do
+    case RequestAggregate.record_and_reserve_detail(fact, request_origin) do
+      :detail ->
+        new_and_enqueue(
+          fact,
+          method,
+          route_identity,
+          failover_count,
+          request_origin,
+          dispatcher
+        )
+
+      :aggregate_only ->
+        {:drop, :sampled_out, :untracked}
+
+      :untracked ->
+        new_and_enqueue(
+          fact,
+          method,
+          route_identity,
+          failover_count,
+          request_origin,
+          dispatcher
+        )
+    end
   end
 
   defp enqueue_lazy(event, dispatcher, encoder) do

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -43,7 +43,8 @@ defmodule Lasso.Providers.Catalog do
   @type snapshot :: %{
           required(:table) => :ets.tid(),
           required(:generation) => non_neg_integer(),
-          optional(:routing_plans) => %{{String.t(), pos_integer()} => RoutingPlan.t()}
+          optional(:routing_plans) => %{{String.t(), pos_integer()} => RoutingPlan.t()},
+          optional(:request_aggregates) => map()
         }
 
   @doc """

--- a/lib/lasso/providers/catalog/owner.ex
+++ b/lib/lasso/providers/catalog/owner.ex
@@ -19,7 +19,7 @@ defmodule Lasso.Providers.Catalog.Owner do
 
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.{Catalog, RestartCounter}
-  alias Lasso.RPC.AttemptProjection
+  alias Lasso.RPC.{AttemptProjection, RequestAggregate}
 
   @grace_period_ms 2_000
 
@@ -166,12 +166,15 @@ defmodule Lasso.Providers.Catalog.Owner do
 
   defp publish(new_table, generation, routing_plans) do
     key = Catalog.persistent_term_key()
+    previous_snapshot = Catalog.snapshot()
     old_table = Catalog.table()
+    request_aggregates = RequestAggregate.prepare(generation, routing_plans, previous_snapshot)
 
     snapshot = %{
       table: new_table,
       generation: generation,
-      routing_plans: routing_plans
+      routing_plans: routing_plans,
+      request_aggregates: request_aggregates
     }
 
     :persistent_term.put(key, snapshot)

--- a/test/lasso/core/request/request_aggregate_test.exs
+++ b/test/lasso/core/request/request_aggregate_test.exs
@@ -1,0 +1,197 @@
+defmodule Lasso.RPC.RequestAggregateTest do
+  use Lasso.Test.LassoIntegrationCase
+
+  @moduletag :integration
+
+  alias Lasso.Providers.Catalog
+
+  alias Lasso.RPC.{
+    AttemptIdentity,
+    AttemptTerminal,
+    RequestAggregate,
+    RequestOptions,
+    RequestPipeline,
+    RequestTerminal
+  }
+
+  test "records exact origin-separated outcomes while bounding detail", %{chain: chain} do
+    setup_providers([
+      %{id: "aggregate-provider", priority: 1, behavior: :healthy, profile: "public"}
+    ])
+
+    success = success_terminal(chain)
+    failure = failure_terminal(chain)
+
+    assert {:ok,
+            %{
+              client: %{total: 0, successes: 0, sampled_out: 0},
+              system: %{total: 0, successes: 0, sampled_out: 0}
+            }} = RequestAggregate.snapshot("public", chain)
+
+    client_results =
+      Enum.map(1..300, fn _ ->
+        RequestAggregate.record_and_reserve_detail(success, :client, 1_000)
+      end)
+
+    system_success_results =
+      Enum.map(1..300, fn _ ->
+        RequestAggregate.record_and_reserve_detail(success, :system, 1_000)
+      end)
+
+    assert Enum.frequencies(client_results) == %{detail: 256, aggregate_only: 44}
+    assert Enum.frequencies(system_success_results) == %{detail: 256, aggregate_only: 44}
+    assert :detail = RequestAggregate.record_and_reserve_detail(failure, :system, 1_000)
+    assert :detail = RequestAggregate.record_and_reserve_detail(success, :client, 2_000)
+
+    assert {:ok,
+            %{
+              generation: generation,
+              client: %{
+                total: 301,
+                successes: 301,
+                failures: 0,
+                elapsed_us: 301_000,
+                sampled_out: 44
+              },
+              system: %{
+                total: 301,
+                successes: 300,
+                failures: 1,
+                elapsed_us: 300_010,
+                sampled_out: 44
+              }
+            }} = RequestAggregate.snapshot("public", chain)
+
+    assert generation == Catalog.active_generation()
+  end
+
+  test "catalog publication replaces counters with the new generation", %{chain: chain} do
+    setup_providers([
+      %{id: "aggregate-provider", priority: 1, behavior: :healthy, profile: "public"}
+    ])
+
+    assert :detail =
+             RequestAggregate.record_and_reserve_detail(success_terminal(chain), :client, 1_000)
+
+    assert {:ok, %{generation: first_generation, client: %{total: 1}}} =
+             RequestAggregate.snapshot("public", chain)
+
+    :ok = Catalog.build_from_config()
+
+    assert {:ok, %{generation: ^first_generation, client: %{total: 1}}} =
+             RequestAggregate.snapshot("public", chain)
+
+    setup_providers([
+      %{id: "aggregate-provider-b", priority: 1, behavior: :healthy, profile: "public"}
+    ])
+
+    assert {:ok, %{generation: next_generation, client: %{total: 0}}} =
+             RequestAggregate.snapshot("public", chain)
+
+    assert next_generation > first_generation
+  end
+
+  test "concurrent producers preserve totals and never exceed the detail budget", %{chain: chain} do
+    setup_providers([
+      %{id: "aggregate-provider", priority: 1, behavior: :healthy, profile: "public"}
+    ])
+
+    terminal = success_terminal(chain)
+
+    results =
+      1..2_000
+      |> Task.async_stream(
+        fn _ -> RequestAggregate.record_and_reserve_detail(terminal, :client, 5_000) end,
+        max_concurrency: 64,
+        ordered: false,
+        timeout: 5_000
+      )
+      |> Enum.map(fn {:ok, result} -> result end)
+
+    frequencies = Enum.frequencies(results)
+    assert frequencies[:detail] <= 256
+    assert frequencies[:detail] + frequencies[:aggregate_only] == 2_000
+
+    assert {:ok,
+            %{
+              client: %{
+                total: 2_000,
+                successes: 2_000,
+                failures: 0,
+                sampled_out: sampled_out
+              }
+            }} = RequestAggregate.snapshot("public", chain)
+
+    assert sampled_out == frequencies[:aggregate_only]
+  end
+
+  test "request pipeline records the final public outcome", %{chain: chain} do
+    setup_providers([
+      %{id: "aggregate-provider", priority: 1, behavior: :healthy, profile: "public"}
+    ])
+
+    opts = %RequestOptions{
+      profile: "public",
+      strategy: :fastest,
+      transport: :http,
+      timeout_ms: 5_000,
+      request_origin: :client
+    }
+
+    assert {:ok, _value, _ctx} =
+             RequestPipeline.execute_via_channels(chain, "eth_blockNumber", [], opts)
+
+    assert {:ok,
+            %{
+              client: %{total: 1, successes: 1, failures: 0, sampled_out: 0},
+              system: %{total: 0}
+            }} = RequestAggregate.snapshot("public", chain)
+  end
+
+  defp success_terminal(chain) do
+    identity = identity(chain)
+    attempt = AttemptTerminal.Response.new(identity, :success, 750)
+
+    RequestTerminal.UpstreamResponse.new_runtime(attempt, 1_000, 1, 1, nil)
+  end
+
+  defp failure_terminal(chain) do
+    RequestTerminal.LocalFailure.new(
+      [
+        request_id: "aggregate-local-failure",
+        profile: "public",
+        subject_token: nil,
+        chain_id: chain,
+        execution_safety: :replay_safe,
+        routing_intent: "fastest",
+        workload_key: "default",
+        elapsed_us: 10,
+        candidate_admission_count: 0,
+        dispatch_count: 0,
+        observed_at: nil
+      ],
+      :invalid_request
+    )
+  end
+
+  defp identity(chain) do
+    AttemptIdentity.new_runtime(%{
+      request_id: "aggregate-request",
+      attempt_id: "aggregate-attempt",
+      profile: "public",
+      subject_token: nil,
+      chain_id: chain,
+      upstream_instance_id: "aggregate-instance",
+      transport: :http,
+      route_generation: Catalog.active_generation(),
+      circuit_scope: :broad,
+      circuit_epoch: 1,
+      execution_safety: :replay_safe,
+      routing_intent: "fastest",
+      workload_key: "default",
+      request_budget_ms: 100,
+      candidate_admission_count: 1,
+      dispatch_count: 1
+    })
+  end
+end


### PR DESCRIPTION
## Summary

- publish fixed-cardinality request aggregate counters with each catalog generation
- record exact client/system totals, successes, failures, and elapsed time before optional diagnostics
- bound healthy detailed diagnostics per scope while always attempting failure detail
- preserve counters across same-generation catalog rebuilds and reset them on generation changes

## Validation

- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix test --include integration` (1497 tests, 0 failures)
- `mix credo --strict`
- `mix dialyzer`
- `git diff --check`