### PR TITLE
Admit RPC bodies before buffering

### DIFF
--- a/lib/lasso_web/controllers/error_json.ex
+++ b/lib/lasso_web/controllers/error_json.ex
@@ -12,6 +12,13 @@ defmodule LassoWeb.ErrorJSON do
     JError.to_response(error_response, nil)
   end
 
+  def render("413.json", %{
+        conn: %Plug.Conn{method: "POST", request_path: "/rpc/" <> _rest}
+      }) do
+    error_response = JError.new(-32_600, "Invalid Request: request body too large")
+    JError.to_response(error_response, nil)
+  end
+
   def render("503.json", %{reason: %LassoWeb.Plugs.RequestByteBudget.CapacityError{}}) do
     error_response =
       JError.new(-32_008, "Local request byte capacity unavailable",

--- a/lib/lasso_web/endpoint.ex
+++ b/lib/lasso_web/endpoint.ex
@@ -110,10 +110,9 @@ defmodule LassoWeb.Endpoint do
 
   # plug(Plug.Telemetry, event_prefix: [:phoenix, :endpoint])
 
-  plug(Plug.Parsers,
+  plug(LassoWeb.Plugs.RequestByteBudget,
     parsers: [:urlencoded, :multipart, :json],
     pass: ["*/*"],
-    body_reader: {LassoWeb.Plugs.RequestByteBudget, :read_body, []},
     json_decoder: Lasso.JSON.Decoder
   )
 

--- a/lib/lasso_web/plugs/request_byte_budget.ex
+++ b/lib/lasso_web/plugs/request_byte_budget.ex
@@ -1,11 +1,15 @@
 defmodule LassoWeb.Plugs.RequestByteBudget do
   @moduledoc false
 
+  @behaviour Plug
+
   import Plug.Conn
 
   alias Lasso.Core.Request.ByteBudget
 
-  @reservation_key :lasso_request_byte_budget_reservation
+  @admission_key :lasso_request_body_admission
+  @max_body_bytes 8_000_000
+  @default_read_length_bytes 1_000_000
 
   defmodule CapacityError do
     @moduledoc false
@@ -13,48 +17,269 @@ defmodule LassoWeb.Plugs.RequestByteBudget do
     defexception message: "in-flight request byte capacity unavailable", plug_status: 503
   end
 
+  defmodule HeaderError do
+    @moduledoc false
+
+    defexception [:message, plug_status: 400]
+  end
+
+  @doc false
+  @spec max_body_bytes() :: pos_integer()
+  def max_body_bytes, do: @max_body_bytes
+
+  @doc false
+  @spec max_buffered_body_bytes() :: pos_integer()
+  def max_buffered_body_bytes, do: @max_body_bytes + @default_read_length_bytes
+
+  @impl Plug
+  def init(opts) do
+    max_body_bytes = Keyword.get(opts, :max_body_bytes, @max_body_bytes)
+    read_length_bytes = Keyword.get(opts, :read_length, @default_read_length_bytes)
+
+    if not is_integer(max_body_bytes) or max_body_bytes <= 0 or
+         not is_integer(read_length_bytes) or read_length_bytes <= 0 do
+      raise ArgumentError, ":max_body_bytes and :read_length must be positive integers"
+    end
+
+    parser_opts =
+      opts
+      |> Keyword.delete(:max_body_bytes)
+      |> Keyword.delete(:length)
+      |> configure_parser_limits(max_body_bytes)
+      |> Keyword.put_new(:read_length, read_length_bytes)
+      |> Keyword.put(:body_reader, {__MODULE__, :read_body, []})
+      |> Plug.Parsers.init()
+
+    %{
+      max_body_bytes: max_body_bytes,
+      read_length_bytes: read_length_bytes,
+      parser_opts: parser_opts
+    }
+  end
+
+  defp configure_parser_limits(opts, max_body_bytes) do
+    Keyword.update!(opts, :parsers, fn parsers ->
+      Enum.map(parsers, fn
+        parser when parser in [:json, Plug.Parsers.JSON] ->
+          {parser, [length: max_body_bytes]}
+
+        parser when parser in [:multipart, Plug.Parsers.MULTIPART] ->
+          {parser, [length: max_body_bytes]}
+
+        {parser, parser_opts} when parser in [:json, Plug.Parsers.JSON] ->
+          {parser, Keyword.put(parser_opts, :length, max_body_bytes)}
+
+        {parser, parser_opts} when parser in [:multipart, Plug.Parsers.MULTIPART] ->
+          {parser, Keyword.put(parser_opts, :length, max_body_bytes)}
+
+        parser ->
+          parser
+      end)
+    end)
+  end
+
+  @impl Plug
+  def call(conn, %{
+        max_body_bytes: max_body_bytes,
+        read_length_bytes: read_length_bytes,
+        parser_opts: parser_opts
+      }) do
+    conn = admit(conn, max_body_bytes, read_length_bytes)
+
+    try do
+      Plug.Parsers.call(conn, parser_opts)
+    catch
+      kind, reason ->
+        release(conn)
+        :erlang.raise(kind, reason, __STACKTRACE__)
+    end
+  end
+
   @spec read_body(Plug.Conn.t(), keyword()) ::
           {:ok, binary(), Plug.Conn.t()}
           | {:more, binary(), Plug.Conn.t()}
           | {:error, term()}
   def read_body(conn, opts) do
+    conn = admit(conn, @max_body_bytes, @default_read_length_bytes)
+
     case Plug.Conn.read_body(conn, opts) do
       {status, body, conn} when status in [:ok, :more] ->
-        reserve_rpc_body(status, body, conn)
+        if Map.has_key?(conn.private, @admission_key),
+          do: verify_body_chunk(status, body, conn),
+          else: {status, body, conn}
 
       {:error, _reason} = error ->
+        release(conn)
         error
     end
   end
 
-  defp reserve_rpc_body(status, body, conn) do
-    if rpc_request?(conn) and not Map.has_key?(conn.private, @reservation_key) do
-      case ByteBudget.reserve(byte_size(body), self()) do
-        {:ok, reservation} ->
-          conn =
-            conn
-            |> put_private(@reservation_key, reservation)
-            |> register_before_send(&release_reservation/1)
-
-          {status, body, conn}
-
-        {:error, _reason} ->
-          raise CapacityError
-      end
-    else
-      {status, body, conn}
-    end
-  end
-
-  defp rpc_request?(%Plug.Conn{method: "POST", request_path: "/rpc" <> _rest}), do: true
-  defp rpc_request?(_conn), do: false
-
-  defp release_reservation(conn) do
-    case Map.get(conn.private, @reservation_key) do
-      %ByteBudget.Reservation{} = reservation -> ByteBudget.release(reservation)
+  @doc false
+  @spec release(Plug.Conn.t()) :: Plug.Conn.t()
+  def release(conn) do
+    case Map.get(conn.private, @admission_key) do
+      %{reservation: %ByteBudget.Reservation{} = reservation} -> ByteBudget.release(reservation)
       _missing -> :ok
     end
 
-    conn
+    %{conn | private: Map.delete(conn.private, @admission_key)}
   end
+
+  defp admit(conn, max_body_bytes, read_length_bytes) do
+    if rpc_request?(conn) and not Map.has_key?(conn.private, @admission_key) do
+      with {:ok, expected_length, reservation_bytes} <-
+             admission_size(conn, max_body_bytes, read_length_bytes),
+           {:ok, reservation} <- ByteBudget.reserve(reservation_bytes, self()) do
+        conn
+        |> put_private(@admission_key, %{
+          reservation: reservation,
+          expected_length: expected_length,
+          observed_bytes: 0,
+          max_body_bytes: max_body_bytes
+        })
+        |> register_before_send(&release/1)
+      else
+        {:error, :too_large} ->
+          raise Plug.Parsers.RequestTooLargeError
+
+        {:error, reason} when reason in [:malformed, :conflicting, :ambiguous_framing] ->
+          raise HeaderError, message: header_error_message(reason)
+
+        {:error, _capacity_reason} ->
+          raise CapacityError
+      end
+    else
+      conn
+    end
+  end
+
+  defp admission_size(conn, max_body_bytes, read_length_bytes) do
+    content_lengths = get_req_header(conn, "content-length")
+    transfer_encodings = get_req_header(conn, "transfer-encoding")
+
+    cond do
+      content_lengths != [] and transfer_encodings != [] ->
+        {:error, :ambiguous_framing}
+
+      content_lengths == [] ->
+        {:ok, :unknown, max_body_bytes + read_length_bytes}
+
+      true ->
+        case parse_content_lengths(content_lengths, max_body_bytes) do
+          {:ok, content_length} ->
+            {:ok, content_length, content_length}
+
+          error ->
+            error
+        end
+    end
+  end
+
+  defp parse_content_lengths(values, max_body_bytes) do
+    values
+    |> Enum.flat_map(&:binary.split(&1, ",", [:global]))
+    |> Enum.reduce_while({:ok, nil}, fn raw_value, {:ok, expected} ->
+      with value when value != "" <- trim_ows(raw_value),
+           {:ok, parsed} <- parse_decimal(value, max_body_bytes) do
+        if is_nil(expected) or expected == parsed do
+          {:cont, {:ok, parsed}}
+        else
+          {:halt, {:error, :conflicting}}
+        end
+      else
+        {:error, :too_large} -> {:halt, {:error, :too_large}}
+        _malformed -> {:halt, {:error, :malformed}}
+      end
+    end)
+    |> case do
+      {:ok, nil} -> {:error, :malformed}
+      result -> result
+    end
+  rescue
+    _error -> {:error, :malformed}
+  end
+
+  defp parse_decimal(value, max_body_bytes),
+    do: parse_decimal(value, max_body_bytes, 0)
+
+  defp parse_decimal(<<>>, _max_body_bytes, parsed), do: {:ok, parsed}
+
+  defp parse_decimal(<<digit, rest::binary>>, max_body_bytes, parsed)
+       when digit in ?0..?9 do
+    next = parsed * 10 + digit - ?0
+
+    if next <= max_body_bytes do
+      parse_decimal(rest, max_body_bytes, next)
+    else
+      {:error, :too_large}
+    end
+  end
+
+  defp parse_decimal(_value, _max_body_bytes, _parsed), do: {:error, :malformed}
+
+  defp trim_ows(value) do
+    start = trim_ows_start(value, 0)
+    finish = trim_ows_end(value, byte_size(value) - 1)
+
+    if finish < start, do: "", else: binary_part(value, start, finish - start + 1)
+  end
+
+  defp trim_ows_start(value, index) when index < byte_size(value) do
+    if :binary.at(value, index) in [?\s, ?\t],
+      do: trim_ows_start(value, index + 1),
+      else: index
+  end
+
+  defp trim_ows_start(_value, index), do: index
+
+  defp trim_ows_end(_value, index) when index < 0, do: index
+
+  defp trim_ows_end(value, index) do
+    if :binary.at(value, index) in [?\s, ?\t],
+      do: trim_ows_end(value, index - 1),
+      else: index
+  end
+
+  defp verify_body_chunk(status, body, conn) do
+    admission = Map.fetch!(conn.private, @admission_key)
+    observed = admission.observed_bytes + byte_size(body)
+    expected = admission.expected_length
+    conn = put_private(conn, @admission_key, %{admission | observed_bytes: observed})
+
+    cond do
+      expected == :unknown and observed > admission.max_body_bytes ->
+        reject_too_large!(conn)
+
+      is_integer(expected) and observed > expected ->
+        reject_body_length!(conn)
+
+      status == :more and is_integer(expected) and observed == expected ->
+        reject_body_length!(conn)
+
+      status == :ok and is_integer(expected) and observed != expected ->
+        reject_body_length!(conn)
+
+      true ->
+        {status, body, conn}
+    end
+  end
+
+  defp reject_too_large!(conn) do
+    release(conn)
+    raise Plug.Parsers.RequestTooLargeError
+  end
+
+  defp reject_body_length!(conn) do
+    release(conn)
+    raise HeaderError, message: "content-length does not match the request body"
+  end
+
+  defp header_error_message(:malformed), do: "malformed content-length header"
+  defp header_error_message(:conflicting), do: "conflicting content-length headers"
+
+  defp header_error_message(:ambiguous_framing),
+    do: "content-length and transfer-encoding conflict"
+
+  defp rpc_request?(%Plug.Conn{method: "POST", request_path: "/rpc/" <> _rest}), do: true
+  defp rpc_request?(_conn), do: false
 end

--- a/test/lasso_web/plugs/request_byte_budget_test.exs
+++ b/test/lasso_web/plugs/request_byte_budget_test.exs
@@ -7,37 +7,356 @@ defmodule LassoWeb.Plugs.RequestByteBudgetTest do
   alias LassoWeb.ErrorJSON
   alias LassoWeb.Plugs.RequestByteBudget
 
+  defmodule ReadSpyAdapter do
+    @spec read_req_body({pid(), map()}, keyword()) :: {:ok | :more, binary(), {pid(), map()}}
+    def read_req_body({owner, state}, opts) do
+      send(owner, {:request_body_read, ByteBudget.stats()})
+
+      case Plug.Adapters.Test.Conn.read_req_body(state, opts) do
+        {status, body, next_state} -> {status, body, {owner, next_state}}
+      end
+    end
+  end
+
+  defmodule ReadErrorAdapter do
+    @spec read_req_body({pid(), term()}, keyword()) :: {:error, term()}
+    def read_req_body({owner, reason}, _opts) do
+      send(owner, :request_body_read)
+      {:error, reason}
+    end
+  end
+
+  defmodule RaisingPipeline do
+    use Plug.Router
+    use Plug.ErrorHandler
+
+    plug(RequestByteBudget,
+      parsers: [:urlencoded, :multipart, :json],
+      pass: ["*/*"],
+      json_decoder: Lasso.JSON.Decoder
+    )
+
+    plug(:match)
+    plug(:dispatch)
+
+    post "/rpc/:chain" do
+      _ = conn
+      _ = chain
+      raise "controller failure"
+    end
+
+    @impl Plug.ErrorHandler
+    def handle_errors(conn, _assigns), do: send_resp(conn, conn.status, "error")
+  end
+
   setup do
     Application.ensure_all_started(:lasso)
     await_empty()
     :ok
   end
 
-  test "an HTTP RPC body holds one reservation until the response is sent" do
+  test "reserves Content-Length before the adapter reads and releases on response" do
     body = Jason.encode!(%{"jsonrpc" => "2.0", "method" => "eth_blockNumber", "id" => 1})
     before = ByteBudget.stats()
-    conn = Plug.Test.conn(:post, "/rpc/ethereum", body)
 
-    assert {:ok, ^body, conn} = RequestByteBudget.read_body(conn, [])
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(byte_size(body))
+      |> with_read_spy()
 
-    during = ByteBudget.stats()
-    assert during.reservations == before.reservations + 1
-    assert during.used_bytes == before.used_bytes + during.minimum_charge_bytes
+    conn = parse(conn)
+
+    assert_received {:request_body_read, during_read}
+    assert during_read.reservations == before.reservations + 1
+    assert during_read.used_bytes == before.used_bytes + during_read.minimum_charge_bytes
+    assert ByteBudget.stats().reservations == before.reservations + 1
+
+    _conn = conn |> without_read_spy() |> send_resp(200, "{}")
+    assert_empty(before)
+  end
+
+  test "unknown-length and transfer-encoded RPC bodies reserve the full parser maximum" do
+    for transfer_encoding <- [nil, "chunked"] do
+      before = ByteBudget.stats()
+
+      conn =
+        :post
+        |> Plug.Test.conn("/rpc/ethereum", "")
+        |> put_req_header("content-type", "application/octet-stream")
+        |> maybe_put_transfer_encoding(transfer_encoding)
+        |> parse()
+
+      during = ByteBudget.stats()
+      assert during.reservations == before.reservations + 1
+
+      assert during.used_bytes ==
+               before.used_bytes + RequestByteBudget.max_buffered_body_bytes()
+
+      _conn = send_resp(conn, 200, "{}")
+      assert_empty(before)
+    end
+  end
+
+  test "a chunked body keeps one full reservation across every read" do
+    before = ByteBudget.stats()
+
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "1234")
+      |> put_req_header("transfer-encoding", "chunked")
+
+    assert {:more, "12", conn} = RequestByteBudget.read_body(conn, length: 2)
+
+    during_first_read = ByteBudget.stats()
+    assert during_first_read.reservations == before.reservations + 1
+
+    assert during_first_read.used_bytes ==
+             before.used_bytes + RequestByteBudget.max_buffered_body_bytes()
+
+    assert {:ok, "34", conn} = RequestByteBudget.read_body(conn, length: 2)
+    assert ByteBudget.stats() == during_first_read
 
     _conn = send_resp(conn, 200, "{}")
-    assert ByteBudget.stats().reservations == before.reservations
-    assert ByteBudget.stats().used_bytes == before.used_bytes
+    assert_empty(before)
   end
 
-  test "non-RPC bodies do not consume the routing budget" do
+  test "repeated admission and body reads never reserve twice" do
+    body = "1234"
     before = ByteBudget.stats()
-    conn = Plug.Test.conn(:post, "/api/other", "{}")
 
-    assert {:ok, "{}", _conn} = RequestByteBudget.read_body(conn, [])
-    assert ByteBudget.stats() == before
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", body)
+      |> put_content_length(byte_size(body))
+
+    assert {:more, "12", conn} = RequestByteBudget.read_body(conn, length: 2)
+    once = ByteBudget.stats()
+    assert once.reservations == before.reservations + 1
+
+    assert {:ok, "34", conn} = RequestByteBudget.read_body(conn, length: 2)
+    assert ByteBudget.stats() == once
+
+    _conn = send_resp(conn, 200, "{}")
+    assert_empty(before)
   end
 
-  test "HTTP admission fails before JSON decoding when every byte bucket is full" do
+  test "accepts the parser boundary and rejects an over-limit body before reading" do
+    max_body_bytes = RequestByteBudget.max_body_bytes()
+    before = ByteBudget.stats()
+
+    accepted =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "")
+      |> put_req_header("content-type", "application/octet-stream")
+      |> put_content_length(max_body_bytes)
+      |> parse()
+
+    assert ByteBudget.stats().used_bytes == before.used_bytes + max_body_bytes
+    _accepted = send_resp(accepted, 200, "{}")
+    assert_empty(before)
+
+    rejected =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "")
+      |> put_req_header("content-type", "application/octet-stream")
+      |> put_content_length(max_body_bytes + 1)
+      |> with_read_spy()
+
+    assert_raise Plug.Parsers.RequestTooLargeError, fn -> parse(rejected) end
+    refute_received {:request_body_read, _stats}
+    assert_empty(before)
+  end
+
+  test "rejects malformed and conflicting Content-Length before reading" do
+    malformed_values = ["", "+1", "-1", "1x", "1,", "1, 2"]
+
+    Enum.each(malformed_values, fn value ->
+      before = ByteBudget.stats()
+
+      conn =
+        :post
+        |> Plug.Test.conn("/rpc/ethereum", "{}")
+        |> put_req_header("content-type", "application/json")
+        |> put_raw_header("content-length", value)
+        |> with_read_spy()
+
+      assert_raise RequestByteBudget.HeaderError, fn -> parse(conn) end
+      refute_received {:request_body_read, _stats}
+      assert_empty(before)
+    end)
+  end
+
+  test "accepts repeated identical Content-Length and rejects conflicting fields" do
+    body = "{}"
+    before = ByteBudget.stats()
+
+    accepted =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_raw_headers("content-length", ["2", "2"])
+      |> parse()
+
+    assert ByteBudget.stats().reservations == before.reservations + 1
+    _accepted = send_resp(accepted, 200, "{}")
+    assert_empty(before)
+
+    rejected =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_raw_headers("content-length", ["2", "3"])
+      |> with_read_spy()
+
+    assert_raise RequestByteBudget.HeaderError, fn -> parse(rejected) end
+    refute_received {:request_body_read, _stats}
+    assert_empty(before)
+  end
+
+  test "rejects Content-Length with Transfer-Encoding before reading" do
+    before = ByteBudget.stats()
+
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "{}")
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(2)
+      |> put_req_header("transfer-encoding", "chunked")
+      |> with_read_spy()
+
+    assert_raise RequestByteBudget.HeaderError, fn -> parse(conn) end
+    refute_received {:request_body_read, _stats}
+    assert_empty(before)
+  end
+
+  test "rejects bodies that are shorter or longer than Content-Length and releases immediately" do
+    for {declared, body} <- [{1, "{}"}, {3, "{}"}] do
+      before = ByteBudget.stats()
+
+      conn =
+        :post
+        |> Plug.Test.conn("/rpc/ethereum", body)
+        |> put_req_header("content-type", "application/json")
+        |> put_content_length(declared)
+
+      assert_raise RequestByteBudget.HeaderError, fn -> parse(conn) end
+      assert_empty(before)
+    end
+  end
+
+  test "parser and adapter read errors release immediately" do
+    before = ByteBudget.stats()
+
+    malformed_json =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "{")
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(1)
+
+    assert_raise Plug.Parsers.ParseError, fn -> parse(malformed_json) end
+    assert_empty(before)
+
+    read_error =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "{}")
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(2)
+      |> Map.put(:adapter, {ReadErrorAdapter, {self(), :closed}})
+
+    assert_raise Plug.BadRequestError, fn -> parse(read_error) end
+    assert_received :request_body_read
+    assert_empty(before)
+  end
+
+  test "a downstream controller exception releases through the error response" do
+    body = ~s({"jsonrpc":"2.0","method":"eth_blockNumber","id":1})
+    before = ByteBudget.stats()
+
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(byte_size(body))
+
+    assert_raise Plug.Conn.WrapperError, fn -> RaisingPipeline.call(conn, []) end
+    assert_empty(before)
+  end
+
+  test "JSON, urlencoded, and multipart parsers share admission and release" do
+    requests = [
+      {"application/json", ~s({"jsonrpc":"2.0","method":"eth_blockNumber","id":1})},
+      {"application/x-www-form-urlencoded", "jsonrpc=2.0&method=eth_blockNumber&id=1"},
+      {"multipart/form-data; boundary=lasso",
+       "--lasso\r\ncontent-disposition: form-data; name=\"jsonrpc\"\r\n\r\n2.0\r\n" <>
+         "--lasso\r\ncontent-disposition: form-data; name=\"method\"\r\n\r\neth_blockNumber\r\n" <>
+         "--lasso--\r\n"}
+    ]
+
+    Enum.each(requests, fn {content_type, body} ->
+      before = ByteBudget.stats()
+
+      conn =
+        :post
+        |> Plug.Test.conn("/rpc/ethereum", body)
+        |> put_req_header("content-type", content_type)
+        |> put_content_length(byte_size(body))
+        |> parse()
+
+      assert conn.body_params["jsonrpc"] == "2.0"
+      assert ByteBudget.stats().reservations == before.reservations + 1
+
+      _conn = send_resp(conn, 200, "{}")
+      assert_empty(before)
+    end)
+  end
+
+  test "multipart reserves its declared length before bypassing the body reader" do
+    body =
+      "--lasso\r\ncontent-disposition: form-data; name=\"jsonrpc\"\r\n\r\n2.0\r\n" <>
+        "--lasso--\r\n"
+
+    before = ByteBudget.stats()
+
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", body)
+      |> put_req_header("content-type", "multipart/form-data; boundary=lasso")
+      |> put_content_length(byte_size(body))
+      |> with_read_spy()
+      |> parse()
+
+    assert_received {:request_body_read, during_read}
+
+    assert during_read.used_bytes == before.used_bytes + during_read.minimum_charge_bytes
+
+    assert conn.body_params["jsonrpc"] == "2.0"
+    _conn = conn |> without_read_spy() |> send_resp(200, "{}")
+    assert_empty(before)
+  end
+
+  test "non-RPC and WebSocket paths never consume the HTTP RPC budget" do
+    before = ByteBudget.stats()
+
+    for {method, path} <- [
+          {:post, "/api/other"},
+          {:get, "/ws/rpc/ethereum"},
+          {:get, "/live/websocket"},
+          {:post, "/rpc-not-a-route"}
+        ] do
+      conn =
+        method
+        |> Plug.Test.conn(path, "{}")
+        |> put_req_header("content-type", "application/json")
+        |> parse()
+
+      assert ByteBudget.stats() == before
+      _conn = send_resp(conn, 200, "{}")
+    end
+  end
+
+  test "HTTP admission fails before reading when every eligible bucket is full" do
     stats = ByteBudget.stats()
 
     reservations =
