### PR TITLE
Add HTTP platform floor benchmark

### DIFF
--- a/bench/platform_floor/README.md
+++ b/bench/platform_floor/README.md
@@ -1,0 +1,81 @@
+# HTTP platform-floor benchmark
+
+This benchmark separates HTTP platform cost from Lasso routing cost. It is a
+diagnostic, not a release gate and not an eRPC comparison suite.
+
+The four floor lanes are:
+
+| mode | endpoint | work |
+| --- | --- | --- |
+| bare | `/echo` | Cowboy, Plug, JSON decode/encode |
+| bare | `/proxy` | echo work plus one Finch HTTP/1 request |
+| phoenix | `/echo` | Phoenix endpoint/router plug stack plus JSON decode/encode |
+| phoenix | `/proxy` | Phoenix floor plus one Finch HTTP/1 request |
+
+The floor deliberately excludes Lasso routing, breaker, retry, projection,
+dashboard, and metering logic. Compare a Lasso run with the Phoenix proxy floor
+to estimate the Lasso-specific slice without pretending the platform is free.
+
+## Measurement contract
+
+- Run the target and synthetic upstream in separate containers with explicit
+  CPU and memory limits.
+- Use at least two load-driver workers and two upstream workers.
+- Keep request/response validation and one-to-one upstream amplification enabled.
+- Treat target cgroup CPU microseconds per successful request as the primary
+  cost metric. Use throughput to show saturation headroom, not as a standalone
+  winner.
+- Report p50, p95, and p99 latency, errors, target throttling, peak memory, and
+  upstream request/response counts.
+- Rotate lane order for at least three rounds. Do not compare cells whose load
+  driver or upstream is saturated.
+
+The driver uses Node worker threads so one JavaScript event loop does not cap the
+target. The upstream uses Node cluster workers and exposes control/statistics on
+a separate admin port.
+
+## Build and run
+
+From the repository root:
+
+```sh
+docker build -f bench/platform_floor/floor_app/Dockerfile -t lasso-platform-floor .
+
+docker run --rm --name lasso-floor-upstream --cpus=2 --memory=1g \
+  -v "$PWD/bench/platform_floor:/bench:ro" \
+  -e WORKERS=2 -e PORT=4100 -e ADMIN_PORT=4101 \
+  -p 4100:4100 -p 4101:4101 node:22-alpine \
+  node /bench/synthetic_upstream.mjs
+```
+
+Start a floor lane:
+
+```sh
+docker run --rm --name lasso-platform-floor --cpus=4 --memory=2g \
+  --add-host=host.docker.internal:host-gateway \
+  -e FLOOR_MODE=phoenix -e PORT=4200 \
+  -e UPSTREAM_URL=http://host.docker.internal:4100 \
+  -p 4200:4200 lasso-platform-floor
+```
+
+Run a measured cell from the host:
+
+```sh
+node bench/platform_floor/load_driver.mjs \
+  --url=http://127.0.0.1:4200/proxy \
+  --workers=4 --concurrency=128 --warmup=5 --duration=15 \
+  --targetContainer=lasso-platform-floor \
+  --upstreamContainer=lasso-floor-upstream \
+  --upstreamAdminUrl=http://127.0.0.1:4101
+```
+
+The result is one JSON document suitable for appending to a JSONL artifact.
+The target and upstream containers must use cgroup v2 for exact CPU accounting.
+The output includes their CPU quota, CPU and throttled time, memory, and the
+load driver's equivalent core usage so saturated cells can be rejected.
+
+Run the benchmark utility tests with:
+
+```sh
+node --test bench/platform_floor/test/*.test.mjs
+```

--- a/bench/platform_floor/floor_app/Dockerfile
+++ b/bench/platform_floor/floor_app/Dockerfile
@@ -1,0 +1,21 @@
+FROM hexpm/elixir:1.18.4-erlang-28.0.2-alpine-3.22.1 AS build
+
+RUN apk add --no-cache build-base git
+WORKDIR /app
+RUN mix local.hex --force && mix local.rebar --force
+
+COPY bench/platform_floor/floor_app/mix.exs ./mix.exs
+COPY mix.lock ./mix.lock
+RUN MIX_ENV=prod mix deps.get --only prod
+RUN MIX_ENV=prod mix deps.compile
+
+COPY bench/platform_floor/floor_app/lib ./lib
+RUN MIX_ENV=prod mix compile
+RUN MIX_ENV=prod mix release
+
+FROM alpine:3.22.1 AS runtime
+RUN apk add --no-cache libstdc++ ncurses-libs openssl
+WORKDIR /app
+COPY --from=build /app/_build/prod/rel/platform_floor ./
+ENV HOME=/app
+CMD ["/app/bin/platform_floor", "start"]

