### PR TITLE
Cache fresh chain consensus snapshots

### DIFF
--- a/lib/lasso/core/block_sync/registry.ex
+++ b/lib/lasso/core/block_sync/registry.ex
@@ -27,6 +27,7 @@ defmodule Lasso.BlockSync.Registry do
 
   @table :block_sync_registry
   @default_freshness_ms 30_000
+  @cache_retries 4
 
   ## Client API
 
@@ -48,6 +49,8 @@ defmodule Lasso.BlockSync.Registry do
     :ets.insert(@table, {{:height, chain_id, provider_id}, {height, timestamp, source, metadata}})
 
     update_block_time(chain_id, height)
+    revision = next_consensus_revision(chain_id)
+    refresh_consensus_cache(chain_id, timestamp, revision)
 
     :ok
   end
@@ -78,10 +81,26 @@ defmodule Lasso.BlockSync.Registry do
 
   Returns `{:ok, height}` or `{:error, :no_data}`.
   """
+  @spec get_consensus_height(pos_integer()) :: {:ok, integer()} | {:error, :no_data}
+  def get_consensus_height(chain_id) when is_integer(chain_id) and chain_id > 0 do
+    now_ms = System.system_time(:millisecond)
+    key = consensus_key(chain_id)
+
+    case :ets.lookup(@table, key) do
+      [{^key, revision, revision, height, valid_through_ms}]
+      when now_ms <= valid_through_ms ->
+        {:ok, height}
+
+      _missing_or_expired ->
+        refresh_consensus_cache(chain_id, now_ms, current_consensus_revision(chain_id))
+    end
+  end
+
   @spec get_consensus_height(pos_integer(), non_neg_integer()) ::
           {:ok, integer()} | {:error, :no_data}
-  def get_consensus_height(chain_id, freshness_ms \\ @default_freshness_ms)
-      when is_integer(chain_id) and chain_id > 0 do
+  def get_consensus_height(chain_id, freshness_ms)
+      when is_integer(chain_id) and chain_id > 0 and is_integer(freshness_ms) and
+             freshness_ms >= 0 do
     calculate_consensus(chain_id, nil, freshness_ms)
   end
 
@@ -179,6 +198,7 @@ defmodule Lasso.BlockSync.Registry do
   def clear_chain(chain_id) when is_integer(chain_id) and chain_id > 0 do
     :ets.match_delete(@table, {{:height, chain_id, :_}, :_})
     :ets.delete(@table, {:block_time, chain_id})
+    :ets.delete(@table, consensus_key(chain_id))
     :ok
   end
 
@@ -223,6 +243,72 @@ defmodule Lasso.BlockSync.Registry do
 
   ## Private Functions
 
+  defp refresh_consensus_cache(chain_id, now_ms, revision) do
+    cutoff = now_ms - @default_freshness_ms
+
+    case select_fresh_samples(chain_id, cutoff) do
+      [] ->
+        {:error, :no_data}
+
+      samples ->
+        height = consensus(Enum.map(samples, &elem(&1, 0)))
+        valid_through_ms = samples |> Enum.map(&elem(&1, 1)) |> Enum.min()
+        valid_through_ms = valid_through_ms + @default_freshness_ms
+
+        publish_consensus(
+          consensus_key(chain_id),
+          revision,
+          height,
+          valid_through_ms,
+          @cache_retries
+        )
+
+        {:ok, height}
+    end
+  end
+
+  defp next_consensus_revision(chain_id) do
+    :ets.update_counter(
+      @table,
+      consensus_key(chain_id),
+      {2, 1},
+      {consensus_key(chain_id), 0, 0, nil, 0}
+    )
+  end
+
+  defp current_consensus_revision(chain_id) do
+    key = consensus_key(chain_id)
+
+    case :ets.lookup(@table, key) do
+      [{^key, revision, _published_revision, _height, _valid_through_ms}] -> revision
+      [] -> 0
+    end
+  end
+
+  defp publish_consensus(key, revision, height, valid_through_ms, retries)
+       when retries > 0 do
+    case :ets.lookup(@table, key) do
+      [{^key, current_revision, _published_revision, _height, _valid_through_ms}]
+      when current_revision > revision ->
+        :ok
+
+      [{^key, ^revision, _published_revision, _height, _valid_through_ms} = current] ->
+        updated = {key, revision, revision, height, valid_through_ms}
+
+        case :ets.select_replace(@table, [{current, [], [{:const, updated}]}]) do
+          1 -> :ok
+          0 -> publish_consensus(key, revision, height, valid_through_ms, retries - 1)
+        end
+
+      [] ->
+        :ok
+    end
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp publish_consensus(_key, _revision, _height, _valid_through_ms, 0), do: :ok
+
   defp calculate_consensus(chain_id, provider_ids, freshness_ms) do
     cutoff = System.system_time(:millisecond) - freshness_ms
     fresh_heights = select_fresh_heights(chain_id, provider_ids, cutoff)
@@ -231,14 +317,27 @@ defmodule Lasso.BlockSync.Registry do
       [] ->
         {:error, :no_data}
 
-      [single] ->
-        {:ok, single}
-
-      list ->
-        sorted = Enum.sort(list, :desc)
-        idx = max(0, floor(length(sorted) * 0.25))
-        {:ok, Enum.at(sorted, idx)}
+      heights ->
+        {:ok, consensus(heights)}
     end
+  end
+
+  defp consensus([single]), do: single
+
+  defp consensus(heights) do
+    sorted = Enum.sort(heights, :desc)
+    idx = max(0, floor(length(sorted) * 0.25))
+    Enum.at(sorted, idx)
+  end
+
+  defp select_fresh_samples(chain_id, cutoff) do
+    :ets.select(@table, [
+      {
+        {{:height, chain_id, :_}, {:"$1", :"$2", :_, :_}},
+        [{:>=, :"$2", cutoff}],
+        [{{:"$1", :"$2"}}]
+      }
+    ])
   end
 
   defp select_fresh_heights(chain_id, provider_ids, cutoff)
@@ -266,4 +365,6 @@ defmodule Lasso.BlockSync.Registry do
       if MapSet.member?(provider_set, provider_id), do: [height | heights], else: heights
     end)
   end
+
+  defp consensus_key(chain_id), do: {:consensus, chain_id}
 end

--- a/lib/lasso/core/chain_state.ex
+++ b/lib/lasso/core/chain_state.ex
@@ -27,12 +27,20 @@ defmodule Lasso.RPC.ChainState do
           | {:error, term()}
   def consensus_height(chain_id, opts \\ []) when is_integer(chain_id) and chain_id > 0 do
     provider_ids = Keyword.get(opts, :provider_ids, nil)
-    freshness_ms = Keyword.get(opts, :freshness_ms, @default_freshness_ms)
 
-    if provider_ids do
-      BlockSyncRegistry.get_consensus_height_filtered(chain_id, provider_ids, freshness_ms)
-    else
-      BlockSyncRegistry.get_consensus_height(chain_id, freshness_ms)
+    case {provider_ids, Keyword.fetch(opts, :freshness_ms)} do
+      {provider_ids, freshness} when is_list(provider_ids) ->
+        BlockSyncRegistry.get_consensus_height_filtered(
+          chain_id,
+          provider_ids,
+          freshness_or_default(freshness)
+        )
+
+      {nil, {:ok, freshness_ms}} ->
+        BlockSyncRegistry.get_consensus_height(chain_id, freshness_ms)
+
+      {nil, :error} ->
+        BlockSyncRegistry.get_consensus_height(chain_id)
     end
   rescue
     e ->
@@ -176,4 +184,7 @@ defmodule Lasso.RPC.ChainState do
   def get_chain_status(chain_id) when is_integer(chain_id) and chain_id > 0 do
     BlockSyncRegistry.get_chain_status(chain_id)
   end
+
+  defp freshness_or_default({:ok, freshness_ms}), do: freshness_ms
+  defp freshness_or_default(:error), do: @default_freshness_ms
 end

--- a/test/lasso/core/block_sync/consensus_p75_test.exs
+++ b/test/lasso/core/block_sync/consensus_p75_test.exs
@@ -118,5 +118,118 @@ defmodule Lasso.BlockSync.ConsensusP75Test do
 
       assert {:ok, 110} = BlockSyncRegistry.get_consensus_height_filtered(chain, [])
     end
+
+    test "default consensus uses the published snapshot and refreshes on height writes", %{
+      chain: chain
+    } do
+      BlockSyncRegistry.put_height(chain, "p1", 100, :http, %{})
+
+      assert [{{:consensus, ^chain}, first_revision, first_revision, 100, first_valid_through}] =
+               :ets.lookup(:block_sync_registry, {:consensus, chain})
+
+      assert is_integer(first_revision)
+      assert is_integer(first_valid_through)
+      assert {:ok, 100} = BlockSyncRegistry.get_consensus_height(chain)
+
+      BlockSyncRegistry.put_height(chain, "p2", 105, :http, %{})
+
+      assert [
+               {{:consensus, ^chain}, second_revision, second_revision, 105, second_valid_through}
+             ] =
+               :ets.lookup(:block_sync_registry, {:consensus, chain})
+
+      assert second_revision > first_revision
+      assert second_valid_through >= first_valid_through
+      assert {:ok, 105} = BlockSyncRegistry.get_consensus_height(chain)
+    end
+
+    test "expired snapshot falls back to an exact fresh calculation", %{chain: chain} do
+      BlockSyncRegistry.put_height(chain, "p1", 100, :http, %{})
+
+      [{{:consensus, ^chain}, revision, revision, 100, _valid_through}] =
+        :ets.lookup(:block_sync_registry, {:consensus, chain})
+
+      now_ms = System.system_time(:millisecond)
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, chain, "p1"}, {999, now_ms - 31_000, :http, %{}}}
+      )
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, chain, "p2"}, {105, now_ms, :http, %{}}}
+      )
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:consensus, chain}, revision, revision, 100, now_ms - 1}
+      )
+
+      assert {:ok, 105} = BlockSyncRegistry.get_consensus_height(chain)
+
+      assert [{{:consensus, ^chain}, ^revision, ^revision, 105, valid_through}] =
+               :ets.lookup(:block_sync_registry, {:consensus, chain})
+
+      assert valid_through >= now_ms
+    end
+
+    test "an interrupted publication is never served and is repaired by the reader", %{
+      chain: chain
+    } do
+      BlockSyncRegistry.put_height(chain, "p1", 100, :http, %{})
+
+      now_ms = System.system_time(:millisecond)
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, chain, "p2"}, {105, now_ms, :http, %{}}}
+      )
+
+      allocated_revision =
+        :ets.update_counter(:block_sync_registry, {:consensus, chain}, {2, 1})
+
+      assert [
+               {{:consensus, ^chain}, ^allocated_revision, published_revision, 100,
+                _valid_through}
+             ] = :ets.lookup(:block_sync_registry, {:consensus, chain})
+
+      assert published_revision < allocated_revision
+      assert {:ok, 105} = BlockSyncRegistry.get_consensus_height(chain)
+
+      assert [
+               {{:consensus, ^chain}, ^allocated_revision, ^allocated_revision, 105,
+                repaired_valid_through}
+             ] = :ets.lookup(:block_sync_registry, {:consensus, chain})
+
+      assert repaired_valid_through >= now_ms
+    end
+
+    test "concurrent writers cannot leave an older consensus snapshot", %{chain: chain} do
+      1..32
+      |> Task.async_stream(
+        fn height ->
+          BlockSyncRegistry.put_height(chain, "p#{height}", height, :http, %{})
+        end,
+        max_concurrency: 16,
+        ordered: false
+      )
+      |> Stream.run()
+
+      assert BlockSyncRegistry.get_consensus_height(chain) ==
+               BlockSyncRegistry.get_consensus_height(chain, 30_000)
+
+      assert [{{:consensus, ^chain}, revision, revision, _height, _valid_through}] =
+               :ets.lookup(:block_sync_registry, {:consensus, chain})
+    end
+
+    test "clearing a chain removes its fixed consensus state", %{chain: chain} do
+      BlockSyncRegistry.put_height(chain, "p1", 100, :http, %{})
+      BlockSyncRegistry.clear_chain(chain)
+
+      assert [] = :ets.lookup(:block_sync_registry, {:consensus, chain})
+      assert {:error, :no_data} = BlockSyncRegistry.get_consensus_height(chain)
+      assert [] = :ets.lookup(:block_sync_registry, {:consensus, chain})
+    end
   end
 end


### PR DESCRIPTION
## Summary
- publish one fixed per-chain consensus snapshot when provider heights change
- serve the default 30s consensus read from a revision-fenced ETS row
- fall back to the exact P75 calculation when the row is missing, expired, or incompletely published
- keep custom freshness and provider-filtered queries on the exact path

## Correctness
- allocated/published revisions prevent interrupted or reordered writers from exposing stale consensus
- readers repair incomplete publications from exact height rows
- validity ends at the earliest contributing provider expiry
- chain cleanup removes the fixed snapshot row

## Validation
- 1,502 integration-enabled tests, 0 failures
- warnings-as-errors compile
- strict Credo
- production/default Dialyzer
- format and diff checks

## Performance
Developer Mac, OTP 28, `+S 4:4`, warmed mock fastest routing with eight providers:
- consensus primitive: ~1.66 us exact scan/sort -> ~0.29 us cached read (5.7x)
- two interleaved whole-routing runs: c1 median roughly 10% faster; c32 roughly 2% higher throughput; reductions down roughly 1-1.5%
- provider-height write cost rises by ~2.15 us/write, shifting work from every request to block/poll cadence

These are directional developer-host measurements, not the full Wayfinder/eRPC acceptance claim.