@@ -52,14 +371,88 @@ defmodule LassoWeb.Plugs.RequestByteBudgetTest do
       Enum.each(reservations, fn {_bucket, reservation} -> ByteBudget.release(reservation) end)
     end)
 
-    conn = Plug.Test.conn(:post, "/rpc/ethereum", ~s({"jsonrpc":"2.0"}))
+    conn =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", ~s({"jsonrpc":"2.0"}))
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(17)
+      |> with_read_spy()
 
-    assert_raise RequestByteBudget.CapacityError, fn ->
-      RequestByteBudget.read_body(conn, [])
-    end
+    assert_raise RequestByteBudget.CapacityError, fn -> parse(conn) end
+    refute_received {:request_body_read, _stats}
   end
 
-  test "capacity errors render as a retriable JSON-RPC transport rejection" do
+  test "parallel unknown-length admissions stay within aggregate capacity" do
+    parent = self()
+    worker_count = 16
+
+    workers =
+      for _index <- 1..worker_count do
+        spawn(fn ->
+          conn =
+            :post
+            |> Plug.Test.conn("/rpc/ethereum", "")
+            |> put_req_header("content-type", "application/octet-stream")
+
+          try do
+            conn = parse(conn)
+            send(parent, {:admitted, self()})
+
+            receive do
+              :release ->
+                _conn = send_resp(conn, 200, "{}")
+                send(parent, {:released, self()})
+            end
+          rescue
+            RequestByteBudget.CapacityError -> send(parent, {:rejected, self()})
+          end
+        end)
+      end
+
+    results = Enum.map(workers, fn _worker -> receive_result() end)
+    admitted = for {:admitted, pid} <- results, do: pid
+    rejected = for {:rejected, pid} <- results, do: pid
+
+    stats = ByteBudget.stats()
+    assert admitted != []
+    assert rejected != []
+
+    assert length(admitted) <=
+             stats.large_bucket_count *
+               div(stats.large_bucket_limit_bytes, RequestByteBudget.max_buffered_body_bytes())
+
+    assert stats.used_bytes <= stats.limit_bytes
+    assert stats.reservations == length(admitted)
+
+    Enum.each(admitted, &send(&1, :release))
+    Enum.each(admitted, fn pid -> assert_receive {:released, ^pid}, 1_000 end)
+    await_empty()
+  end
+
+  test "owner death is reclaimed by the budget audit" do
+    parent = self()
+    before = ByteBudget.stats()
+
+    {pid, monitor} =
+      spawn_monitor(fn ->
+        conn =
+          :post
+          |> Plug.Test.conn("/rpc/ethereum", "")
+          |> put_req_header("content-type", "application/octet-stream")
+          |> parse()
+
+        send(parent, {:held_reservation, ByteBudget.stats(), conn.state})
+      end)
+
+    assert_receive {:held_reservation, during, :unset}, 1_000
+    assert during.reservations == before.reservations + 1
+    assert_receive {:DOWN, ^monitor, :process, ^pid, :normal}, 1_000
+
+    send(ByteBudget, :audit)
+    await_empty()
+  end
+
+  test "capacity errors retain the retriable JSON-RPC transport response" do
     response =
       ErrorJSON.render("503.json", %{
         reason: %RequestByteBudget.CapacityError{}
@@ -73,6 +466,96 @@ defmodule LassoWeb.Plugs.RequestByteBudgetTest do
                "message" => "Local request byte capacity unavailable"
              }
            } = response