--- a/bench/platform_floor/floor_app/lib/platform_floor.ex
+++ b/bench/platform_floor/floor_app/lib/platform_floor.ex
@@ -1,0 +1,169 @@
+defmodule PlatformFloor.JSON do
+  @moduledoc false
+
+  def decode!(body), do: :json.decode(body)
+  def encode!(value), do: value |> :json.encode() |> IO.iodata_to_binary()
+end
+
+defmodule PlatformFloor.Handler do
+  @moduledoc false
+
+  import Plug.Conn
+
+  def echo(conn, request) do
+    send_json(conn, %{"jsonrpc" => "2.0", "id" => request["id"], "result" => "0x1"})
+  end
+
+  def proxy(conn, request) do
+    body = PlatformFloor.JSON.encode!(request)
+
+    {:ok, %Finch.Response{status: 200, body: response_body}} =
+      :post
+      |> Finch.build(upstream_url(), [{"content-type", "application/json"}], body)
+      |> Finch.request(PlatformFloor.Finch, receive_timeout: 5_000, pool_timeout: 5_000)
+
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, response_body)
+  end
+
+  defp send_json(conn, value) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(200, PlatformFloor.JSON.encode!(value))
+  end
+
+  defp upstream_url do
+    :persistent_term.get({PlatformFloor, :upstream_url})
+  end
+end
+
+defmodule PlatformFloor.BarePlug do
+  @moduledoc false
+
+  import Plug.Conn
+
+  def init(options), do: options
+
+  def call(%Plug.Conn{method: "POST", path_info: ["echo"]} = conn, _options) do
+    {request, conn} = read_request(conn)
+    PlatformFloor.Handler.echo(conn, request)
+  end
+
+  def call(%Plug.Conn{method: "POST", path_info: ["proxy"]} = conn, _options) do
+    {request, conn} = read_request(conn)
+    PlatformFloor.Handler.proxy(conn, request)
+  end
+
+  def call(conn, _options), do: send_resp(conn, 404, "")
+
+  defp read_request(conn) do
+    {:ok, body, conn} = read_body(conn, length: 8_000_000, read_length: 1_000_000)
+    {PlatformFloor.JSON.decode!(body), conn}
+  end
+end
+
+defmodule PlatformFloor.Router do
+  @moduledoc false
+
+  use Phoenix.Router
+
+  pipeline :api do
+    plug(:accepts, ["json"])
+  end
+
+  scope "/" do
+    pipe_through(:api)
+    post("/echo", PlatformFloor.Controller, :echo)
+    post("/proxy", PlatformFloor.Controller, :proxy)
+  end
+end
+
+defmodule PlatformFloor.Controller do
+  @moduledoc false
+
+  def init(action), do: action
+
+  def call(conn, action), do: apply(__MODULE__, action, [conn, conn.params])
+
+  def echo(conn, request), do: PlatformFloor.Handler.echo(conn, request)
+  def proxy(conn, request), do: PlatformFloor.Handler.proxy(conn, request)
+end
+
+defmodule PlatformFloor.PhoenixEndpoint do
+  @moduledoc false
+
+  use Phoenix.Endpoint, otp_app: :platform_floor
+
+  @session_options [
+    store: :cookie,
+    key: "_platform_floor_key",
+    signing_salt: "platform-floor"
+  ]
+
+  plug(Plug.RequestId)
+
+  plug(Plug.Parsers,
+    parsers: [:urlencoded, :multipart, :json],
+    pass: ["*/*"],
+    json_decoder: PlatformFloor.JSON
+  )
+
+  plug(Plug.MethodOverride)
+  plug(Plug.Head)
+  plug(Plug.Session, @session_options)
+  plug(CORSPlug, origin: "*", methods: ["GET", "POST", "OPTIONS"])
+  plug(PlatformFloor.Router)
+end
+
+defmodule PlatformFloor.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    port = System.get_env("PORT", "4200") |> String.to_integer()
+    mode = System.get_env("FLOOR_MODE", "bare")
+
+    :persistent_term.put(
+      {PlatformFloor, :upstream_url},
+      System.get_env("UPSTREAM_URL", "http://127.0.0.1:4100")
+    )
+
+    Application.put_env(:phoenix, :json_library, PlatformFloor.JSON)
+
+    Application.put_env(:platform_floor, PlatformFloor.PhoenixEndpoint,
+      adapter: Phoenix.Endpoint.Cowboy2Adapter,
+      http: [ip: {0, 0, 0, 0}, port: port],
+      secret_key_base: String.duplicate("platform-floor-secret-", 4),
+      server: true,
+      url: [host: "localhost"]
+    )
+
+    children = [
+      {Finch,
+       name: PlatformFloor.Finch,
+       pools: %{
+         :default => [
+           protocols: [:http1],
+           size: System.get_env("POOL_SIZE", "256") |> String.to_integer(),
+           count: 1
+         ]
+       }},
+      server_child(mode, port)
+    ]
+
+    Supervisor.start_link(children, strategy: :one_for_one, name: PlatformFloor.Supervisor)
+  end
+
+  defp server_child("bare", port) do
+    {Plug.Cowboy,
+     scheme: :http, plug: PlatformFloor.BarePlug, options: [ip: {0, 0, 0, 0}, port: port]}
+  end
+
+  defp server_child("phoenix", _port), do: PlatformFloor.PhoenixEndpoint
+
+  defp server_child(mode, _port),
+    do: raise("FLOOR_MODE must be bare or phoenix, got #{inspect(mode)}")
+end

--- a/bench/platform_floor/floor_app/mix.exs
+++ b/bench/platform_floor/floor_app/mix.exs
@@ -1,0 +1,26 @@
+defmodule PlatformFloor.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :platform_floor,
+      version: "0.1.0",
+      elixir: "~> 1.17",
+      start_permanent: true,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [mod: {PlatformFloor.Application, []}, extra_applications: [:logger]]
+  end
+
+  defp deps do
+    [
+      {:cors_plug, "3.0.3"},
+      {:finch, "0.23.0"},
+      {:phoenix, "1.8.11"},
+      {:plug_cowboy, "2.9.0"}
+    ]
+  end
+end

