### PR TITLE
Add opt-in HTTP response heap tuning

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -57,6 +57,16 @@ unless cowboy_telemetry_enabled do
   config :lasso, LassoWeb.Endpoint, http: [stream_handlers: [:cowboy_stream_h]]
 end
 
+http_response_heap_tuning_enabled =
+  case System.get_env("LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED") do
+    nil -> false
+    value when value in ["true", "1"] -> true
+    value when value in ["false", "0"] -> false
+    _value -> raise "LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED must be true, false, 1, or 0"
+  end
+
+config :lasso, :http_response_heap_tuning_enabled, http_response_heap_tuning_enabled
+
 positive_integer_env = fn name, default ->
   case System.get_env(name) do
     nil ->

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -287,6 +287,7 @@ Set in `config/runtime.exs` or via environment variables:
 | `SECRET_KEY_BASE` | Phoenix secret key (required in production) | - |
 | `DATABASE_URL` | PostgreSQL connection URL (cloud only) | - |
 | `LASSO_COWBOY_TELEMETRY_ENABLED` | Enable Cowboy per-request telemetry (`true`, `false`, `1`, or `0`); disabling it does not disable Lasso application or dashboard events | `true` |
+| `LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED` | Use a larger short-lived heap while validating completed HTTP upstream responses; useful for CPU-bound, high-concurrency deployments | `false` |
 | `LASSO_HTTP_POOL_SIZE` | Maximum HTTP/1 connections per upstream host and pool | `256` |
 | `LASSO_HTTP_POOL_COUNT` | Independent Finch pools per upstream host | `1` |
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -159,6 +159,7 @@ The dashboard aggregates data across all nodes for unified observability with re
 | `LASSO_NODE_ID` | Prod | Unique node identifier | `"local"` in dev |
 | `LASSO_VM_METRICS_ENABLED` | No | Set to `false` to disable VM metrics | `true` |
 | `LASSO_COWBOY_TELEMETRY_ENABLED` | No | Set to `false` to disable Cowboy per-request telemetry; Lasso application and dashboard events remain enabled | `true` |
+| `LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED` | No | Use a larger short-lived heap while validating completed HTTP upstream responses; benchmark before enabling for latency-bound traffic | `false` |
 | `LASSO_HTTP_POOL_SIZE` | No | Maximum HTTP/1 connections per upstream host and pool | `256` |
 | `LASSO_HTTP_POOL_COUNT` | No | Independent Finch pools per upstream host | `1` |
 

--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -17,6 +17,10 @@ defmodule Lasso.Application do
     node_id = Application.fetch_env!(:lasso, :node_id)
     :persistent_term.put({Lasso.Cluster.Topology, :self_node_id}, node_id)
 
+    Lasso.RPC.Transports.HTTP.configure_response_heap_tuning(
+      Application.get_env(:lasso, :http_response_heap_tuning_enabled, false)
+    )
+
     # Create ETS tables owned by Application process (never dies).
     # These tables survive GenServer restarts and provide stable storage.
 

--- a/lib/lasso/core/transport/http/http.ex
+++ b/lib/lasso/core/transport/http/http.ex
@@ -15,6 +15,9 @@ defmodule Lasso.RPC.Transports.HTTP do
   alias Lasso.RPC.PreparedRequest
   alias Lasso.RPC.Transport.HTTP.Client, as: HttpClient
 
+  @response_heap_tuning_key {__MODULE__, :response_heap_tuning_enabled}
+  @response_validation_min_heap_size 4_185
+
   # Channel is the provider configuration for HTTP (stateless)
   @type channel :: %{url: String.t(), provider_id: String.t(), config: map()}
 
@@ -107,6 +110,7 @@ defmodule Lasso.RPC.Transports.HTTP do
            ) do
         {:ok, {:raw, raw_bytes}} ->
           received_at_us = System.monotonic_time(:microsecond)
+          tune_response_heap()
           validation = UpstreamResponse.validate_unary(raw_bytes, upstream_id, client_id)
           validated_at_us = System.monotonic_time(:microsecond)
 
@@ -157,6 +161,28 @@ defmodule Lasso.RPC.Transports.HTTP do
   @impl true
   def close(_channel) do
     # HTTP channels are stateless