+  end
+
+  test "framing and size errors render as JSON-RPC responses at the endpoint" do
+    malformed =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "{}")
+      |> put_req_header("content-type", "application/json")
+      |> put_raw_header("content-length", "invalid")
+
+    assert {400, %{"jsonrpc" => "2.0", "id" => nil, "error" => malformed_error}} =
+             endpoint_error_response(malformed, RequestByteBudget.HeaderError)
+
+    assert malformed_error["code"] == -32_700
+
+    oversized =
+      :post
+      |> Plug.Test.conn("/rpc/ethereum", "")
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(RequestByteBudget.max_body_bytes() + 1)
+
+    assert {413, %{"jsonrpc" => "2.0", "id" => nil, "error" => oversized_error}} =
+             endpoint_error_response(oversized, Plug.Parsers.RequestTooLargeError)
+
+    assert oversized_error == %{
+             "code" => -32_600,
+             "message" => "Invalid Request: request body too large"
+           }
+  end
+
+  test "an oversized non-RPC endpoint request retains the generic 413 response" do
+    body = String.duplicate(" ", RequestByteBudget.max_body_bytes() + 1)
+
+    oversized =
+      :post
+      |> Plug.Test.conn("/api/other", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_content_length(byte_size(body))
+
+    assert {413, %{"errors" => %{"detail" => "Request Entity Too Large"}}} =
+             endpoint_error_response(oversized, Plug.Parsers.RequestTooLargeError)
+  end
+
+  defp parse(conn) do
+    opts =
+      RequestByteBudget.init(
+        parsers: [:urlencoded, :multipart, :json],
+        pass: ["*/*"],
+        json_decoder: Lasso.JSON.Decoder
+      )
+
+    RequestByteBudget.call(conn, opts)
+  end
+
+  defp with_read_spy(%Plug.Conn{adapter: {_adapter, state}} = conn),
+    do: %{conn | adapter: {ReadSpyAdapter, {self(), state}}}
+
+  defp without_read_spy(%Plug.Conn{adapter: {ReadSpyAdapter, {_owner, state}}} = conn),
+    do: %{conn | adapter: {Plug.Adapters.Test.Conn, state}}
+
+  defp put_content_length(conn, length),
+    do: put_raw_header(conn, "content-length", Integer.to_string(length))
+
+  defp put_raw_header(conn, name, value), do: put_raw_headers(conn, name, [value])
+
+  defp put_raw_headers(conn, name, values) do
+    headers = Enum.reject(conn.req_headers, fn {header, _value} -> header == name end)
+    %{conn | req_headers: Enum.map(values, &{name, &1}) ++ headers}
+  end
+
+  defp maybe_put_transfer_encoding(conn, nil), do: conn
+
+  defp maybe_put_transfer_encoding(conn, value),
+    do: put_req_header(conn, "transfer-encoding", value)
+
+  defp endpoint_error_response(%Plug.Conn{adapter: {_adapter, %{ref: ref}}} = conn, error) do
+    assert_raise error, fn ->
+      LassoWeb.Endpoint.call(conn, LassoWeb.Endpoint.init([]))
+    end
+
+    assert_receive {^ref, {status, _headers, body}}, 1_000
+    {status, Jason.decode!(body)}
+  end
+
+  defp receive_result do
+    receive do
+      {:admitted, _pid} = result -> result
+      {:rejected, _pid} = result -> result
+    after
+      2_000 -> flunk("parallel admission worker did not report")
+    end
   end
 
   defp fill_all_small_buckets(bucket_count, _bytes, reservations, _attempts)
@@ -90,6 +573,12 @@ defmodule LassoWeb.Plugs.RequestByteBudgetTest do
       end
 
     fill_all_small_buckets(bucket_count, bytes, reservations, attempts - 1)
+  end
+
+  defp assert_empty(before) do
+    stats = ByteBudget.stats()
+    assert stats.reservations == before.reservations
+    assert stats.used_bytes == before.used_bytes
   end
 
   defp await_empty(attempts \\ 100)


### PR DESCRIPTION
## Summary

- reserve aggregate RPC request-byte capacity before JSON, urlencoded, or multipart reads
- reject unsafe framing and oversized bodies before parsing or dispatch
- keep one bounded reservation through request completion with crash-audit recovery
- preserve non-RPC, WebSocket, and LiveView behavior and scope RPC 413 responses correctly

## Validation

- warnings-as-errors compilation
- 20 focused body-admission tests
- rebased full unit suite: 1,522 tests, 0 failures, 160 excluded
- independent boundedness/compatibility review approved
- formatting, Credo, and diff checks passed

## Operational note

Unknown-length or transfer-encoded RPC bodies reserve the configured maximum plus one read window before the first read. This is intentionally conservative under overload.