--- a/bench/platform_floor/load_driver.mjs
+++ b/bench/platform_floor/load_driver.mjs
@@ -1,0 +1,303 @@
+#!/usr/bin/env node
+import { execFile } from "node:child_process";
+import http from "node:http";
+import https from "node:https";
+import os from "node:os";
+import { appendFileSync } from "node:fs";
+import { promisify } from "node:util";
+import { isMainThread, parentPort, Worker, workerData } from "node:worker_threads";
+import { RelativeHistogram } from "./relative_histogram.mjs";
+
+const execFileAsync = promisify(execFile);
+
+function parseArgs(argv) {
+  return Object.fromEntries(argv.map((argument) => {
+    const separator = argument.indexOf("=");
+    if (!argument.startsWith("--") || separator < 3) throw new Error(`invalid argument ${argument}`);
+    return [argument.slice(2, separator), argument.slice(separator + 1)];
+  }));
+}
+
+function integer(value, label, minimum = 1) {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum) {
+    throw new Error(`${label} must be an integer >= ${minimum}`);
+  }
+  return parsed;
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function requestBody(id) {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    method: "eth_getBalance",
+    params: [`0x${id.toString(16).padStart(40, "0")}`, "latest"],
+  });
+}
+
+function invoke(target, agent, id, timeoutMs, histogram, counters) {
+  const body = requestBody(id);
+  const transport = target.protocol === "https:" ? https : http;
+  const startedAt = process.hrtime.bigint();
+  counters.started += 1;
+
+  return new Promise((resolve) => {
+    let finished = false;
+    const finish = (category) => {
+      if (finished) return;
+      finished = true;
+      if (category === null) {
+        counters.success += 1;
+        histogram.record(Number(process.hrtime.bigint() - startedAt) / 1_000);
+      } else {
+        counters.errors += 1;
+        counters.errorCategories[category] = (counters.errorCategories[category] || 0) + 1;
+      }
+      resolve();
+    };
+
+    const request = transport.request({
+      protocol: target.protocol,
+      hostname: target.hostname,
+      port: target.port,
+      path: `${target.pathname}${target.search}`,
+      method: "POST",
+      agent,
+      timeout: timeoutMs,
+      headers: {
+        "content-type": "application/json",
+        "content-length": Buffer.byteLength(body),
+      },
+    }, (response) => {
+      const chunks = [];
+      response.on("data", (chunk) => chunks.push(chunk));
+      response.on("aborted", () => finish("network_error"));
+      response.on("error", () => finish("network_error"));
+      response.on("end", () => {
+        if (response.statusCode !== 200) return finish(`http_${response.statusCode}`);
+        try {
+          const decoded = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+          const valid = decoded?.jsonrpc === "2.0" && decoded?.id === id &&
+            Object.hasOwn(decoded, "result") && !Object.hasOwn(decoded, "error");
+          finish(valid ? null : "invalid_json_rpc_response");
+        } catch {
+          finish("invalid_json");
+        }
+      });
+    });
+    request.on("timeout", () => request.destroy(new Error("timeout")));
+    request.on("error", (error) => finish(error.message === "timeout" ? "timeout" : "network_error"));
+    request.end(body);
+  });
+}
+
+async function runWorker() {
+  const target = new URL(workerData.url);
+  const transport = target.protocol === "https:" ? https : http;
+  const agent = new transport.Agent({
+    keepAlive: true,
+    maxSockets: workerData.concurrency,
+    maxFreeSockets: workerData.concurrency,
+  });
+  let sequence = (workerData.index + 1) * 1_000_000_000;
+
+  const runFor = async (durationMs, record) => {
+    const endsAt = process.hrtime.bigint() + BigInt(durationMs) * 1_000_000n;
+    const histogram = new RelativeHistogram();
+    const counters = { started: 0, success: 0, errors: 0, errorCategories: {} };
+    await Promise.all(Array.from({ length: workerData.concurrency }, async () => {
+      while (process.hrtime.bigint() < endsAt) {
+        sequence += 1;
+        await invoke(target, agent, sequence, workerData.timeoutMs, histogram, counters);
+      }
+    }));
+    return record ? { histogram: histogram.serialize(), counters } : null;
+  };
+
+  await runFor(workerData.warmupMs, false);
+  parentPort.postMessage({ type: "ready" });
+  parentPort.once("message", async ({ type, durationMs }) => {
+    if (type !== "measure") throw new Error(`unexpected command ${type}`);
+    const startedAt = process.hrtime.bigint();
+    const result = await runFor(durationMs, true);
+    const elapsedSeconds = Number(process.hrtime.bigint() - startedAt) / 1e9;
+    agent.destroy();
+    parentPort.postMessage({ type: "result", elapsedSeconds, ...result });
+  });
+}
+
+async function dockerCgroupSample(container) {
+  if (!container) return null;
+  const script = [
+    "cat /sys/fs/cgroup/cpu.stat",
+    "printf '\\n--cpu-max--\\n'",
+    "cat /sys/fs/cgroup/cpu.max",
+    "printf '\\n--memory-current--\\n'",
+    "cat /sys/fs/cgroup/memory.current",
+    "printf '\\n--memory-peak--\\n'",
+    "cat /sys/fs/cgroup/memory.peak 2>/dev/null || true",
+    "printf '\\n--pids--\\n'",
+    "cat /sys/fs/cgroup/pids.current",
+  ].join("; ");
+  const { stdout } = await execFileAsync("docker", ["exec", container, "sh", "-c", script]);
+  const [cpu, cpuMax, memoryCurrent, memoryPeak, pids] = stdout.split(/\n--[^\n]+--\n/);
+  const cpuStat = Object.fromEntries(cpu.trim().split("\n").map((line) => {
+    const [key, value] = line.trim().split(/\s+/, 2);
+    return [key, Number(value)];
+  }));
+  return {
+    capturedAt: new Date().toISOString(),
+    cpuStat,
+    cpuMax: cpuMax.trim(),
+    memoryCurrentBytes: Number(memoryCurrent.trim()),
+    memoryPeakBytes: memoryPeak.trim() === "" ? null : Number(memoryPeak.trim()),
+    pidsCurrent: Number(pids.trim()),
+  };
+}
+
+function resourceDelta(container, start, end, successfulRequests) {
+  if (start === null || end === null) return null;
+  const cpuMicroseconds = end.cpuStat.usage_usec - start.cpuStat.usage_usec;
+  return {
+    container,
+    start,
+    end,
+    cpuMicroseconds,
+    cpuMicrosecondsPerSuccessful: successfulRequests === 0
+      ? null
+      : cpuMicroseconds / successfulRequests,
+    throttledMicroseconds: end.cpuStat.throttled_usec - start.cpuStat.throttled_usec,
+  };
+}
+
+async function upstreamRequest(adminUrl, method, path, body = null) {
+  if (!adminUrl) return null;
+  const response = await fetch(new URL(path, adminUrl), {
+    method,
+    headers: body === null ? {} : { "content-type": "application/json" },
+    body: body === null ? null : JSON.stringify(body),
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!response.ok) throw new Error(`upstream ${path} failed with HTTP ${response.status}`);
+  return response.json();
+}
+
+async function runMain() {
+  const args = parseArgs(process.argv.slice(2));
+  const workerCount = integer(args.workers || Math.min(4, os.availableParallelism()), "workers");
+  const concurrency = integer(args.concurrency || 64, "concurrency");
+  const warmupMs = integer(Math.round(Number(args.warmup || 5) * 1_000), "warmupMs", 0);
+  const durationMs = integer(Math.round(Number(args.duration || 15) * 1_000), "durationMs");
+  const timeoutMs = integer(args.timeout || 10_000, "timeout");
+  const target = new URL(args.url || "http://127.0.0.1:4000/rpc/1");
+  const targetContainer = args.targetContainer || null;
+  const upstreamContainer = args.upstreamContainer || null;
+  const upstreamAdminUrl = args.upstreamAdminUrl || null;
+  if (workerCount > concurrency) {
+    throw new Error("workers must be less than or equal to concurrency");
+  }
+  const baseConcurrency = Math.floor(concurrency / workerCount);
+  const remainder = concurrency % workerCount;
+  const workers = Array.from({ length: workerCount }, (_, index) => new Worker(import.meta.filename, {
+    workerData: {
+      index,
+      url: target.toString(),
+      concurrency: baseConcurrency + (index < remainder ? 1 : 0),
+      warmupMs,
+      timeoutMs,
+    },
+  }));
+
+  const ready = workers.map((worker) => new Promise((resolve, reject) => {
+    worker.once("error", reject);
+    worker.once("message", (message) => {
+      if (message.type !== "ready") reject(new Error(`unexpected worker message ${message.type}`));
+      else resolve();
+    });
+  }));
+  await Promise.all(ready);
+  const upstreamReset = await upstreamRequest(upstreamAdminUrl, "POST", "/control", {
+    mode: "healthy",
+    reset: true,
+  });
+  const [targetStart, upstreamStart] = await Promise.all([
+    dockerCgroupSample(targetContainer),
+    dockerCgroupSample(upstreamContainer),
+  ]);
+  const clientCpuStart = process.cpuUsage();
+  const measuredStartedAt = new Date();
+  const results = workers.map((worker) => new Promise((resolve, reject) => {
+    worker.once("error", reject);
+    worker.once("message", (message) => {
+      if (message.type !== "result") reject(new Error(`unexpected worker message ${message.type}`));
+      else resolve(message);
+    });
+    worker.postMessage({ type: "measure", durationMs });
+  }));
+  const workerResults = await Promise.all(results);
+  const measuredEndedAt = new Date();
+  const clientCpu = process.cpuUsage(clientCpuStart);
+  const [targetEnd, upstreamEnd] = await Promise.all([
+    dockerCgroupSample(targetContainer),
+    dockerCgroupSample(upstreamContainer),
+  ]);
+  const upstreamStats = await upstreamRequest(upstreamAdminUrl, "GET", "/stats");
+  await Promise.all(workers.map((worker) => worker.terminate()));
+
+  const histogram = new RelativeHistogram();
+  const counters = { started: 0, success: 0, errors: 0, errorCategories: {} };
+  for (const result of workerResults) {
+    histogram.merge(result.histogram);
+    counters.started += result.counters.started;
+    counters.success += result.counters.success;
+    counters.errors += result.counters.errors;
+    for (const [category, count] of Object.entries(result.counters.errorCategories)) {
+      counters.errorCategories[category] = (counters.errorCategories[category] || 0) + count;
+    }
+  }
+  const elapsedSeconds = Math.max(...workerResults.map(({ elapsedSeconds }) => elapsedSeconds));
+  const latencyUs = histogram.serialize();
+  if (args.includeHistogramBins !== "true") delete latencyUs.bins;
+
+  const output = {
+    schemaVersion: 1,
+    label: args.label || null,
+    target: target.toString(),
+    runner: {
+      node: process.version,
+      platform: process.platform,
+      architecture: process.arch,
+    },
+    workload: { workerCount, concurrency, warmupMs, durationMs, timeoutMs },
+    timing: {
+      startedAt: measuredStartedAt.toISOString(),
+      endedAt: measuredEndedAt.toISOString(),
+      elapsedSeconds,
+    },
+    counters,
+    successfulRps: counters.success / elapsedSeconds,
+    latencyUs,
+    client: {
+      cpuMicroseconds: clientCpu.user + clientCpu.system,
+      cpuMicrosecondsPerStarted: counters.started === 0
+        ? null
+        : (clientCpu.user + clientCpu.system) / counters.started,
+      equivalentCores: (clientCpu.user + clientCpu.system) / (elapsedSeconds * 1_000_000),
+    },
+    targetResources: resourceDelta(targetContainer, targetStart, targetEnd, counters.success),
+    upstreamResources:
+      resourceDelta(upstreamContainer, upstreamStart, upstreamEnd, counters.success),
+    upstream: { reset: upstreamReset, stats: upstreamStats },
+  };
+  const encoded = `${JSON.stringify(output)}\n`;
+  if (args.output) appendFileSync(args.output, encoded);
+  process.stdout.write(encoded);
+  if (counters.errors > 0 || histogram.underflow > 0 || histogram.overflow > 0) process.exitCode = 1;
+}
+
+if (isMainThread) await runMain();
+else await runWorker();

--- a/bench/platform_floor/relative_histogram.mjs
+++ b/bench/platform_floor/relative_histogram.mjs
@@ -1,0 +1,115 @@
+const defaults = {
+  lowestTrackable: 1,
+  highestTrackable: 60_000_000,
+  relativePrecision: 0.001,
+};
+
+export class RelativeHistogram {
+  constructor(options = {}) {
+    this.lowestTrackable = options.lowestTrackable ?? defaults.lowestTrackable;
+    this.highestTrackable = options.highestTrackable ?? defaults.highestTrackable;
+    this.relativePrecision = options.relativePrecision ?? defaults.relativePrecision;
+    if (!(this.lowestTrackable > 0) || this.highestTrackable <= this.lowestTrackable) {
+      throw new Error("invalid histogram range");
+    }
+    if (!(this.relativePrecision > 0 && this.relativePrecision < 1)) {
+      throw new Error("relativePrecision must be in (0, 1)");
+    }
+
+    this.logRatio = Math.log1p(this.relativePrecision);
+    this.bucketCount = Math.ceil(
+      Math.log(this.highestTrackable / this.lowestTrackable) / this.logRatio,
+    ) + 1;
+    this.counts = new Uint32Array(this.bucketCount);
+    this.total = 0;
+    this.sum = 0;
+    this.minimum = Infinity;
+    this.maximum = 0;
+    this.underflow = 0;
+    this.overflow = 0;
+  }
+
+  record(value) {
+    if (!Number.isFinite(value) || value < 0) throw new Error("invalid histogram value");
+    if (value < this.lowestTrackable) this.underflow += 1;
+    if (value > this.highestTrackable) this.overflow += 1;
+    const bounded = Math.min(this.highestTrackable, Math.max(this.lowestTrackable, value));
+    const index = Math.min(
+      this.bucketCount - 1,
+      Math.max(0, Math.floor(Math.log(bounded / this.lowestTrackable) / this.logRatio)),
+    );
+    if (this.counts[index] === 0xffffffff) throw new Error("histogram bucket overflow");
+    this.counts[index] += 1;
+    this.total += 1;
+    this.sum += value;
+    this.minimum = Math.min(this.minimum, value);
+    this.maximum = Math.max(this.maximum, value);
+  }
+
+  merge(serialized) {
+    if (
+      serialized.bucketCount !== this.bucketCount ||
+      serialized.lowestTrackable !== this.lowestTrackable ||
+      serialized.highestTrackable !== this.highestTrackable ||
+      serialized.relativePrecision !== this.relativePrecision
+    ) throw new Error("incompatible histograms");
+
+    for (const [index, count] of serialized.bins) {
+      if (!Number.isSafeInteger(index) || index < 0 || index >= this.bucketCount) {
+        throw new Error("invalid histogram bucket index");
+      }
+      if (!Number.isSafeInteger(count) || count < 0 || this.counts[index] + count > 0xffffffff) {
+        throw new Error("histogram bucket overflow");
+      }
+      this.counts[index] += count;
+    }
+    this.total += serialized.total;
+    this.sum += serialized.sum;
+    this.underflow += serialized.underflow;
+    this.overflow += serialized.overflow;
+    if (serialized.total > 0) {
+      this.minimum = Math.min(this.minimum, serialized.minimum);
+      this.maximum = Math.max(this.maximum, serialized.maximum);
+    }
+  }
+
+  percentile(fraction) {
+    if (this.total === 0) return null;
+    const target = Math.ceil(this.total * fraction);
+    let cumulative = 0;
+    for (let index = 0; index < this.counts.length; index += 1) {
+      cumulative += this.counts[index];
+      if (cumulative >= target) {
+        if (index === 0) return Math.min(this.maximum, this.lowestTrackable);
+        const upper = this.lowestTrackable * Math.exp((index + 1) * this.logRatio);
+        return Math.min(this.maximum, upper);
+      }
+    }
+    throw new Error("histogram count invariant failed");
+  }
+
+  serialize() {
+    const bins = [];
+    for (let index = 0; index < this.counts.length; index += 1) {
+      if (this.counts[index] > 0) bins.push([index, this.counts[index]]);
+    }
+    return {
+      lowestTrackable: this.lowestTrackable,
+      highestTrackable: this.highestTrackable,
+      relativePrecision: this.relativePrecision,
+      bucketCount: this.bucketCount,
+      total: this.total,
+      sum: this.sum,
+      minimum: this.total === 0 ? null : this.minimum,
+      maximum: this.total === 0 ? null : this.maximum,
+      underflow: this.underflow,
+      overflow: this.overflow,
+      percentiles: {
+        p50: this.percentile(0.5),
+        p95: this.percentile(0.95),
+        p99: this.percentile(0.99),
+      },
+      bins,
+    };
+  }
+}

--- a/bench/platform_floor/synthetic_upstream.mjs
+++ b/bench/platform_floor/synthetic_upstream.mjs
@@ -1,0 +1,214 @@
+#!/usr/bin/env node
+import cluster from "node:cluster";
+import http from "node:http";
+import os from "node:os";
+
+const dataPort = Number(process.env.PORT || 4100);
+const adminPort = Number(process.env.ADMIN_PORT || dataPort + 1);
+const workerCount = Number(process.env.WORKERS || Math.min(4, os.availableParallelism()));
+const initialDelayMs = Number(process.env.RESPONSE_DELAY_MS || 1);
+const allowedModes = new Set(["healthy", "http_503", "rpc_error", "connection_reset"]);
+
+function readBody(request, limit = 1_048_576) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let bytes = 0;
+    request.on("data", (chunk) => {
+      bytes += chunk.length;
+      if (bytes > limit) reject(new Error("request body exceeded limit"));
+      else chunks.push(chunk);
+    });
+    request.on("end", () => resolve(Buffer.concat(chunks)));
+    request.on("error", reject);
+  });
+}
+
+function sendJson(response, status, value, onComplete = null) {
+  const body = Buffer.from(JSON.stringify(value));
+  response.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": body.length,
+  });
+  response.end(body, onComplete);
+}
+
+if (cluster.isPrimary) {
+  if (!Number.isSafeInteger(workerCount) || workerCount < 1) throw new Error("WORKERS must be positive");
+  let generation = 0;
+  let mode = "healthy";
+  let delayMs = initialDelayMs;
+  const pending = new Map();
+
+  for (let index = 0; index < workerCount; index += 1) cluster.fork();
+
+  for (const worker of Object.values(cluster.workers)) {
+    worker.on("message", (message) => {
+      const request = pending.get(message.requestId);
+      if (!request) return;
+      request.responses.push(message);
+      if (request.responses.length === workerCount) {
+        pending.delete(message.requestId);
+        request.resolve(request.responses);
+      }
+    });
+  }
+
+  const broadcast = (type, payload = {}) => new Promise((resolve, reject) => {
+    const requestId = `${process.pid}-${Date.now()}-${Math.random()}`;
+    const timeout = setTimeout(() => {
+      pending.delete(requestId);
+      reject(new Error(`${type} worker acknowledgement timed out`));
+    }, 5_000);
+    pending.set(requestId, {
+      responses: [],
+      resolve: (responses) => {
+        clearTimeout(timeout);
+        resolve(responses);
+      },
+    });
+    for (const worker of Object.values(cluster.workers)) worker.send({ type, requestId, ...payload });
+  });
+
+  const aggregate = (responses) => {
+    const totals = {
+      requests: 0,
+      responses: 0,
+      benchmarkRequests: 0,
+      benchmarkResponses: 0,
+      systemRequests: 0,
+      systemResponses: 0,
+      errors: 0,
+      connectionsAccepted: 0,
+      activeRequests: 0,
+      peakActiveRequests: 0,
+    };
+    for (const { stats } of responses) {
+      totals.requests += stats.requests;
+      totals.responses += stats.responses;
+      totals.benchmarkRequests += stats.benchmarkRequests;
+      totals.benchmarkResponses += stats.benchmarkResponses;
+      totals.systemRequests += stats.systemRequests;
+      totals.systemResponses += stats.systemResponses;
+      totals.errors += stats.errors;
+      totals.connectionsAccepted += stats.connectionsAccepted;
+      totals.activeRequests += stats.activeRequests;
+      totals.peakActiveRequests += stats.peakActiveRequests;
+    }
+    return { generation, mode, delayMs, workers: workerCount, totals };
+  };
+
+  const admin = http.createServer(async (request, response) => {
+    try {
+      if (request.method === "GET" && request.url === "/stats") {
+        sendJson(response, 200, aggregate(await broadcast("stats")));
+        return;
+      }
+      if (request.method === "POST" && request.url === "/control") {
+        const update = JSON.parse((await readBody(request)).toString("utf8") || "{}");
+        const nextMode = update.mode ?? mode;
+        const nextDelayMs = update.delayMs ?? delayMs;
+        if (!allowedModes.has(nextMode)) throw new Error(`unsupported mode ${nextMode}`);
+        if (!Number.isFinite(nextDelayMs) || nextDelayMs < 0) throw new Error("invalid delayMs");
+        generation += 1;
+        mode = nextMode;
+        delayMs = nextDelayMs;
+        const responses = await broadcast("control", {
+          generation,
+          mode,
+          delayMs,
+          reset: update.reset === true,
+        });
+        sendJson(response, 200, aggregate(responses));
+        return;
+      }
+      sendJson(response, 404, { error: "not found" });
+    } catch (error) {
+      sendJson(response, 400, { error: String(error) });
+    }
+  });
+  admin.listen(adminPort, "0.0.0.0", () => {
+    process.stdout.write(`${JSON.stringify({ ready: true, dataPort, adminPort, workers: workerCount })}\n`);
+  });
+} else {
+  let control = { generation: 0, mode: "healthy", delayMs: initialDelayMs };
+  let totals = {
+    requests: 0,
+    responses: 0,
+    benchmarkRequests: 0,
+    benchmarkResponses: 0,
+    systemRequests: 0,
+    systemResponses: 0,
+    errors: 0,
+    connectionsAccepted: 0,
+    activeRequests: 0,
+    peakActiveRequests: 0,
+  };
+
+  const snapshot = () => ({ ...totals });
+  process.on("message", (message) => {
+    if (message.type === "control") {
+      control = { generation: message.generation, mode: message.mode, delayMs: message.delayMs };
+      if (message.reset) {
+        totals = {
+          ...totals,
+          requests: 0,
+          responses: 0,
+          benchmarkRequests: 0,
+          benchmarkResponses: 0,
+          systemRequests: 0,
+          systemResponses: 0,
+          errors: 0,
+          connectionsAccepted: 0,
+          peakActiveRequests: totals.activeRequests,
+        };
+      }
+      process.send({ requestId: message.requestId, stats: snapshot() });
+    } else if (message.type === "stats") {
+      process.send({ requestId: message.requestId, stats: snapshot() });
+    }
+  });
+
+  const server = http.createServer(async (request, response) => {
+    if (request.method !== "POST") {
+      sendJson(response, 404, { error: "not found" });
+      return;
+    }
+    totals.requests += 1;
+    totals.activeRequests += 1;
+    totals.peakActiveRequests = Math.max(totals.peakActiveRequests, totals.activeRequests);
+    const decision = { ...control };
+    try {
+      const rpc = JSON.parse((await readBody(request)).toString("utf8"));
+      const benchmark = rpc.method === "eth_getBalance";
+      totals[benchmark ? "benchmarkRequests" : "systemRequests"] += 1;
+      if (decision.delayMs > 0) await new Promise((resolve) => setTimeout(resolve, decision.delayMs));
+      if (decision.mode === "connection_reset") {
+        request.socket.destroy();
+        return;
+      }
+      if (decision.mode === "http_503") {
+        sendJson(response, 503, { error: "synthetic unavailable" }, () => {
+          totals.responses += 1;
+          totals[benchmark ? "benchmarkResponses" : "systemResponses"] += 1;
+        });
+        return;
+      }
+      const body = decision.mode === "rpc_error"
+        ? { jsonrpc: "2.0", id: rpc.id ?? null, error: { code: -32000, message: "synthetic error" } }
+        : { jsonrpc: "2.0", id: rpc.id ?? null, result: "0x1" };
+      sendJson(response, 200, body, () => {
+        totals.responses += 1;
+        totals[benchmark ? "benchmarkResponses" : "systemResponses"] += 1;
+      });
+    } catch (error) {
+      totals.errors += 1;
+      sendJson(response, 400, { error: String(error) });
+    } finally {
+      totals.activeRequests -= 1;
+    }
+  });
+  server.on("connection", () => { totals.connectionsAccepted += 1; });
+  server.keepAliveTimeout = 65_000;
+  server.headersTimeout = 66_000;
+  server.listen(dataPort, "0.0.0.0");
+}