+    :ok
+  end
+
+  @doc false
+  @spec configure_response_heap_tuning(boolean()) :: :ok
+  def configure_response_heap_tuning(enabled) when is_boolean(enabled) do
+    :persistent_term.put(@response_heap_tuning_key, enabled)
+  end
+
+  @doc false
+  @spec response_heap_tuning_enabled?() :: boolean()
+  def response_heap_tuning_enabled? do
+    :persistent_term.get(@response_heap_tuning_key, false)
+  end
+
+  @doc false
+  @spec tune_response_heap() :: :ok
+  def tune_response_heap do
+    if response_heap_tuning_enabled?() do
+      Process.flag(:min_heap_size, @response_validation_min_heap_size)
+    end
+
     :ok
   end
 

--- a/test/lasso/core/transport/http/response_heap_runtime_config_test.exs
+++ b/test/lasso/core/transport/http/response_heap_runtime_config_test.exs
@@ -1,0 +1,43 @@
+defmodule Lasso.Core.Transport.HTTP.ResponseHeapRuntimeConfigTest do
+  use ExUnit.Case, async: false
+
+  @env_name "LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED"
+
+  setup do
+    original = System.get_env(@env_name)
+
+    on_exit(fn -> restore_env(original) end)
+
+    :ok
+  end
+
+  test "runtime configuration is disabled by default and parses explicit boolean values" do
+    for {value, expected} <- [
+          {nil, false},
+          {"true", true},
+          {"1", true},
+          {"false", false},
+          {"0", false}
+        ] do
+      assert get_in(runtime_config(value), [:lasso, :http_response_heap_tuning_enabled]) ==
+               expected
+    end
+  end
+
+  test "runtime configuration rejects ambiguous values" do
+    assert_raise RuntimeError,
+                 "LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED must be true, false, 1, or 0",
+                 fn -> runtime_config("yes") end
+  end
+
+  defp runtime_config(value) do
+    restore_env(value)
+
+    base_config = Config.Reader.read!(Path.expand("config/config.exs"), env: :test)
+    runtime_config = Config.Reader.read!(Path.expand("config/runtime.exs"), env: :test)
+    Config.Reader.merge(base_config, runtime_config)
+  end
+
+  defp restore_env(nil), do: System.delete_env(@env_name)
+  defp restore_env(value), do: System.put_env(@env_name, value)
+end

--- a/test/lasso/core/transport/http/response_heap_test.exs
+++ b/test/lasso/core/transport/http/response_heap_test.exs
@@ -1,0 +1,45 @@
+defmodule Lasso.Core.Transport.HTTP.ResponseHeapTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.RPC.Transports.HTTP
+
+  setup do
+    previous = HTTP.response_heap_tuning_enabled?()
+
+    on_exit(fn ->
+      HTTP.configure_response_heap_tuning(previous)
+    end)
+
+    :ok
+  end
+
+  test "disabled tuning preserves the task heap" do
+    HTTP.configure_response_heap_tuning(false)
+
+    assert {:ok, before_min_heap, after_min_heap} = heap_probe()
+    assert after_min_heap == before_min_heap
+  end
+
+  test "enabled tuning expands the task heap to the bounded validation class" do
+    HTTP.configure_response_heap_tuning(true)
+
+    assert {:ok, before_min_heap, 4_185} = heap_probe()
+    assert before_min_heap < 4_185
+  end
+
+  defp heap_probe do
+    task =
+      Task.async(fn ->
+        before_min_heap = min_heap_size()
+        :ok = HTTP.tune_response_heap()
+        {:ok, before_min_heap, min_heap_size()}
+      end)
+
+    Task.await(task)
+  end
+
+  defp min_heap_size do
+    {:garbage_collection, options} = Process.info(self(), :garbage_collection)
+    Keyword.fetch!(options, :min_heap_size)
+  end
+end


### PR DESCRIPTION
## Summary

- add an opt-in runtime setting for a larger short-lived heap during HTTP upstream response validation
- apply the setting only after network I/O completes, avoiding heap retention while waiting on slow providers
- keep existing behavior as the default and document the deployment tradeoff

## Validation

- `mix format --check-formatted`
- compile with warnings as errors
- strict Credo on changed files
- Dialyzer in the CI dev environment
- 139 focused HTTP/request-owner/pipeline tests
- 1,526 unit tests
- 1,526 integration-enabled tests
- production release build and interleaved enabled/disabled load checks

The option defaults to `false`; enabling it is intended for CPU-bound, high-concurrency deployments after workload-specific validation.