--- a/bench/platform_floor/test/benchmark_contract.test.mjs
+++ b/bench/platform_floor/test/benchmark_contract.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const benchmarkRoot = fileURLToPath(new URL("..", import.meta.url));
+
+async function freePort() {
+  const server = createServer();
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address();
+  server.close();
+  await once(server, "close");
+  return port;
+}
+
+async function waitFor(url, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url, { headers: { connection: "close" } });
+      if (response.ok) return;
+    } catch {
+      // The clustered data and admin listeners may not be ready yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for ${url}`);
+}
+
+async function stop(child) {
+  if (child.exitCode !== null) return;
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("child did not exit")), 5_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    child.kill("SIGTERM");
+  });
+}
+
+function runNode(script, arguments_, options = {}) {
+  return spawn(process.execPath, [script, ...arguments_], {
+    cwd: benchmarkRoot,
+    stdio: ["ignore", "pipe", "pipe"],
+    ...options,
+  });
+}
+
+async function collect(child) {
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => { stdout += chunk; });
+  child.stderr.on("data", (chunk) => { stderr += chunk; });
+  const [code, signal] = await once(child, "exit");
+  assert.equal(signal, null, stderr);
+  assert.equal(code, 0, stderr);
+  return stdout;
+}
+
+test("clustered upstream and multi-worker driver preserve exact amplification", async (t) => {
+  const dataPort = await freePort();
+  const adminPort = await freePort();
+  const upstream = runNode("synthetic_upstream.mjs", [], {
+    env: {
+      ...process.env,
+      PORT: String(dataPort),
+      ADMIN_PORT: String(adminPort),
+      WORKERS: "2",
+      RESPONSE_DELAY_MS: "0",
+    },
+  });
+  t.after(() => stop(upstream));
+  await waitFor(`http://127.0.0.1:${adminPort}/stats`);
+
+  const driver = runNode("load_driver.mjs", [
+    `--url=http://127.0.0.1:${dataPort}`,
+    "--workers=2",
+    "--concurrency=4",
+    "--warmup=0.05",
+    "--duration=0.1",
+    "--timeout=2000",
+    `--upstreamAdminUrl=http://127.0.0.1:${adminPort}`,
+    "--label=contract-test",
+  ]);
+  const output = JSON.parse((await collect(driver)).trim());
+
+  assert.equal(output.label, "contract-test");
+  assert.equal(output.workload.workerCount, 2);
+  assert.equal(output.counters.errors, 0);
+  assert.ok(output.counters.success > 0);
+  assert.equal(output.counters.started, output.counters.success);
+  assert.equal(output.upstream.stats.workers, 2);
+  assert.equal(output.upstream.stats.totals.benchmarkRequests, output.counters.success);
+  assert.equal(output.upstream.stats.totals.benchmarkResponses, output.counters.success);
+  assert.equal(output.upstream.reset.totals.connectionsAccepted, 0);
+  assert.equal(output.latencyUs.bins, undefined);
+});
+
+test("driver rejects more workers than concurrent requests", async () => {
+  const driver = runNode("load_driver.mjs", [
+    "--url=http://127.0.0.1:1",
+    "--workers=3",
+    "--concurrency=2",
+    "--duration=0.1",
+  ]);
+  let stderr = "";
+  driver.stderr.on("data", (chunk) => { stderr += chunk; });
+  const [code] = await once(driver, "exit");
+
+  assert.notEqual(code, 0);
+  assert.match(stderr, /workers must be less than or equal to concurrency/);
+});

--- a/bench/platform_floor/test/relative_histogram.test.mjs
+++ b/bench/platform_floor/test/relative_histogram.test.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { RelativeHistogram } from "../relative_histogram.mjs";
+
+test("records, serializes, and merges compatible histograms", () => {
+  const left = new RelativeHistogram({
+    lowestTrackable: 1,
+    highestTrackable: 10_000,
+    relativePrecision: 0.01,
+  });
+  const right = new RelativeHistogram({
+    lowestTrackable: 1,
+    highestTrackable: 10_000,
+    relativePrecision: 0.01,
+  });
+
+  for (const value of [1, 10, 100]) left.record(value);
+  for (const value of [1_000, 10_000]) right.record(value);
+  left.merge(right.serialize());
+
+  const result = left.serialize();
+  assert.equal(result.total, 5);
+  assert.equal(result.sum, 11_111);
+  assert.equal(result.minimum, 1);
+  assert.equal(result.maximum, 10_000);
+  assert.equal(result.underflow, 0);
+  assert.equal(result.overflow, 0);
+  assert.ok(result.percentiles.p50 >= 100);
+  assert.ok(result.percentiles.p50 <= 101);
+  assert.ok(result.percentiles.p95 >= 9_900);
+  assert.ok(result.percentiles.p95 <= 10_000);
+});
+
+test("counts values outside the configured range", () => {
+  const histogram = new RelativeHistogram({
+    lowestTrackable: 10,
+    highestTrackable: 100,
+    relativePrecision: 0.01,
+  });
+
+  histogram.record(0);
+  histogram.record(101);
+
+  const result = histogram.serialize();
+  assert.equal(result.total, 2);
+  assert.equal(result.underflow, 1);
+  assert.equal(result.overflow, 1);
+  assert.equal(result.minimum, 0);
+  assert.equal(result.maximum, 101);
+});
+
+test("rejects incompatible histogram merges", () => {
+  const histogram = new RelativeHistogram({ relativePrecision: 0.01 });
+  const incompatible = new RelativeHistogram({ relativePrecision: 0.02 });
+
+  assert.throws(() => histogram.merge(incompatible.serialize()), /incompatible histograms/);
+});
+
+test("rejects invalid or overflowing merged buckets", () => {
+  const histogram = new RelativeHistogram({
+    lowestTrackable: 1,
+    highestTrackable: 100,
+    relativePrecision: 0.01,
+  });
+  const serialized = histogram.serialize();
+
+  assert.throws(
+    () => histogram.merge({ ...serialized, bins: [[serialized.bucketCount, 1]] }),
+    /invalid histogram bucket index/,
+  );
+  assert.throws(
+    () => histogram.merge({ ...serialized, bins: [[0, 0x1_0000_0000]] }),
+    /histogram bucket overflow/,
+  );
+});


### PR DESCRIPTION
## Summary

- add a bare Cowboy/Plug and Phoenix endpoint floor for isolating HTTP platform cost from Lasso routing cost
- add a multi-worker load driver with strict JSON-RPC correlation, cgroup v2 CPU/memory/throttling measurements, and load-generator saturation evidence
- add a clustered synthetic upstream with exact benchmark/system request amplification accounting
- document the measurement contract and cover histogram merging plus the real multi-process driver/upstream protocol

This is benchmark-only and does not change the Lasso runtime. It intentionally contains no eRPC implementation or comparison artifact.

## Verification

- `mix test --include integration` — 1,526 tests, 0 failures
- `node --test bench/platform_floor/test/*.test.mjs` — 6 tests, 0 failures
- `mix compile --warnings-as-errors`
- `mix credo --strict`
- `mix format --check-formatted`
- `git diff --check`
- floor Docker release build
- real bare and Phoenix `/proxy` smoke tests against the clustered upstream
