### PR TITLE
Sync WebSocket continuity hardening from Cloud

### DIFF
--- a/docs/RPC_STANDARDS.md
+++ b/docs/RPC_STANDARDS.md
@@ -200,10 +200,16 @@ Lasso normalizes all responses to JSON-RPC 2.0 format:
 
 When a provider fails mid-stream, Lasso automatically:
 
-1. **Detects gap:** Computes missed blocks between last received and current head
-2. **HTTP backfill:** Fetches missing blocks/logs via `eth_getBlockByNumber` or `eth_getLogs`
-3. **Injects events:** Delivers backfilled events to clients
-4. **Resumes stream:** Subscribes to new provider and continues
+1. **Establishes replacement:** Subscribes to the replacement and buffers its events
+2. **Detects gap:** Reads the current head after replacement confirmation
+3. **HTTP backfill:** Replays the checkpoint block through the bounded current head
+4. **Merges events:** Orders and suppresses overlap between replay and the live buffer
+5. **Resumes stream:** Continues from the replacement provider
+
+Subscription IDs are returned only after usable upstream establishment.
+Recovery that exceeds the replay, buffer, attempt, or time bounds closes the
+affected downstream socket with code 1011 so the client receives a terminal
+signal and can reconnect.
 
 **Supported Subscription Types:**
 

--- a/lib/lasso/core/streaming/client_subscription_registry.ex
+++ b/lib/lasso/core/streaming/client_subscription_registry.ex
@@ -99,6 +99,12 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
     GenServer.cast(via(profile, chain_id), {:dispatch, key, payload})
   end
 
+  @spec terminate(String.t(), pos_integer(), key, term()) :: :ok
+  def terminate(profile, chain_id, key, reason)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
+    GenServer.cast(via(profile, chain_id), {:terminate, key, reason})
+  end
+
   # GenServer callbacks
 
   @impl true
@@ -189,6 +195,36 @@ defmodule Lasso.Core.Streaming.ClientSubscriptionRegistry do
     end)
 
     {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:terminate, key, reason}, state) do
+    subscription_ids = Map.get(state.by_key, key, [])
+
+    Enum.each(subscription_ids, fn subscription_id ->
+      case Map.get(state.by_id, subscription_id) do
+        %{client_pid: pid} ->
+          send(pid, {:subscription_terminated, subscription_id, reason})
+
+        nil ->
+          :ok
+      end
+    end)
+
+    terminated_state =
+      Enum.reduce(subscription_ids, state, fn subscription_id, acc ->
+        {_key, next_state} = remove_client_from_state(acc, subscription_id)
+        next_state
+      end)
+
+    if subscription_ids != [] do
+      GenServer.cast(
+        UpstreamSubscriptionPool.via(state.profile, state.chain_id),
+        {:clients_removed, %{key => length(subscription_ids)}}
+      )
+    end
+
+    {:noreply, terminated_state}
   end
 
   @impl true

--- a/lib/lasso/core/streaming/instance_subscription_manager.ex
+++ b/lib/lasso/core/streaming/instance_subscription_manager.ex
@@ -68,7 +68,18 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
   @spec ensure_subscription(String.t(), sub_key()) ::
           {:ok, :new | :existing} | {:error, term()}
   def ensure_subscription(instance_id, sub_key) when is_binary(instance_id) do
-    GenServer.call(via(instance_id), {:ensure_subscription, sub_key}, 15_000)
+    ensure_subscription(instance_id, sub_key, 15_000)
+  end
+
+  @spec ensure_subscription(String.t(), sub_key(), pos_integer()) ::
+          {:ok, :new | :existing} | {:error, term()}
+  def ensure_subscription(instance_id, sub_key, timeout_ms)
+      when is_binary(instance_id) and is_integer(timeout_ms) and timeout_ms > 0 do
+    GenServer.call(
+      via(instance_id),
+      {:ensure_subscription, sub_key, timeout_ms},
+      timeout_ms + 100
+    )
   catch
     :exit, {:noproc, _} -> {:error, :noproc}
     :exit, {:timeout, _} -> {:error, :timeout}
@@ -116,16 +127,11 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
 
   @impl true
   def handle_call({:ensure_subscription, sub_key}, _from, state) do
-    case state.connection_state do
-      nil ->
-        {:reply, {:error, :connection_unknown}, state}
+    handle_subscription_call(state, sub_key, 15_000)
+  end
 
-      %{status: :disconnected} ->
-        {:reply, {:error, :not_connected}, state}
-
-      %{connection_id: current_conn_id} ->
-        handle_subscription_request(state, sub_key, current_conn_id)
-    end
+  def handle_call({:ensure_subscription, sub_key, timeout_ms}, _from, state) do
+    handle_subscription_call(state, sub_key, timeout_ms)
   end
 
   @impl true
@@ -151,6 +157,19 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
     }
 
     {:reply, status, state}
+  end
+
+  defp handle_subscription_call(state, sub_key, timeout_ms) do
+    case state.connection_state do
+      nil ->
+        {:reply, {:error, :connection_unknown}, state}
+
+      %{status: :disconnected} ->
+        {:reply, {:error, :not_connected}, state}
+
+      %{connection_id: current_conn_id} ->
+        handle_subscription_request(state, sub_key, current_conn_id, timeout_ms)
+    end
   end
 
   @impl true
@@ -370,10 +389,10 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
     end
   end
 
-  defp handle_subscription_request(state, sub_key, current_conn_id) do
+  defp handle_subscription_request(state, sub_key, current_conn_id, timeout_ms) do
     case Map.get(state.active_subscriptions, sub_key) do
       nil ->
-        create_new_subscription(state, sub_key, current_conn_id)
+        create_new_subscription(state, sub_key, current_conn_id, timeout_ms)
 
       %{marked_for_teardown_at: nil, connection_id: ^current_conn_id} ->
         {:reply, {:ok, :existing}, state}
@@ -386,7 +405,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
 
         emit_telemetry(:stale_subscription_detected, state, sub_key)
         state = remove_subscription(state, sub_key, sub_info.upstream_id)
-        create_new_subscription(state, sub_key, current_conn_id)
+        create_new_subscription(state, sub_key, current_conn_id, timeout_ms)
 
       %{connection_id: ^current_conn_id} = sub_info ->
         Logger.debug("Cancelling teardown for subscription",
@@ -400,7 +419,7 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
 
       %{upstream_id: upstream_id} ->
         state = remove_subscription(state, sub_key, upstream_id)
-        create_new_subscription(state, sub_key, current_conn_id)
+        create_new_subscription(state, sub_key, current_conn_id, timeout_ms)
     end
   end
 
@@ -415,8 +434,8 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
     %{state | active_subscriptions: new_subs, upstream_index: new_index}
   end
 
-  defp create_new_subscription(state, sub_key, connection_id) do
-    case create_upstream_subscription(state.instance_id, sub_key) do
+  defp create_new_subscription(state, sub_key, connection_id, timeout_ms) do
+    case create_upstream_subscription(state.instance_id, sub_key, timeout_ms) do
       {:ok, upstream_id} ->
         now = System.monotonic_time(:millisecond)
 
@@ -476,10 +495,10 @@ defmodule Lasso.Core.Streaming.InstanceSubscriptionManager do
     end
   end
 
-  defp create_upstream_subscription(instance_id, sub_key) do
+  defp create_upstream_subscription(instance_id, sub_key, timeout_ms) do
     params = subscription_params(sub_key)
 
-    case Connection.request(instance_id, "eth_subscribe", params, 10_000) do
+    case Connection.request(instance_id, "eth_subscribe", params, timeout_ms) do
       {:ok, %Response.Success{} = response} ->
         Response.Success.decode_result(response)
 

--- a/lib/lasso/core/streaming/stream_coordinator.ex
+++ b/lib/lasso/core/streaming/stream_coordinator.ex
@@ -3,8 +3,9 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   Per-key coordinator that owns continuity (markers, dedupe) and orchestrates failover.
 
   Receives upstream events from UpstreamSubscriptionPool and provider health signals.
-  Orchestrates failover with synchronous transitions: :active -> :backfilling -> :switching -> :active.
-  Ensures gap-free, duplicate-free event delivery with automatic provider failover.
+  Establishes a replacement before bounded replay and merges buffered live events
+  through the stream dedupe state. Exhausted recovery terminates downstream
+  subscriptions instead of silently continuing an incomplete stream.
   """
 
   use GenServer
@@ -52,6 +53,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   @failover_cooldown_ms 5_000
   @max_event_buffer 100
   @degraded_mode_retry_delay_ms 60_000
+  @default_recovery_timeout_ms 30_000
 
   @spec start_link({String.t(), pos_integer(), term(), keyword()}) :: GenServer.on_start()
   def start_link({profile, chain_id, key, opts})
@@ -87,10 +89,17 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     )
   end
 
-  @spec provider_unhealthy(String.t(), pos_integer(), term(), String.t(), String.t()) :: :ok
+  @spec provider_unhealthy(String.t(), pos_integer(), term(), String.t(), String.t() | nil) :: :ok
   def provider_unhealthy(profile, chain_id, key, failed_id, proposed_new_id)
       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 do
     GenServer.cast(via(profile, chain_id, key), {:provider_unhealthy, failed_id, proposed_new_id})
+  end
+
+  @spec upstream_established(String.t(), pos_integer(), term(), String.t()) :: :ok
+  def upstream_established(profile, chain_id, key, provider_id)
+      when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
+             is_binary(provider_id) do
+    GenServer.cast(via(profile, chain_id, key), {:upstream_established, provider_id})
   end
 
   # GenServer callbacks
@@ -110,18 +119,22 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       # Backfill config
       max_backfill_blocks: Keyword.get(opts, :max_backfill_blocks, 32),
       backfill_timeout: Keyword.get(opts, :backfill_timeout, 30_000),
-      continuity_policy: Keyword.get(opts, :continuity_policy, :best_effort),
+      continuity_policy: Keyword.get(opts, :continuity_policy, :strict_abort),
       backfill_requester:
         Keyword.get(opts, :backfill_requester, &Lasso.RPC.RequestPipeline.execute_owned/5),
       backfill_provider_selector:
         Keyword.get(opts, :backfill_provider_selector, &pick_best_http_provider/3),
+      replacement_requester:
+        Keyword.get(opts, :replacement_requester, &request_pool_replacement/5),
       # Failover state machine
       failover_status: :active,
       failover_context: nil,
       failover_history: [],
       max_failover_attempts: Keyword.get(opts, :max_failover_attempts),
       failover_cooldown_ms: Keyword.get(opts, :failover_cooldown_ms, @failover_cooldown_ms),
-      max_event_buffer: Keyword.get(opts, :max_event_buffer, @max_event_buffer)
+      max_event_buffer: Keyword.get(opts, :max_event_buffer, @max_event_buffer),
+      recovery_timeout_ms: Keyword.get(opts, :recovery_timeout_ms, @default_recovery_timeout_ms),
+      recovery_deadline_us: nil
     }
 
     {:ok, state}
@@ -134,19 +147,28 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   end
 
   @impl true
-  def handle_cast({:upstream_event, _provider_id, _upstream_id, payload, _received_at}, state) do
+  def handle_cast({:upstream_event, provider_id, _upstream_id, payload, _received_at}, state) do
     case state.failover_status do
       :active ->
-        # Normal processing path
-        process_event_normal(state, payload)
+        if is_nil(state.primary_provider_id) or provider_id == state.primary_provider_id do
+          process_event_normal(state, payload)
+        else
+          drop_stale_provider_event(state, provider_id)
+        end
 
       :backfilling ->
-        # Buffer events during backfill
-        buffer_event(state, payload)
+        if provider_id == state.failover_context.new_provider_id do
+          buffer_event(state, payload)
+        else
+          drop_stale_provider_event(state, provider_id)
+        end
 
       :switching ->
-        # Buffer events during subscription switch
-        buffer_event(state, payload)
+        if provider_id == state.failover_context.new_provider_id do
+          buffer_event(state, payload)
+        else
+          drop_stale_provider_event(state, provider_id)
+        end
 
       :degraded ->
         # Circuit breaker triggered, drop events
@@ -184,11 +206,18 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
+  @impl true
+  def handle_cast({:upstream_established, provider_id}, %{failover_status: :active} = state) do
+    {:noreply, %{state | primary_provider_id: provider_id}}
+  end
+
+  def handle_cast({:upstream_established, _provider_id}, state), do: {:noreply, state}
+
   # Subscription confirmation from Pool
   @impl true
   def handle_info({:subscription_confirmed, provider_id, upstream_id}, state) do
     if state.failover_status == :switching do
-      complete_failover(state, provider_id, upstream_id)
+      start_backfill_after_replacement(state, provider_id, upstream_id)
     else
       Logger.warning("Unexpected subscription_confirmed in status #{state.failover_status}",
         chain_id: state.chain_id,
@@ -236,7 +265,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     Process.demonitor(context.backfill_owner_ref, [:flush])
 
     case result do
-      :ok -> transition_to_switching(state)
+      :ok -> complete_failover(state, context.new_provider_id, nil)
       {:error, reason} -> handle_backfill_failure(state, reason)
     end
   end
@@ -284,6 +313,16 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
           Process.send_after(self(), :retry_from_degraded, @degraded_mode_retry_delay_ms)
           {:noreply, state}
       end
+    else
+      {:noreply, state}
+    end
+  end
+
+  @impl true
+  def handle_info({:failover_deadline, deadline_us}, state) do
+    if state.recovery_deadline_us == deadline_us and
+         state.failover_status in [:switching, :backfilling] do
+      enter_degraded_mode(state, failover_budget(state))
     else
       {:noreply, state}
     end
@@ -349,9 +388,33 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
+  defp drop_stale_provider_event(state, provider_id) do
+    :telemetry.execute(
+      [:lasso, :stream, :dropped_event],
+      %{count: 1},
+      %{
+        chain_id: state.chain_id,
+        reason: :stale_provider,
+        provider_id: provider_id,
+        primary_provider_id: state.primary_provider_id
+      }
+    )
+
+    {:noreply, state}
+  end
+
   # Standard failover initiation with empty buffer
   defp initiate_failover(state, old_provider_id, new_provider_id) do
-    initiate_failover_with_buffer(state, old_provider_id, new_provider_id, [])
+    deadline_us =
+      System.monotonic_time(:microsecond) + state.recovery_timeout_ms * 1_000
+
+    state = %{state | recovery_deadline_us: deadline_us}
+
+    if is_binary(new_provider_id) do
+      initiate_failover_with_buffer(state, old_provider_id, new_provider_id, [])
+    else
+      enter_degraded_mode(state, failover_budget(state))
+    end
   end
 
   # Failover initiation with preserved buffer (used during cascade)
@@ -380,7 +443,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
       case state.backfill_provider_selector.(state.profile, state.chain_id, excluded_providers) do
         {:ok, http_provider} ->
-          start_backfill_owner(
+          start_replacement(
             state,
             old_provider_id,
             new_provider_id,
@@ -401,7 +464,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
-  defp start_backfill_owner(
+  defp start_replacement(
          state,
          old_provider_id,
          new_provider_id,
@@ -411,6 +474,13 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
          budget
        ) do
     started_at_us = System.monotonic_time(:microsecond)
+    remaining_ms = recovery_remaining_ms(state.recovery_deadline_us)
+
+    Process.send_after(
+      self(),
+      {:failover_deadline, state.recovery_deadline_us},
+      remaining_ms
+    )
 
     plan =
       GapFiller.Plan.new(
@@ -418,7 +488,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
         state.chain_id,
         http_provider,
         self(),
-        state.backfill_timeout,
+        min(state.backfill_timeout, remaining_ms),
         started_at_us: started_at_us,
         requester: state.backfill_requester
       )
@@ -433,26 +503,19 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       plan: plan
     }
 
-    owner_id = make_ref()
-    coordinator_pid = self()
-    key = state.key
-    continuity_marker = continuity_marker(state.state, key)
-
-    {owner_pid, owner_ref} =
-      spawn_monitor(fn ->
-        result = safely_execute_backfill(backfill_ctx, key, continuity_marker, owner_id)
-        send(coordinator_pid, {:backfill_result, owner_id, self(), result})
-      end)
+    continuity_marker = continuity_marker(state.state, state.key)
 
     failover_context = %{
       old_provider_id: old_provider_id,
       new_provider_id: new_provider_id,
       http_provider_id: http_provider,
-      backfill_owner_id: owner_id,
-      backfill_owner_pid: owner_pid,
-      backfill_owner_ref: owner_ref,
-      backfill_task_ref: owner_ref,
+      backfill_owner_id: nil,
+      backfill_owner_pid: nil,
+      backfill_owner_ref: nil,
+      backfill_task_ref: nil,
       backfill_plan: plan,
+      backfill_context: backfill_ctx,
+      continuity_marker: continuity_marker,
       started_at: div(started_at_us, 1_000),
       event_buffer: initial_buffer,
       event_buffer_count: length(initial_buffer),
@@ -486,13 +549,54 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       to_provider_id: new_provider_id
     })
 
+    state.replacement_requester.(
+      state.profile,
+      state.chain_id,
+      state.key,
+      new_provider_id,
+      self()
+    )
+
+    telemetry_resubscribe_initiated(state.chain_id, state.key, new_provider_id)
+
     {:noreply,
      %{
        state
-       | failover_status: :backfilling,
+       | failover_status: :switching,
          failover_context: failover_context,
          failover_history: new_history
      }}
+  end
+
+  defp start_backfill_after_replacement(state, provider_id, _upstream_id) do
+    context = state.failover_context
+    owner_id = make_ref()
+    coordinator_pid = self()
+    key = state.key
+
+    {owner_pid, owner_ref} =
+      spawn_monitor(fn ->
+        result =
+          safely_execute_backfill(
+            context.backfill_context,
+            key,
+            context.continuity_marker,
+            owner_id
+          )
+
+        send(coordinator_pid, {:backfill_result, owner_id, self(), result})
+      end)
+
+    updated_context = %{
+      context
+      | new_provider_id: provider_id,
+        backfill_owner_id: owner_id,
+        backfill_owner_pid: owner_pid,
+        backfill_owner_ref: owner_ref,
+        backfill_task_ref: owner_ref
+    }
+
+    {:noreply, %{state | failover_status: :backfilling, failover_context: updated_context}}
   end
 
   defp safely_execute_backfill(ctx, key, continuity_marker, owner_id) do
@@ -521,12 +625,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
   defp backfill_blocks(ctx, key, last, owner_id) do
     with {:ok, head} <- GapFiller.fetch_head(ctx.plan) do
-      case ContinuityPolicy.needed_block_range(
-             last,
-             head,
-             ctx.max_backfill,
-             ctx.continuity_policy
-           ) do
+      case continuity_range(last, head, ctx.max_backfill, ctx.continuity_policy) do
         {:none} ->
           :ok
 
@@ -566,12 +665,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
 
   defp backfill_logs(ctx, key, filter, last, owner_id) do
     with {:ok, head} <- GapFiller.fetch_head(ctx.plan) do
-      case ContinuityPolicy.needed_block_range(
-             last,
-             head,
-             ctx.max_backfill,
-             ctx.continuity_policy
-           ) do
+      case continuity_range(last, head, ctx.max_backfill, ctx.continuity_policy) do
         {:none} ->
           :ok
 
@@ -619,29 +713,6 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end)
   end
 
-  defp transition_to_switching(state) do
-    Logger.info("Backfill complete, transitioning to :switching",
-      chain_id: state.chain_id,
-      key: inspect(state.key)
-    )
-
-    # Request resubscription from Pool
-    pool_ref = Lasso.Core.Streaming.UpstreamSubscriptionPool.via(state.profile, state.chain_id)
-
-    GenServer.cast(
-      pool_ref,
-      {:resubscribe, state.key, state.failover_context.new_provider_id, self()}
-    )
-
-    telemetry_resubscribe_initiated(
-      state.chain_id,
-      state.key,
-      state.failover_context.new_provider_id
-    )
-
-    {:noreply, %{state | failover_status: :switching}}
-  end
-
   defp complete_failover(state, provider_id, _upstream_id) do
     Logger.info("Failover complete: now on provider #{provider_id}",
       chain_id: state.chain_id,
@@ -657,7 +728,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       | primary_provider_id: provider_id,
         failover_status: :active,
         failover_context: nil,
-        failover_history: []
+        failover_history: [],
+        recovery_deadline_us: nil
     }
 
     duration_ms = System.monotonic_time(:millisecond) - state.failover_context.started_at
@@ -678,15 +750,20 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       ordered_buffer =
         case subscription_key(state.key) do
           {:newHeads} ->
-            Enum.sort_by(state.failover_context.event_buffer, fn payload ->
+            state.failover_context.event_buffer
+            |> Enum.reverse()
+            |> Enum.sort_by(fn payload ->
               decode_hex(Map.get(payload, "number", "0x0"))
             end)
 
           {:logs, _filter} ->
-            Enum.sort_by(state.failover_context.event_buffer, fn log ->
+            state.failover_context.event_buffer
+            |> Enum.reverse()
+            |> Enum.sort_by(fn log ->
               {decode_hex(Map.get(log, "blockNumber", "0x0")),
                decode_hex(Map.get(log, "transactionIndex", "0x0")),
-               decode_hex(Map.get(log, "logIndex", "0x0"))}
+               decode_hex(Map.get(log, "logIndex", "0x0")),
+               Map.get(log, "removed", false) == true}
             end)
         end
 
@@ -792,6 +869,13 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
   defp enter_degraded_mode(state, budget) do
     cancel_backfill_owner(state)
 
+    ClientSubscriptionRegistry.terminate(
+      state.profile,
+      state.chain_id,
+      state.key,
+      :continuity_exhausted
+    )
+
     tried_providers =
       state.failover_history
       |> Enum.map(& &1.provider_id)
@@ -824,7 +908,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
        state
        | failover_status: :degraded,
          failover_context: nil,
-         failover_history: []
+         failover_history: [],
+         recovery_deadline_us: nil
      }}
   end
 
@@ -864,6 +949,14 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
       {:logs, _filter} ->
         StreamState.last_log_block(stream_state) || StreamState.last_block_num(stream_state)
     end
+  end
+
+  defp continuity_range(last_seen, head, max_backfill, policy) when is_integer(last_seen) do
+    ContinuityPolicy.needed_block_range(last_seen - 1, head, max_backfill + 1, policy)
+  end
+
+  defp continuity_range(last_seen, head, max_backfill, policy) do
+    ContinuityPolicy.needed_block_range(last_seen, head, max_backfill, policy)
   end
 
   defp failover_budget(%{max_failover_attempts: override})
@@ -915,10 +1008,19 @@ defmodule Lasso.Core.Streaming.StreamCoordinator do
     end
   end
 
+  defp request_pool_replacement(profile, chain_id, key, provider_id, coordinator_pid) do
+    pool_ref = Lasso.Core.Streaming.UpstreamSubscriptionPool.via(profile, chain_id)
+    GenServer.cast(pool_ref, {:resubscribe, key, provider_id, coordinator_pid})
+  end
+
   defp decode_hex(nil), do: 0
   defp decode_hex("0x" <> rest), do: String.to_integer(rest, 16)
   defp decode_hex(num) when is_integer(num), do: num
   defp decode_hex(_), do: 0
+
+  defp recovery_remaining_ms(deadline_us) do
+    max(div(deadline_us - System.monotonic_time(:microsecond) + 999, 1_000), 0)
+  end
 
   defp cancel_backfill_owner(%{failover_context: context}) when is_map(context) do
     owner_ref = Map.get(context, :backfill_owner_ref)

--- a/lib/lasso/core/streaming/stream_state.ex
+++ b/lib/lasso/core/streaming/stream_state.ex
@@ -41,14 +41,23 @@ defmodule Lasso.Core.Streaming.StreamState do
       num = decode_hex(Map.get(payload, "number"))
       now = System.monotonic_time(:millisecond)
       dedupe1 = state.dedupe |> DedupeCache.put({:block, hash}, now) |> DedupeCache.cleanup(now)
-      markers1 = %{state.markers | last_block_num: num}
+
+      markers1 = %{
+        state.markers
+        | last_block_num: advance_marker(state.markers.last_block_num, num)
+      }
+
       {%{state | dedupe: dedupe1, markers: markers1}, :emit}
     end
   end
 
   @spec ingest_log(t(), map()) :: {t(), :emit | :skip}
   def ingest_log(%__MODULE__{} = state, payload) do
-    key = {Map.get(payload, "blockHash"), Map.get(payload, "logIndex")}
+    key = {
+      Map.get(payload, "blockHash"),
+      Map.get(payload, "logIndex"),
+      Map.get(payload, "removed", false) == true
+    }
 
     if DedupeCache.member?(state.dedupe, {:log, key}) do
       {state, :skip}
@@ -56,7 +65,12 @@ defmodule Lasso.Core.Streaming.StreamState do
       num = decode_hex(Map.get(payload, "blockNumber"))
       now = System.monotonic_time(:millisecond)
       dedupe1 = state.dedupe |> DedupeCache.put({:log, key}, now) |> DedupeCache.cleanup(now)
-      markers1 = %{state.markers | last_log_block: num}
+
+      markers1 = %{
+        state.markers
+        | last_log_block: advance_marker(state.markers.last_log_block, num)
+      }
+
       {%{state | dedupe: dedupe1, markers: markers1}, :emit}
     end
   end
@@ -71,4 +85,8 @@ defmodule Lasso.Core.Streaming.StreamState do
   defp decode_hex(nil), do: nil
   defp decode_hex("0x" <> rest), do: String.to_integer(rest, 16)
   defp decode_hex(num) when is_integer(num), do: num
+
+  defp advance_marker(nil, next), do: next
+  defp advance_marker(current, nil), do: current
+  defp advance_marker(current, next), do: max(current, next)
 end

--- a/lib/lasso/core/streaming/upstream_subscription_pool.ex
+++ b/lib/lasso/core/streaming/upstream_subscription_pool.ex
@@ -36,6 +36,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
   @readiness_retry_base_ms 100
   @readiness_retry_cap_ms 5_000
+  @establishment_timeout_ms 4_000
 
   @type profile :: String.t()
   @type chain_id :: pos_integer()
@@ -114,6 +115,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
       profile: profile,
       chain_id: chain_id,
       keys: %{},
+      coordinator_monitors: %{},
       dedupe_max_items: Map.get(dedupe_cfg, :max_items, 256),
       dedupe_max_age_ms: Map.get(dedupe_cfg, :max_age_ms, 30_000),
       max_backfill_blocks: 32,
@@ -127,7 +129,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   def handle_call(
         {:subscribe, client_pid, pool_key, subscription_key, provider_constraint,
          request_owner_pid, deadline_us},
-        _from,
+        from,
         state
       ) do
     with :ok <- authorize_operation(request_owner_pid, client_pid, deadline_us),
@@ -143,7 +145,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
              deadline_us
            ) do
         :ok ->
-          new_state =
+          published_state =
             publish_client_subscription(
               state,
               pool_key,
@@ -151,7 +153,22 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
               provider_constraint
             )
 
-          {:reply, {:ok, subscription_id}, new_state}
+          case published_state.keys[pool_key] do
+            %{status: :active} ->
+              {:reply, {:ok, subscription_id}, published_state}
+
+            %{status: :establishing} ->
+              new_state =
+                add_pending_subscriber(
+                  published_state,
+                  pool_key,
+                  subscription_id,
+                  from,
+                  deadline_us
+                )
+
+              {:noreply, new_state}
+          end
 
         {:error, error} ->
           {:reply, {:error, error}, state}
@@ -277,7 +294,16 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
           transient_excluded_providers: MapSet.new(),
           markers: %{},
           dedupe: nil,
-          noproc_retries: 0
+          noproc_retries: 0,
+          pending_subscribers: [],
+          establishment_attempt_token: nil,
+          establishment_attempt_pid: nil,
+          establishment_attempt_ref: nil,
+          establishment_attempt_exclusions: [],
+          resubscribe_token: nil,
+          resubscribe_pid: nil,
+          resubscribe_ref: nil,
+          resubscribe_coordinator_pid: nil
         }
 
         %{state | keys: Map.put(state.keys, pool_key, entry)}
@@ -298,7 +324,15 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
             readiness_retries: 0,
             retry_token: nil,
             transient_excluded_providers: MapSet.new(),
-            noproc_retries: 0
+            noproc_retries: 0,
+            establishment_attempt_token: nil,
+            establishment_attempt_pid: nil,
+            establishment_attempt_ref: nil,
+            establishment_attempt_exclusions: [],
+            resubscribe_token: nil,
+            resubscribe_pid: nil,
+            resubscribe_ref: nil,
+            resubscribe_coordinator_pid: nil
         }
 
         %{state | keys: Map.put(state.keys, pool_key, updated)}
@@ -371,89 +405,54 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   def handle_cast({:resubscribe, pool_key, new_provider_id, coordinator_pid}, state) do
     Logger.info("Resubscribing key #{inspect(pool_key)} to provider #{new_provider_id}")
 
-    entry = Map.get(state.keys, pool_key)
-
-    if entry do
-      old_provider_id = entry.primary_provider_id
-      old_instance_id = entry.instance_id
-
-      new_instance_id =
-        Catalog.lookup_instance_id(state.profile, state.chain_id, new_provider_id)
-
-      if is_nil(new_instance_id) do
-        Logger.error("Cannot resolve instance_id for provider #{new_provider_id}")
-        send(coordinator_pid, {:subscription_failed, :no_instance})
+    case Map.get(state.keys, pool_key) do
+      nil ->
+        Logger.debug("Resubscription skipped: key #{inspect(pool_key)} no longer active")
+        send(coordinator_pid, {:subscription_failed, :key_inactive})
         {:noreply, state}
-      else
-        subscription_key = entry.subscription_key
-        InstanceSubscriptionRegistry.register_consumer(new_instance_id, subscription_key)
 
-        case InstanceSubscriptionManager.ensure_subscription(new_instance_id, subscription_key) do
-          {:ok, _status} ->
-            release_overwritten_transition(
-              state,
-              pool_key,
-              entry,
-              subscription_key,
-              new_instance_id
-            )
+      %{resubscribe_pid: pid} when is_pid(pid) ->
+        send(coordinator_pid, {:subscription_failed, :replacement_in_progress})
+        {:noreply, state}
 
-            transition_fields =
-              if old_instance_id && old_instance_id != new_instance_id do
-                %{
-                  transitioning_from: old_provider_id,
-                  transitioning_from_instance_id: old_instance_id
-                }
-              else
-                %{}
-              end
+      entry ->
+        new_instance_id =
+          Catalog.lookup_instance_id(state.profile, state.chain_id, new_provider_id)
 
-            updated_entry =
-              entry
-              |> Map.drop([:transitioning_from, :transitioning_from_instance_id])
-              |> Map.merge(%{
-                primary_provider_id: new_provider_id,
-                instance_id: new_instance_id,
-                status: :active
-              })
-              |> Map.merge(transition_fields)
+        if is_nil(new_instance_id) do
+          Logger.error("Cannot resolve instance_id for provider #{new_provider_id}")
+          send(coordinator_pid, {:subscription_failed, :no_instance})
+          {:noreply, state}
+        else
+          token = make_ref()
+          pool_pid = self()
+          subscription_key = entry.subscription_key
 
-            new_state = %{state | keys: Map.put(state.keys, pool_key, updated_entry)}
+          {owner_pid, owner_ref} =
+            spawn_monitor(fn ->
+              result =
+                InstanceSubscriptionManager.ensure_subscription(
+                  new_instance_id,
+                  subscription_key
+                )
 
-            send(coordinator_pid, {:subscription_confirmed, new_provider_id, nil})
-
-            if old_instance_id && old_instance_id != new_instance_id do
-              Process.send_after(
-                self(),
-                {:deferred_release, pool_key, old_provider_id, old_instance_id},
-                5_000
+              send(
+                pool_pid,
+                {:resubscribe_result, pool_key, token, self(), coordinator_pid, new_provider_id,
+                 new_instance_id, result}
               )
-            end
+            end)
 
-            {:noreply, new_state}
+          updated_entry = %{
+            entry
+            | resubscribe_token: token,
+              resubscribe_pid: owner_pid,
+              resubscribe_ref: owner_ref,
+              resubscribe_coordinator_pid: coordinator_pid
+          }
 
-          {:error, reason} ->
-            unless instance_in_use_elsewhere?(
-                     state,
-                     pool_key,
-                     new_instance_id,
-                     subscription_key
-                   ) do
-              InstanceSubscriptionRegistry.unregister_consumer(new_instance_id, subscription_key)
-            end
-
-            Logger.error(
-              "Resubscription failed for #{inspect(pool_key)} to #{new_provider_id}: #{inspect(reason)}"
-            )
-
-            send(coordinator_pid, {:subscription_failed, reason})
-            {:noreply, state}
+          {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated_entry)}}
         end
-      end
-    else
-      Logger.debug("Resubscription skipped: key #{inspect(pool_key)} no longer active")
-      send(coordinator_pid, {:subscription_failed, :key_inactive})
-      {:noreply, state}
     end
   end
 
@@ -478,25 +477,16 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
              excluded_providers,
              entry.provider_constraint
            ),
-         {:ok, instance_id} <- resolve_instance_id(state, provider_id),
-         {:ok, _status} <-
-           attempt_upstream_subscribe(provider_id, instance_id, entry.subscription_key) do
-      InstanceSubscriptionRegistry.register_consumer(instance_id, entry.subscription_key)
-
-      new_state = activate_subscription(state, pool_key, entry, provider_id, instance_id)
-
-      Logger.info(
-        "Upstream subscription established for key #{inspect(pool_key)} on provider #{provider_id}"
+         {:ok, instance_id} <- resolve_instance_id(state, provider_id) do
+      start_establishment_attempt(
+        state,
+        pool_key,
+        generation,
+        excluded_providers,
+        entry,
+        provider_id,
+        instance_id
       )
-
-      broadcast_subscription_event(state, %Subscription.Established{
-        ts: System.system_time(:millisecond),
-        chain_id: state.chain_id,
-        provider_id: provider_id,
-        subscription_type: Subscription.subscription_type(entry.subscription_key)
-      })
-
-      {:noreply, new_state}
     else
       {:error, :entry_invalid} ->
         {:noreply, state}
@@ -509,27 +499,129 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
       {:error, :no_instance} ->
         retry_readiness(state, pool_key, generation, excluded_providers)
+    end
+  end
 
-      {:error, {:noproc, _instance_id}} ->
-        retry_readiness(state, pool_key, generation, excluded_providers)
+  defp start_establishment_attempt(
+         state,
+         pool_key,
+         generation,
+         excluded_providers,
+         entry,
+         provider_id,
+         instance_id
+       ) do
+    token = make_ref()
+    pool_pid = self()
+    timeout_ms = establishment_attempt_timeout(entry)
+    subscription_key = entry.subscription_key
 
-      {:error, {:subscribe_failed, provider_id, reason}}
-      when reason in [:connection_unknown, :not_connected, :timeout] ->
-        retry_transient_failure(state, pool_key, generation, excluded_providers, provider_id)
+    {owner_pid, owner_ref} =
+      spawn_monitor(fn ->
+        result =
+          attempt_upstream_subscribe(provider_id, instance_id, subscription_key, timeout_ms)
 
-      {:error, {:subscribe_failed, provider_id, %JError{retriable?: true}}} ->
-        retry_transient_failure(state, pool_key, generation, excluded_providers, provider_id)
+        send(
+          pool_pid,
+          {:establishment_result, pool_key, generation, token, self(), provider_id, instance_id,
+           excluded_providers, result}
+        )
+      end)
 
-      {:error, {:subscribe_failed, provider_id, _reason}} ->
-        entry = state.keys[pool_key]
+    updated_entry = %{
+      entry
+      | establishment_attempt_token: token,
+        establishment_attempt_pid: owner_pid,
+        establishment_attempt_ref: owner_ref,
+        establishment_attempt_exclusions: excluded_providers
+    }
 
-        if entry.provider_constraint do
-          new_state = mark_subscription_failed(state, pool_key, "Constrained provider rejected")
-          {:noreply, new_state}
-        else
-          new_excluded = [provider_id | excluded_providers]
-          do_handle_subscription_failure(state, pool_key, generation, new_excluded)
-        end
+    {:noreply, %{state | keys: Map.put(state.keys, pool_key, updated_entry)}}
+  end
+
+  defp handle_establishment_result(
+         state,
+         pool_key,
+         _generation,
+         _excluded_providers,
+         entry,
+         provider_id,
+         instance_id,
+         {:ok, _status}
+       ) do
+    InstanceSubscriptionRegistry.register_consumer(instance_id, entry.subscription_key)
+    new_state = activate_subscription(state, pool_key, entry, provider_id, instance_id)
+
+    Logger.info(
+      "Upstream subscription established for key #{inspect(pool_key)} on provider #{provider_id}"
+    )
+
+    broadcast_subscription_event(state, %Subscription.Established{
+      ts: System.system_time(:millisecond),
+      chain_id: state.chain_id,
+      provider_id: provider_id,
+      subscription_type: Subscription.subscription_type(entry.subscription_key)
+    })
+
+    {:noreply, new_state}
+  end
+
+  defp handle_establishment_result(
+         state,
+         pool_key,
+         generation,
+         excluded_providers,
+         _entry,
+         _provider_id,
+         _resolved_instance_id,
+         {:error, {:noproc, _failed_instance_id}}
+       ) do
+    retry_readiness(state, pool_key, generation, excluded_providers)
+  end
+
+  defp handle_establishment_result(
+         state,
+         pool_key,
+         generation,
+         excluded_providers,
+         _entry,
+         provider_id,
+         _instance_id,
+         {:error, {:subscribe_failed, provider_id, reason}}
+       )
+       when reason in [:connection_unknown, :not_connected, :timeout] do
+    retry_transient_failure(state, pool_key, generation, excluded_providers, provider_id)
+  end
+
+  defp handle_establishment_result(
+         state,
+         pool_key,
+         generation,
+         excluded_providers,
+         _entry,
+         provider_id,
+         _instance_id,
+         {:error, {:subscribe_failed, provider_id, %JError{retriable?: true}}}
+       ) do
+    retry_transient_failure(state, pool_key, generation, excluded_providers, provider_id)
+  end
+
+  defp handle_establishment_result(
+         state,
+         pool_key,
+         generation,
+         excluded_providers,
+         entry,
+         provider_id,
+         _instance_id,
+         {:error, {:subscribe_failed, provider_id, _reason}}
+       ) do
+    if entry.provider_constraint do
+      new_state = mark_subscription_failed(state, pool_key, "Constrained provider rejected")
+      {:noreply, new_state}
+    else
+      new_excluded = [provider_id | excluded_providers]
+      do_handle_subscription_failure(state, pool_key, generation, new_excluded)
     end
   end
 
@@ -541,6 +633,10 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
   defp validate_entry_for_establishment(entry, _generation) when entry.refcount < 1,
     do: {:error, :entry_invalid}
+
+  defp validate_entry_for_establishment(%{establishment_attempt_pid: pid}, _generation)
+       when is_pid(pid),
+       do: {:error, :entry_invalid}
 
   defp validate_entry_for_establishment(entry, _generation), do: {:ok, entry}
 
@@ -584,12 +680,12 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  defp attempt_upstream_subscribe(provider_id, instance_id, key) do
+  defp attempt_upstream_subscribe(provider_id, instance_id, key, timeout_ms) do
     Logger.debug(
       "Attempting upstream subscribe via instance #{instance_id} for key #{inspect(key)}"
     )
 
-    case InstanceSubscriptionManager.ensure_subscription(instance_id, key) do
+    case InstanceSubscriptionManager.ensure_subscription(instance_id, key, timeout_ms) do
       {:ok, status} ->
         {:ok, status}
 
@@ -611,8 +707,26 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
         readiness_retries: 0,
         retry_token: nil,
         transient_excluded_providers: MapSet.new(),
-        noproc_retries: 0
+        noproc_retries: 0,
+        establishment_attempt_token: nil,
+        establishment_attempt_pid: nil,
+        establishment_attempt_ref: nil,
+        establishment_attempt_exclusions: []
     }
+
+    state = ensure_coordinator_monitored(state, pool_key)
+
+    StreamCoordinator.upstream_established(
+      state.profile,
+      state.chain_id,
+      pool_key,
+      provider_id
+    )
+
+    send(
+      self(),
+      {:settle_subscription_established, pool_key, entry.establishment_generation}
+    )
 
     %{state | keys: Map.put(state.keys, pool_key, updated_entry)}
   end
@@ -715,7 +829,22 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
         state
 
       entry ->
-        updated_entry = %{entry | status: :failed, establishment_generation: make_ref()}
+        pending_subscribers = Map.get(entry, :pending_subscribers, [])
+
+        Enum.each(pending_subscribers, fn waiter ->
+          ClientSubscriptionRegistry.remove_client(
+            state.profile,
+            state.chain_id,
+            waiter.subscription_id
+          )
+        end)
+
+        updated_entry =
+          entry
+          |> Map.put(:status, :failed)
+          |> Map.put(:establishment_generation, make_ref())
+          |> settle_pending_subscribers({:error, :upstream_establishment_failed})
+          |> Map.update!(:refcount, &max(&1 - length(pending_subscribers), 0))
 
         broadcast_subscription_event(state, %Subscription.Failed{
           ts: System.system_time(:millisecond),
@@ -726,7 +855,16 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
         })
 
         Logger.error("Subscription failed for #{inspect(key)}: #{reason}")
-        %{state | keys: Map.put(state.keys, key, updated_entry)}
+
+        if updated_entry.refcount == 0 do
+          send(self(), {:stop_coordinator_if_unused, key})
+
+          state
+          |> release_coordinator_monitor(key)
+          |> Map.update!(:keys, &Map.delete(&1, key))
+        else
+          %{state | keys: Map.put(state.keys, key, updated_entry)}
+        end
     end
   end
 
@@ -821,6 +959,183 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
       _ ->
         {:noreply, state}
+    end
+  end
+
+  def handle_info(
+        {:establishment_result, pool_key, generation, token, owner_pid, provider_id, instance_id,
+         excluded_providers, result},
+        state
+      ) do
+    case Map.get(state.keys, pool_key) do
+      %{
+        status: :establishing,
+        establishment_generation: ^generation,
+        establishment_attempt_token: ^token,
+        establishment_attempt_pid: ^owner_pid
+      } = entry ->
+        Process.demonitor(entry.establishment_attempt_ref, [:flush])
+
+        cleared_entry = clear_establishment_attempt(entry)
+        new_state = %{state | keys: Map.put(state.keys, pool_key, cleared_entry)}
+
+        handle_establishment_result(
+          new_state,
+          pool_key,
+          generation,
+          excluded_providers,
+          cleared_entry,
+          provider_id,
+          instance_id,
+          result
+        )
+
+      _stale ->
+        if match?({:ok, _status}, result) do
+          InstanceSubscriptionManager.release_subscription(
+            instance_id,
+            subscription_key(pool_key)
+          )
+        end
+
+        {:noreply, state}
+    end
+  end
+
+  def handle_info(
+        {:resubscribe_result, pool_key, token, owner_pid, coordinator_pid, new_provider_id,
+         new_instance_id, result},
+        state
+      ) do
+    case Map.get(state.keys, pool_key) do
+      %{
+        resubscribe_token: ^token,
+        resubscribe_pid: ^owner_pid,
+        resubscribe_coordinator_pid: ^coordinator_pid
+      } = entry ->
+        Process.demonitor(entry.resubscribe_ref, [:flush])
+        cleared_entry = clear_resubscribe_attempt(entry)
+        new_state = %{state | keys: Map.put(state.keys, pool_key, cleared_entry)}
+
+        settle_resubscribe(
+          new_state,
+          pool_key,
+          cleared_entry,
+          coordinator_pid,
+          new_provider_id,
+          new_instance_id,
+          result
+        )
+
+      _stale ->
+        if match?({:ok, _status}, result) do
+          InstanceSubscriptionManager.release_subscription(
+            new_instance_id,
+            subscription_key(pool_key)
+          )
+        end
+
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:DOWN, ref, :process, owner_pid, _reason}, state) do
+    case Enum.find(state.keys, fn {_pool_key, entry} ->
+           Map.get(entry, :establishment_attempt_ref) == ref and
+             Map.get(entry, :establishment_attempt_pid) == owner_pid
+         end) do
+      {pool_key, entry} ->
+        generation = entry.establishment_generation
+        exclusions = Map.get(entry, :establishment_attempt_exclusions, [])
+        cleared_entry = clear_establishment_attempt(entry)
+        new_state = %{state | keys: Map.put(state.keys, pool_key, cleared_entry)}
+        retry_readiness(new_state, pool_key, generation, exclusions)
+
+      nil ->
+        case Enum.find(state.keys, fn {_pool_key, entry} ->
+               Map.get(entry, :resubscribe_ref) == ref and
+                 Map.get(entry, :resubscribe_pid) == owner_pid
+             end) do
+          {pool_key, entry} ->
+            coordinator_pid = entry.resubscribe_coordinator_pid
+            cleared_entry = clear_resubscribe_attempt(entry)
+            send(coordinator_pid, {:subscription_failed, :replacement_owner_down})
+            {:noreply, %{state | keys: Map.put(state.keys, pool_key, cleared_entry)}}
+
+          nil ->
+            case Enum.find(state.coordinator_monitors, fn {_pool_key, monitor} ->
+                   monitor.ref == ref and monitor.pid == owner_pid
+                 end) do
+              {pool_key, _monitor} ->
+                ClientSubscriptionRegistry.terminate(
+                  state.profile,
+                  state.chain_id,
+                  pool_key,
+                  :continuity_exhausted
+                )
+
+                {:noreply,
+                 %{
+                   state
+                   | coordinator_monitors: Map.delete(state.coordinator_monitors, pool_key)
+                 }}
+
+              nil ->
+                {:noreply, state}
+            end
+        end
+    end
+  end
+
+  def handle_info(
+        {:subscription_establishment_timeout, pool_key, generation, subscription_id, token},
+        state
+      ) do
+    case Map.get(state.keys, pool_key) do
+      %{status: :establishing, establishment_generation: ^generation} = entry ->
+        case Enum.split_with(Map.get(entry, :pending_subscribers, []), fn waiter ->
+               waiter.subscription_id == subscription_id and waiter.token == token
+             end) do
+          {[waiter], remaining} ->
+            GenServer.reply(waiter.from, {:error, :timeout})
+
+            {_removed?, reduced_state} =
+              remove_client_subscription(
+                %{
+                  state
+                  | keys: Map.put(state.keys, pool_key, %{entry | pending_subscribers: remaining})
+                },
+                subscription_id
+              )
+
+            {:noreply, reduced_state}
+
+          _ ->
+            {:noreply, state}
+        end
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:settle_subscription_established, pool_key, generation}, state) do
+    case Map.get(state.keys, pool_key) do
+      %{status: :active, establishment_generation: ^generation} = entry ->
+        settled_entry = settle_pending_subscribers(entry, :established)
+        {:noreply, %{state | keys: Map.put(state.keys, pool_key, settled_entry)}}
+
+      _ ->
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:stop_coordinator_if_unused, pool_key}, state) do
+    if Map.has_key?(state.keys, pool_key) do
+      {:noreply, state}
+    else
+      _ = StreamSupervisor.stop_coordinator(state.profile, state.chain_id, pool_key)
+      {:noreply, state}
     end
   end
 
@@ -975,8 +1290,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
   end
 
   def handle_info({:ensure_coordinator, key}, state) do
-    _ = start_coordinator_for_key(state, key)
-    {:noreply, state}
+    {:noreply, ensure_coordinator_monitored(state, key)}
   end
 
   def handle_info(_, state), do: {:noreply, state}
@@ -1062,10 +1376,43 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
       dedupe_max_age_ms: state.dedupe_max_age_ms,
       max_backfill_blocks: state.max_backfill_blocks,
       backfill_timeout: state.backfill_timeout,
-      continuity_policy: :best_effort
+      continuity_policy: :strict_abort
     ]
 
     StreamSupervisor.ensure_coordinator(state.profile, state.chain_id, pool_key, opts)
+  end
+
+  defp ensure_coordinator_monitored(state, pool_key) do
+    case start_coordinator_for_key(state, pool_key) do
+      {:ok, pid} ->
+        case Map.get(state.coordinator_monitors, pool_key) do
+          %{pid: ^pid} ->
+            state
+
+          existing ->
+            if existing, do: Process.demonitor(existing.ref, [:flush])
+            monitor = %{pid: pid, ref: Process.monitor(pid)}
+
+            %{
+              state
+              | coordinator_monitors: Map.put(state.coordinator_monitors, pool_key, monitor)
+            }
+        end
+
+      {:error, _reason} ->
+        state
+    end
+  end
+
+  defp release_coordinator_monitor(state, pool_key) do
+    case Map.pop(state.coordinator_monitors, pool_key) do
+      {nil, monitors} ->
+        %{state | coordinator_monitors: monitors}
+
+      {%{ref: ref}, monitors} ->
+        Process.demonitor(ref, [:flush])
+        %{state | coordinator_monitors: monitors}
+    end
   end
 
   defp pick_next_provider(state, pool_key, failed_provider_id) do
@@ -1095,8 +1442,31 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
     end
   end
 
-  defp dispatch_failover(state, pool_key, _failed_provider_id, nil) do
-    retry_pending_subscription(state, pool_key)
+  defp dispatch_failover(state, pool_key, failed_provider_id, nil) do
+    StreamCoordinator.provider_unhealthy(
+      state.profile,
+      state.chain_id,
+      pool_key,
+      failed_provider_id,
+      nil
+    )
+
+    case Map.get(state.keys, pool_key) do
+      nil ->
+        state
+
+      entry ->
+        release_entry_upstreams(state, pool_key, entry)
+
+        updated = %{
+          entry
+          | status: :failed,
+            primary_provider_id: nil,
+            instance_id: nil
+        }
+
+        %{state | keys: Map.put(state.keys, pool_key, updated)}
+    end
   end
 
   defp dispatch_failover(state, key, failed_provider_id, new_provider_id)
@@ -1141,10 +1511,12 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
 
       %{refcount: 1} = entry ->
         release_entry_upstreams(state, pool_key, entry)
+        _entry = settle_pending_subscribers(entry, {:error, :subscription_inactive})
+        send(self(), {:stop_coordinator_if_unused, pool_key})
 
-        profile = state.profile
-        Task.start(fn -> StreamSupervisor.stop_coordinator(profile, state.chain_id, pool_key) end)
-        %{state | keys: Map.delete(state.keys, pool_key)}
+        state
+        |> release_coordinator_monitor(pool_key)
+        |> Map.update!(:keys, &Map.delete(&1, pool_key))
 
       entry ->
         updated = %{entry | refcount: entry.refcount - 1}
@@ -1214,6 +1586,166 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPool do
       {:ok, key} -> {true, maybe_drop_upstream_when_unref(state, key)}
     end
   end
+
+  defp add_pending_subscriber(state, pool_key, subscription_id, from, deadline_us) do
+    entry = state.keys[pool_key]
+    token = make_ref()
+    timeout_ms = establishment_timeout_ms(deadline_us)
+
+    timer_ref =
+      Process.send_after(
+        self(),
+        {:subscription_establishment_timeout, pool_key, entry.establishment_generation,
+         subscription_id, token},
+        timeout_ms
+      )
+
+    waiter = %{
+      subscription_id: subscription_id,
+      from: from,
+      token: token,
+      timer_ref: timer_ref,
+      deadline_us: deadline_us
+    }
+
+    pending = [waiter | Map.get(entry, :pending_subscribers, [])]
+    %{state | keys: Map.put(state.keys, pool_key, Map.put(entry, :pending_subscribers, pending))}
+  end
+
+  defp settle_pending_subscribers(entry, outcome) do
+    Enum.each(Map.get(entry, :pending_subscribers, []), fn waiter ->
+      Process.cancel_timer(waiter.timer_ref)
+
+      reply =
+        case outcome do
+          :established -> {:ok, waiter.subscription_id}
+          {:error, reason} -> {:error, reason}
+        end
+
+      GenServer.reply(waiter.from, reply)
+    end)
+
+    Map.put(entry, :pending_subscribers, [])
+  end
+
+  defp establishment_timeout_ms(deadline_us) when is_integer(deadline_us) do
+    remaining = div(deadline_us - System.monotonic_time(:microsecond) + 999, 1_000)
+    max(min(remaining, @establishment_timeout_ms), 0)
+  end
+
+  defp establishment_timeout_ms(_deadline_us), do: @establishment_timeout_ms
+
+  defp establishment_attempt_timeout(entry) do
+    now_us = System.monotonic_time(:microsecond)
+
+    entry
+    |> Map.get(:pending_subscribers, [])
+    |> Enum.map(fn
+      %{deadline_us: deadline_us} when is_integer(deadline_us) ->
+        max(div(deadline_us - now_us + 999, 1_000), 1)
+
+      _waiter ->
+        @establishment_timeout_ms
+    end)
+    |> Enum.min(fn -> @establishment_timeout_ms end)
+    |> min(@establishment_timeout_ms)
+  end
+
+  defp clear_establishment_attempt(entry) do
+    %{
+      entry
+      | establishment_attempt_token: nil,
+        establishment_attempt_pid: nil,
+        establishment_attempt_ref: nil,
+        establishment_attempt_exclusions: []
+    }
+  end
+
+  defp settle_resubscribe(
+         state,
+         pool_key,
+         entry,
+         coordinator_pid,
+         new_provider_id,
+         new_instance_id,
+         {:ok, _status}
+       ) do
+    old_provider_id = entry.primary_provider_id
+    old_instance_id = entry.instance_id
+    subscription_key = entry.subscription_key
+    InstanceSubscriptionRegistry.register_consumer(new_instance_id, subscription_key)
+
+    release_overwritten_transition(
+      state,
+      pool_key,
+      entry,
+      subscription_key,
+      new_instance_id
+    )
+
+    transition_fields =
+      if old_instance_id && old_instance_id != new_instance_id do
+        %{
+          transitioning_from: old_provider_id,
+          transitioning_from_instance_id: old_instance_id
+        }
+      else
+        %{}
+      end
+
+    updated_entry =
+      entry
+      |> Map.drop([:transitioning_from, :transitioning_from_instance_id])
+      |> Map.merge(%{
+        primary_provider_id: new_provider_id,
+        instance_id: new_instance_id,
+        status: :active
+      })
+      |> Map.merge(transition_fields)
+
+    new_state = %{state | keys: Map.put(state.keys, pool_key, updated_entry)}
+    send(coordinator_pid, {:subscription_confirmed, new_provider_id, nil})
+
+    if old_instance_id && old_instance_id != new_instance_id do
+      Process.send_after(
+        self(),
+        {:deferred_release, pool_key, old_provider_id, old_instance_id},
+        5_000
+      )
+    end
+
+    {:noreply, new_state}
+  end
+
+  defp settle_resubscribe(
+         state,
+         pool_key,
+         _entry,
+         coordinator_pid,
+         new_provider_id,
+         _new_instance_id,
+         {:error, reason}
+       ) do
+    Logger.error(
+      "Resubscription failed for #{inspect(pool_key)} to #{new_provider_id}: #{inspect(reason)}"
+    )
+
+    send(coordinator_pid, {:subscription_failed, reason})
+    {:noreply, state}
+  end
+
+  defp clear_resubscribe_attempt(entry) do
+    %{
+      entry
+      | resubscribe_token: nil,
+        resubscribe_pid: nil,
+        resubscribe_ref: nil,
+        resubscribe_coordinator_pid: nil
+    }
+  end
+
+  defp subscription_key({:route, _provider_id, key}), do: key
+  defp subscription_key(key), do: key
 
   defp remove_owned_client_subscription(state, subscription_id, nil, _client_pid, nil) do
     {removed?, state} = remove_client_subscription(state, subscription_id)

--- a/lib/lasso/core/support/continuity_policy.ex
+++ b/lib/lasso/core/support/continuity_policy.ex
@@ -13,7 +13,7 @@ defmodule Lasso.Core.Support.ContinuityPolicy do
           | {:exceeded, pos_integer(), pos_integer()}
   def needed_block_range(last_seen, head, max_backfill_blocks, _policy)
       when is_integer(last_seen) do
-    if head <= last_seen + 1 do
+    if head <= last_seen do
       {:none}
     else
       from_n = last_seen + 1

--- a/lib/lasso_web/sockets/rpc_socket.ex
+++ b/lib/lasso_web/sockets/rpc_socket.ex
@@ -228,6 +228,15 @@ defmodule LassoWeb.RPCSocket do
   end
 
   @impl true
+  def handle_info({:subscription_terminated, subscription_id, :continuity_exhausted}, state) do
+    if Map.has_key?(state.subscriptions, subscription_id) do
+      {:stop, :continuity_exhausted, {1011, "Lasso subscription continuity exhausted"}, state}
+    else
+      {:ok, state}
+    end
+  end
+
+  @impl true
   def handle_info({:send_notification, notification_json}, state) do
     # Send metadata notification as separate WebSocket frame
     {:push, {:text, notification_json}, state}

--- a/test/integration/zero_gap_failover_test.exs
+++ b/test/integration/zero_gap_failover_test.exs
@@ -1,33 +1,21 @@
 defmodule Lasso.Integration.ZeroGapFailoverTest do
   @moduledoc """
-  Integration tests for zero-gap failover guarantee.
-
-  Tests the critical production guarantee:
-  "Client receives complete block sequence during provider failover (no missing blocks, no duplicates)"
-
-  This validates Lasso's core value proposition - seamless failover that users don't notice.
-
-  ## What We Test
-
-  These tests verify the behavioral guarantees provided by StreamCoordinator and
-  UpstreamSubscriptionPool, not the internal failover choreography:
-
-  1. **Deduplication** - When multiple providers send the same blocks, clients receive each block once
-  2. **Ordering** - Out-of-order blocks are delivered to clients (client can reorder if needed)
-
-  These guarantees ensure zero-gap failover works correctly in production.
+  Transport-integrated WebSocket replacement and bounded replay tests.
   """
 
   use Lasso.Test.LassoIntegrationCase, async: false
 
   alias Lasso.Core.Streaming.UpstreamSubscriptionPool
-  alias Lasso.Testing.{IntegrationHelper, MockWSProvider}
+  alias Lasso.Testing.{IntegrationHelper, MockHTTPProvider, MockWSProvider}
 
   @moduletag :integration
 
   describe "WebSocket subscription zero-gap guarantee" do
-    test "no duplicate blocks during rapid provider switching", %{chain: chain} do
+    test "disconnect replaces the upstream and replays missed heads without overlap", %{
+      chain: chain
+    } do
       profile = "public"
+      head = start_supervised!({Agent, fn -> 203 end})
 
       {:ok, [p1_id, p2_id]} =
         IntegrationHelper.setup_test_chain_with_providers(
@@ -39,32 +27,42 @@ defmodule Lasso.Integration.ZeroGapFailoverTest do
           provider_type: :ws
         )
 
+      start_backfill_provider(chain, head, profile)
+
       client_pid = self()
       {:ok, _sub_id} = IntegrationHelper.subscribe_client(chain, client_pid, {:newHeads}, profile)
 
       wait_for_subscription_active(profile, chain, {:newHeads})
+      assert wait_for_any_upstream_subscription_established(profile, chain, {:newHeads}) == p1_id
 
-      MockWSProvider.send_block_sequence(chain, p1_id, 200, 5, delay_ms: 30)
-      MockWSProvider.send_block_sequence(chain, p2_id, 200, 5, delay_ms: 30)
+      MockWSProvider.send_block(chain, p1_id, block(200))
+      assert Enum.map(collect_blocks(1, timeout: 2_000), &extract_block_number/1) == [200]
 
-      Process.sleep(1000)
+      :ok = MockWSProvider.simulate_provider_failure(chain, p1_id)
+      wait_for_primary_provider(profile, chain, {:newHeads}, p2_id)
 
-      blocks = collect_all_blocks(timeout: 100)
-      block_numbers = Enum.map(blocks, &extract_block_number/1)
+      assert Enum.map(collect_blocks(3, timeout: 3_000), &extract_block_number/1) == [
+               201,
+               202,
+               203
+             ]
 
-      unique_blocks = Enum.uniq(block_numbers)
+      MockWSProvider.send_block(chain, p2_id, block(204))
+      assert Enum.map(collect_blocks(1, timeout: 2_000), &extract_block_number/1) == [204]
+      refute_receive {:subscription_event, _duplicate}, 100
 
-      assert length(unique_blocks) == length(block_numbers),
-             "Duplicate blocks detected during rapid switching: #{inspect(block_numbers)}"
+      Agent.update(head, fn _ -> 205 end)
+      :ok = MockWSProvider.simulate_provider_failure(chain, p2_id)
+      wait_for_primary_provider(profile, chain, {:newHeads}, p1_id)
 
-      assert Enum.all?(block_numbers, fn n -> n >= 200 and n <= 204 end),
-             "Received out-of-range blocks: #{inspect(block_numbers)}"
+      assert Enum.map(collect_blocks(1, timeout: 3_000), &extract_block_number/1) == [205]
     end
 
     test "handles out-of-order blocks during failover", %{chain: chain} do
       profile = "public"
+      head = start_supervised!({Agent, fn -> 303 end})
 
-      {:ok, [_p1_id, _p2_id]} =
+      {:ok, [p1_id, p2_id]} =
         IntegrationHelper.setup_test_chain_with_providers(
           chain,
           [
@@ -74,6 +72,8 @@ defmodule Lasso.Integration.ZeroGapFailoverTest do
           provider_type: :ws
         )
 
+      start_backfill_provider(chain, head, profile)
+
       client_pid = self()
       {:ok, _sub_id} = IntegrationHelper.subscribe_client(chain, client_pid, {:newHeads}, profile)
 
@@ -82,46 +82,62 @@ defmodule Lasso.Integration.ZeroGapFailoverTest do
       selected_provider =
         wait_for_any_upstream_subscription_established(profile, chain, {:newHeads})
 
-      MockWSProvider.send_block(chain, selected_provider, %{
-        "number" => "0x12c",
-        "hash" => "0x#{Integer.to_string(300 * 1000, 16)}",
-        "timestamp" => "0x#{Integer.to_string(:os.system_time(:second), 16)}"
-      })
+      assert selected_provider == p1_id
 
-      Process.sleep(50)
+      Enum.each([300, 302, 301], fn number ->
+        MockWSProvider.send_block(chain, selected_provider, block(number))
+      end)
 
-      MockWSProvider.send_block(chain, selected_provider, %{
-        "number" => "0x12e",
-        "hash" => "0x#{Integer.to_string(302 * 1000, 16)}",
-        "timestamp" => "0x#{Integer.to_string(:os.system_time(:second), 16)}"
-      })
+      assert Enum.map(collect_blocks(3, timeout: 2_000), &extract_block_number/1) == [
+               300,
+               302,
+               301
+             ]
 
-      Process.sleep(50)
+      :ok = MockWSProvider.simulate_provider_failure(chain, p1_id)
+      wait_for_primary_provider(profile, chain, {:newHeads}, p2_id)
 
-      MockWSProvider.send_block(chain, selected_provider, %{
-        "number" => "0x12d",
-        "hash" => "0x#{Integer.to_string(301 * 1000, 16)}",
-        "timestamp" => "0x#{Integer.to_string(:os.system_time(:second), 16)}"
-      })
-
-      Process.sleep(50)
-
-      MockWSProvider.send_block(chain, selected_provider, %{
-        "number" => "0x12f",
-        "hash" => "0x#{Integer.to_string(303 * 1000, 16)}",
-        "timestamp" => "0x#{Integer.to_string(:os.system_time(:second), 16)}"
-      })
-
-      Process.sleep(50)
-
-      blocks = collect_blocks(4, timeout: 2000)
-
-      block_numbers = Enum.map(blocks, &extract_block_number/1) |> Enum.sort()
-
-      assert block_numbers == [300, 301, 302, 303],
-             "Missing blocks during out-of-order delivery: #{inspect(block_numbers)}"
+      assert Enum.map(collect_blocks(1, timeout: 3_000), &extract_block_number/1) == [303]
+      refute_receive {:subscription_event, _duplicate}, 100
     end
   end
+
+  defp start_backfill_provider(chain, head, profile) do
+    behavior =
+      {:conditional,
+       fn
+         "eth_blockNumber", [], _state ->
+           {:ok, encode_hex(Agent.get(head, & &1))}
+
+         "eth_getBlockByNumber", [number, false], _state ->
+           {:ok, number |> decode_hex() |> block()}
+
+         "eth_getLogs", [_filter], _state ->
+           {:ok, []}
+
+         method, _params, _state ->
+           {:error, {:unexpected_method, method}}
+       end}
+
+    assert {:ok, "backfill"} =
+             MockHTTPProvider.start_mock(chain, %{
+               id: "backfill",
+               profile: profile,
+               priority: 1,
+               behavior: behavior
+             })
+  end
+
+  defp block(number) do
+    %{
+      "number" => encode_hex(number),
+      "hash" => "0x#{Integer.to_string(number * 1000, 16)}",
+      "timestamp" => encode_hex(:os.system_time(:second))
+    }
+  end
+
+  defp encode_hex(number), do: "0x" <> Integer.to_string(number, 16)
+  defp decode_hex("0x" <> number), do: String.to_integer(number, 16)
 
   defp collect_blocks(count, opts) do
     timeout = Keyword.get(opts, :timeout, 5000)
@@ -138,22 +154,6 @@ defmodule Lasso.Integration.ZeroGapFailoverTest do
     after
       timeout ->
         raise "Timeout waiting for #{count} more blocks. Received: #{length(acc)} blocks"
-    end
-  end
-
-  defp collect_all_blocks(opts) do
-    timeout = Keyword.get(opts, :timeout, 100)
-    collect_all_blocks_recursive(timeout, [])
-  end
-
-  defp collect_all_blocks_recursive(timeout, acc) do
-    receive do
-      {:subscription_event, event} ->
-        block = event["params"]["result"]
-        collect_all_blocks_recursive(timeout, [block | acc])
-    after
-      timeout ->
-        Enum.reverse(acc)
     end
   end
 
@@ -208,6 +208,32 @@ defmodule Lasso.Integration.ZeroGapFailoverTest do
   defp wait_for_any_upstream_subscription_established(profile, chain, key, timeout \\ 3000) do
     deadline = System.monotonic_time(:millisecond) + timeout
     wait_for_active_subscription_loop(profile, chain, key, deadline)
+  end
+
+  defp wait_for_primary_provider(profile, chain, key, provider_id, timeout \\ 5_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    wait_for_primary_provider_loop(profile, chain, key, provider_id, deadline)
+  end
+
+  defp wait_for_primary_provider_loop(profile, chain, key, provider_id, deadline) do
+    pool_state = :sys.get_state(UpstreamSubscriptionPool.via(profile, chain))
+
+    coordinator_state =
+      :sys.get_state(Lasso.Core.Streaming.StreamCoordinator.via(profile, chain, key))
+
+    case {Map.get(pool_state.keys, key), coordinator_state} do
+      {%{status: :active, primary_provider_id: ^provider_id},
+       %{failover_status: :active, primary_provider_id: ^provider_id}} ->
+        :ok
+
+      current ->
+        if System.monotonic_time(:millisecond) < deadline do
+          Process.sleep(10)
+          wait_for_primary_provider_loop(profile, chain, key, provider_id, deadline)
+        else
+          flunk("provider replacement did not complete: #{inspect(current)}")
+        end
+    end
   end
 
   defp wait_for_active_subscription_loop(profile, chain, key, deadline) do

--- a/test/lasso/core/streaming/client_subscription_registry_test.exs
+++ b/test/lasso/core/streaming/client_subscription_registry_test.exs
@@ -1,0 +1,78 @@
+defmodule Lasso.Core.Streaming.ClientSubscriptionRegistryTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Core.Streaming.{ClientSubscriptionRegistry, UpstreamSubscriptionPool}
+
+  @profile "test-client-registry"
+  @chain_id 42_424
+  @key {:newHeads}
+
+  test "client DOWN decrements the upstream pool refcount" do
+    profile = "#{@profile}-#{System.unique_integer([:positive])}"
+
+    {:ok, pool} = UpstreamSubscriptionPool.start_link({profile, @chain_id})
+    {:ok, registry} = ClientSubscriptionRegistry.start_link({profile, @chain_id})
+
+    :sys.replace_state(pool, fn state ->
+      %{
+        state
+        | keys: %{
+            @key => %{
+              refcount: 2,
+              status: :active,
+              primary_provider_id: "provider-a",
+              instance_id: "instance-a",
+              markers: %{},
+              dedupe: nil,
+              noproc_retries: 0
+            }
+          }
+      }
+    end)
+
+    client = spawn(fn -> Process.sleep(:infinity) end)
+    :ok = ClientSubscriptionRegistry.add_client(profile, @chain_id, "sub-1", client, @key)
+
+    Process.exit(client, :kill)
+
+    assert_eventually(fn ->
+      [] == ClientSubscriptionRegistry.list_by_key(profile, @chain_id, @key)
+    end)
+
+    assert_eventually(fn ->
+      %{keys: %{@key => %{refcount: 1}}} = :sys.get_state(pool)
+      true
+    end)
+
+    GenServer.stop(registry)
+    GenServer.stop(pool)
+  end
+
+  test "continuity exhaustion is delivered to every downstream subscriber" do
+    profile = "#{@profile}-termination-#{System.unique_integer([:positive])}"
+    {:ok, registry} = ClientSubscriptionRegistry.start_link({profile, @chain_id})
+
+    :ok = ClientSubscriptionRegistry.add_client(profile, @chain_id, "sub-1", self(), @key)
+    :ok = ClientSubscriptionRegistry.add_client(profile, @chain_id, "sub-2", self(), @key)
+
+    :ok = ClientSubscriptionRegistry.terminate(profile, @chain_id, @key, :continuity_exhausted)
+
+    assert_receive {:subscription_terminated, "sub-1", :continuity_exhausted}
+    assert_receive {:subscription_terminated, "sub-2", :continuity_exhausted}
+
+    GenServer.stop(registry)
+  end
+
+  defp assert_eventually(fun, attempts \\ 20)
+
+  defp assert_eventually(fun, attempts) when attempts > 0 do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(10)
+      assert_eventually(fun, attempts - 1)
+    end
+  end
+
+  defp assert_eventually(fun, 0), do: assert(fun.())
+end

--- a/test/lasso/core/streaming/stream_coordinator_background_owner_test.exs
+++ b/test/lasso/core/streaming/stream_coordinator_background_owner_test.exs
@@ -2,10 +2,20 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
   use ExUnit.Case, async: false
 
   alias Lasso.Core.Request.ExecutionScope
-  alias Lasso.Core.Streaming.StreamCoordinator
+  alias Lasso.Core.Streaming.{ClientSubscriptionRegistry, StreamCoordinator}
 
   defp new_head(number) do
     %{"hash" => "0x#{number}", "number" => "0x#{Integer.to_string(number, 16)}"}
+  end
+
+  defp log_event(number, block_hash, removed \\ false) do
+    %{
+      "blockNumber" => "0x#{Integer.to_string(number, 16)}",
+      "blockHash" => block_hash,
+      "transactionIndex" => "0x0",
+      "logIndex" => "0x0",
+      "removed" => removed
+    }
   end
 
   defp await_state(pid, predicate, attempts \\ 1_000)
@@ -18,7 +28,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
     if predicate.(state) do
       state
     else
-      :erlang.yield()
+      Process.sleep(1)
       await_state(pid, predicate, attempts - 1)
     end
   end
@@ -33,6 +43,10 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
       {:ok, "http-fixed"}
     end
 
+    replacement = fn _profile, _chain_id, _key, provider_id, coordinator_pid ->
+      send(coordinator_pid, {:subscription_confirmed, provider_id, "upstream-new"})
+    end
+
     {:ok, pid} =
       StreamCoordinator.start_link(
         {profile, chain_id, key,
@@ -40,6 +54,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
            [
              primary_provider_id: "ws-old",
              backfill_provider_selector: selector,
+             replacement_requester: replacement,
              max_failover_attempts: 1
            ],
            opts
@@ -58,6 +73,9 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
       case {method, params} do
         {"eth_blockNumber", []} ->
           {:ok, "0xc", %{}}
+
+        {"eth_getBlockByNumber", ["0xA", false]} ->
+          {:ok, new_head(10), %{}}
 
         {"eth_getBlockByNumber", ["0xB", false]} ->
           {:ok, new_head(11), %{}}
@@ -85,6 +103,9 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
     assert_receive {:backfill_request, owner_pid, head_scope, ^chain_id, "eth_blockNumber", [],
                     head_opts}
 
+    assert_receive {:backfill_request, ^owner_pid, replay_scope, ^chain_id,
+                    "eth_getBlockByNumber", ["0xA", false], replay_opts}
+
     assert_receive {:backfill_request, ^owner_pid, block_scope, ^chain_id, "eth_getBlockByNumber",
                     ["0xB", false], block_opts}
 
@@ -103,7 +124,12 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
     refute owner_pid in elem(Process.info(pid, :links), 1)
 
     Enum.each(
-      [{head_scope, head_opts}, {block_scope, block_opts}, {final_scope, final_opts}],
+      [
+        {head_scope, head_opts},
+        {replay_scope, replay_opts},
+        {block_scope, block_opts},
+        {final_scope, final_opts}
+      ],
       fn {scope, opts} ->
         assert scope.owner_pid == owner_pid
         assert scope.caller_pid == pid
@@ -127,14 +153,227 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
 
     send(owner_pid, :release)
 
-    switching = await_state(pid, &(&1.failover_status == :switching))
+    active = await_state(pid, &(&1.failover_status == :active))
 
-    assert switching.failover_context.event_buffer_count == 2
+    assert active.state.markers.last_block_num == 12
+  end
 
-    assert Enum.map(switching.failover_context.event_buffer, & &1["number"]) == [
-             "0xC",
-             "0xB"
-           ]
+  test "replacement is live before backfill and overlapping heads are delivered once in order" do
+    test_pid = self()
+    chain_id = System.unique_integer([:positive])
+    profile = "profile-#{chain_id}"
+    key = {:newHeads}
+
+    requester = fn _scope, _chain_id, method, params, _opts ->
+      case {method, params} do
+        {"eth_blockNumber", []} ->
+          send(test_pid, {:head_requested, self()})
+
+          receive do
+            :respond_head -> {:ok, "0x66", %{}}
+          end
+
+        {"eth_getBlockByNumber", [number, false]} ->
+          block_number = String.to_integer(String.trim_leading(number, "0x"), 16)
+
+          block =
+            if block_number == 100 do
+              %{new_head(block_number) | "hash" => "0xcanonical-100"}
+            else
+              new_head(block_number)
+            end
+
+          {:ok, block, %{}}
+      end
+    end
+
+    replacement = fn _profile, _chain_id, _key, provider_id, coordinator_pid ->
+      send(test_pid, {:replacement_requested, provider_id})
+      send(coordinator_pid, {:subscription_confirmed, provider_id, "upstream-new"})
+    end
+
+    selector = fn _profile, _chain_id, _excluded -> {:ok, "http-fixed"} end
+
+    start_supervised!({ClientSubscriptionRegistry, {profile, chain_id}})
+    :ok = ClientSubscriptionRegistry.add_client(profile, chain_id, "client-sub", self(), key)
+
+    {:ok, pid} =
+      StreamCoordinator.start_link(
+        {profile, chain_id, key,
+         primary_provider_id: "ws-old",
+         backfill_requester: requester,
+         backfill_provider_selector: selector,
+         replacement_requester: replacement}
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    GenServer.cast(pid, {:upstream_event, "ws-old", "sub-old", new_head(100), 1})
+    assert_receive {:subscription_event, %{"params" => %{"result" => %{"number" => "0x64"}}}}
+
+    GenServer.cast(pid, {:provider_unhealthy, "ws-old", "ws-new"})
+
+    assert_receive {:replacement_requested, "ws-new"}
+    assert_receive {:head_requested, owner_pid}
+
+    GenServer.cast(pid, {:upstream_event, "ws-old", "sub-old", new_head(103), 2})
+    GenServer.cast(pid, {:upstream_event, "ws-new", "sub-new", new_head(102), 2})
+    send(owner_pid, :respond_head)
+
+    assert await_state(pid, &(&1.failover_status == :active)).primary_provider_id == "ws-new"
+
+    assert_receive {:subscription_event,
+                    %{
+                      "params" => %{
+                        "result" => %{"number" => "0x64", "hash" => "0xcanonical-100"}
+                      }
+                    }}
+
+    assert_receive {:subscription_event, %{"params" => %{"result" => %{"number" => "0x65"}}}}
+    assert_receive {:subscription_event, %{"params" => %{"result" => %{"number" => "0x66"}}}}
+
+    GenServer.cast(pid, {:upstream_event, "ws-old", "sub-old", new_head(104), 3})
+    refute_receive {:subscription_event, _duplicate}, 50
+  end
+
+  test "log failover replays the last block, preserves removals, and suppresses overlap" do
+    test_pid = self()
+    chain_id = System.unique_integer([:positive])
+    profile = "profile-#{chain_id}"
+    filter = %{"address" => "0xabc"}
+    key = {:logs, filter}
+
+    canonical_100 = log_event(100, "0xcanonical-100")
+    log_101 = log_event(101, "0xcanonical-101")
+
+    requester = fn _scope, _chain_id, method, params, _opts ->
+      case {method, params} do
+        {"eth_blockNumber", []} ->
+          send(test_pid, {:log_head_requested, self()})
+
+          receive do
+            :respond_log_head -> {:ok, "0x65", %{}}
+          end
+
+        {"eth_getLogs", [request_filter]} ->
+          send(test_pid, {:log_backfill_filter, request_filter})
+          {:ok, [canonical_100, log_101], %{}}
+      end
+    end
+
+    replacement = fn _profile, _chain_id, _key, provider_id, coordinator_pid ->
+      send(coordinator_pid, {:subscription_confirmed, provider_id, "upstream-new"})
+    end
+
+    start_supervised!({ClientSubscriptionRegistry, {profile, chain_id}})
+    :ok = ClientSubscriptionRegistry.add_client(profile, chain_id, "client-logs", self(), key)
+
+    {:ok, pid} =
+      StreamCoordinator.start_link(
+        {profile, chain_id, key,
+         primary_provider_id: "ws-old",
+         backfill_requester: requester,
+         backfill_provider_selector: fn _profile, _chain_id, _excluded ->
+           {:ok, "http-fixed"}
+         end,
+         replacement_requester: replacement}
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    original = log_event(100, "0xold-100")
+    GenServer.cast(pid, {:upstream_event, "ws-old", "sub-old", original, 1})
+    assert_receive {:subscription_event, %{"params" => %{"result" => ^original}}}
+
+    GenServer.cast(pid, {:provider_unhealthy, "ws-old", "ws-new"})
+    assert_receive {:log_head_requested, owner_pid}
+
+    removed = %{original | "removed" => true}
+    GenServer.cast(pid, {:upstream_event, "ws-new", "sub-new", removed, 2})
+    GenServer.cast(pid, {:upstream_event, "ws-new", "sub-new", log_101, 3})
+    send(owner_pid, :respond_log_head)
+
+    assert_receive {:log_backfill_filter, %{"fromBlock" => "0x64", "toBlock" => "0x65"}}
+
+    assert await_state(pid, &(&1.failover_status == :active)).primary_provider_id == "ws-new"
+
+    assert_receive {:subscription_event, %{"params" => %{"result" => ^removed}}}
+    assert_receive {:subscription_event, %{"params" => %{"result" => ^canonical_100}}}
+    assert_receive {:subscription_event, %{"params" => %{"result" => ^log_101}}}
+    refute_receive {:subscription_event, _duplicate}, 50
+  end
+
+  test "a gap beyond the replay window terminates downstream subscriptions" do
+    chain_id = System.unique_integer([:positive])
+    profile = "profile-#{chain_id}"
+    key = {:newHeads}
+
+    requester = fn _scope, _chain_id, method, params, _opts ->
+      case {method, params} do
+        {"eth_blockNumber", []} -> {:ok, "0xc8", %{}}
+        {"eth_getBlockByNumber", _params} -> flunk("strict overflow must not partially replay")
+      end
+    end
+
+    replacement = fn _profile, _chain_id, _key, provider_id, coordinator_pid ->
+      send(coordinator_pid, {:subscription_confirmed, provider_id, "upstream-new"})
+    end
+
+    start_supervised!({ClientSubscriptionRegistry, {profile, chain_id}})
+    :ok = ClientSubscriptionRegistry.add_client(profile, chain_id, "client-sub", self(), key)
+
+    {:ok, pid} =
+      StreamCoordinator.start_link(
+        {profile, chain_id, key,
+         primary_provider_id: "ws-old",
+         max_backfill_blocks: 32,
+         continuity_policy: :strict_abort,
+         max_failover_attempts: 1,
+         backfill_requester: requester,
+         backfill_provider_selector: fn _profile, _chain_id, _excluded ->
+           {:ok, "http-fixed"}
+         end,
+         replacement_requester: replacement}
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    GenServer.cast(pid, {:upstream_event, "ws-old", "sub-old", new_head(100), 1})
+    assert_receive {:subscription_event, _head_100}
+
+    GenServer.cast(pid, {:provider_unhealthy, "ws-old", "ws-new"})
+
+    assert_receive {:subscription_terminated, "client-sub", :continuity_exhausted}
+    assert await_state(pid, &(&1.failover_status == :degraded)).failover_context == nil
+  end
+
+  test "replacement deadline exhaustion terminates downstream subscriptions" do
+    chain_id = System.unique_integer([:positive])
+    profile = "profile-#{chain_id}"
+    key = {:newHeads}
+
+    start_supervised!({ClientSubscriptionRegistry, {profile, chain_id}})
+    :ok = ClientSubscriptionRegistry.add_client(profile, chain_id, "client-sub", self(), key)
+
+    {:ok, pid} =
+      StreamCoordinator.start_link(
+        {profile, chain_id, key,
+         primary_provider_id: "ws-old",
+         recovery_timeout_ms: 20,
+         backfill_provider_selector: fn _profile, _chain_id, _excluded ->
+           {:ok, "http-fixed"}
+         end,
+         replacement_requester: fn _profile, _chain_id, _key, _provider, _coordinator ->
+           :ok
+         end}
+      )
+
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    GenServer.cast(pid, {:provider_unhealthy, "ws-old", "ws-new"})
+
+    assert_receive {:subscription_terminated, "client-sub", :continuity_exhausted}, 200
+    assert await_state(pid, &(&1.failover_status == :degraded)).recovery_deadline_us == nil
   end
 
   test "a failed request is terminal for the backfill" do
@@ -145,8 +384,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
 
       case {method, params} do
         {"eth_blockNumber", []} -> {:ok, "0xc", %{}}
-        {"eth_getBlockByNumber", ["0xB", false]} -> {:error, :upstream_failed, %{}}
-        {"eth_getBlockByNumber", ["0xC", false]} -> flunk("request after terminal error")
+        {"eth_getBlockByNumber", ["0xA", false]} -> {:error, :upstream_failed, %{}}
+        {"eth_getBlockByNumber", [_number, false]} -> flunk("request after terminal error")
       end
     end
 
@@ -160,8 +399,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorBackgroundOwnerTest do
     GenServer.cast(pid, {:provider_unhealthy, "ws-old", "ws-new"})
 
     assert_receive {:attempted_request, "eth_blockNumber", []}
-    assert_receive {:attempted_request, "eth_getBlockByNumber", ["0xB", false]}
-    refute_receive {:attempted_request, "eth_getBlockByNumber", ["0xC", false]}, 0
+    assert_receive {:attempted_request, "eth_getBlockByNumber", ["0xA", false]}
+    refute_receive {:attempted_request, "eth_getBlockByNumber", ["0xB", false]}, 0
 
     assert await_state(pid, &(&1.failover_status == :degraded)).failover_context == nil
     assert Process.alive?(pid)

--- a/test/lasso/core/streaming/stream_coordinator_test.exs
+++ b/test/lasso/core/streaming/stream_coordinator_test.exs
@@ -44,6 +44,10 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
     {:ok, List.last(excluded)}
   end
 
+  defp successful_replacement(_profile, _chain_id, _key, provider_id, coordinator_pid) do
+    send(coordinator_pid, {:subscription_confirmed, provider_id, "upstream-new"})
+  end
+
   # Helper to get coordinator state (encapsulated for stability)
   defp get_coordinator_state(pid) do
     :sys.get_state(pid)
@@ -104,7 +108,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       opts = [
         primary_provider_id: "provider_1",
         backfill_requester: &successful_backfill_request/5,
-        backfill_provider_selector: &successful_backfill_provider/3
+        backfill_provider_selector: &successful_backfill_provider/3,
+        replacement_requester: &successful_replacement/5
       ]
 
       {:ok, pid} = StreamCoordinator.start_link({"public", chain, key, opts})
@@ -173,8 +178,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       # Send events
       event1 = new_heads_event(100)
       event2 = new_heads_event(101)
-      GenServer.cast(pid, {:upstream_event, "provider_1", "upstream_1", event1, now()})
-      GenServer.cast(pid, {:upstream_event, "provider_1", "upstream_1", event2, now()})
+      GenServer.cast(pid, {:upstream_event, "p2", "upstream_1", event1, now()})
+      GenServer.cast(pid, {:upstream_event, "p2", "upstream_1", event2, now()})
 
       Process.sleep(10)
 
@@ -201,7 +206,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
       # Send event
       event = new_heads_event(100)
-      GenServer.cast(pid, {:upstream_event, "provider_1", "upstream_1", event, now()})
+      GenServer.cast(pid, {:upstream_event, "p2", "upstream_1", event, now()})
 
       Process.sleep(10)
 
@@ -242,7 +247,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       opts = [
         primary_provider_id: "provider_1",
         backfill_requester: &successful_backfill_request/5,
-        backfill_provider_selector: &successful_backfill_provider/3
+        backfill_provider_selector: &successful_backfill_provider/3,
+        replacement_requester: &successful_replacement/5
       ]
 
       {:ok, pid} = StreamCoordinator.start_link({"public", chain, key, opts})
@@ -262,14 +268,10 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
       Process.sleep(10)
 
-      # Verify failover initiated - test outcome, not intermediate state
-      # May be :backfilling or :switching (backfill completes fast in tests)
+      # Verify replacement and backfill completed.
       state = get_coordinator_state(pid)
-      assert state.failover_status in [:backfilling, :switching]
-
-      # Test observable outcome: failure recorded in history
-      assert length(state.failover_history) == 1
-      assert hd(state.failover_history).provider_id == "provider_1"
+      assert state.failover_status == :active
+      assert state.primary_provider_id == "provider_2"
     end
 
     test "ignores signal when status is :backfilling", %{coordinator: pid} do
@@ -344,7 +346,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
         max_failover_attempts: 2,
         failover_cooldown_ms: 1_000,
         backfill_requester: &successful_backfill_request/5,
-        backfill_provider_selector: &successful_backfill_provider/3
+        backfill_provider_selector: &successful_backfill_provider/3,
+        replacement_requester: &successful_replacement/5
       ]
 
       {:ok, pid} = StreamCoordinator.start_link({"public", chain, key, opts})
@@ -396,13 +399,10 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       GenServer.cast(pid, {:provider_unhealthy, "p2", "p3"})
       Process.sleep(10)
 
-      # Test outcome: did NOT enter degraded mode, failover proceeding
+      # Test outcome: did not enter degraded mode and recovered.
       state = get_coordinator_state(pid)
       refute state.failover_status == :degraded
-      assert state.failover_status in [:backfilling, :switching]
-
-      # History should have grown (new failure recorded)
-      assert length(state.failover_history) == 2
+      assert state.failover_status == :active
     end
 
     test "resets failover history after entering degraded mode", %{coordinator: pid} do
@@ -493,7 +493,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       opts = [
         primary_provider_id: "provider_1",
         backfill_requester: &successful_backfill_request/5,
-        backfill_provider_selector: &successful_backfill_provider/3
+        backfill_provider_selector: &successful_backfill_provider/3,
+        replacement_requester: &successful_replacement/5
       ]
 
       {:ok, pid} = StreamCoordinator.start_link({"public", chain, key, opts})
@@ -506,10 +507,9 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       GenServer.cast(pid, {:provider_unhealthy, "provider_1", "provider_2"})
       Process.sleep(50)
 
-      # History should have one entry
       state = get_coordinator_state(pid)
-      assert length(state.failover_history) == 1
-      assert hd(state.failover_history).provider_id == "provider_1"
+      assert state.failover_history == []
+      assert state.primary_provider_id == "provider_2"
 
       GenServer.stop(pid)
     end
@@ -547,7 +547,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
       # Send events up to max
       for i <- 1..3 do
         event = new_heads_event(100 + i)
-        GenServer.cast(pid, {:upstream_event, "p1", "up1", event, now()})
+        GenServer.cast(pid, {:upstream_event, "p2", "up1", event, now()})
       end
 
       Process.sleep(20)
@@ -581,7 +581,7 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
 
       log =
         capture_log(fn ->
-          GenServer.cast(pid, {:upstream_event, "p1", "up1", event4, now()})
+          GenServer.cast(pid, {:upstream_event, "p2", "up1", event4, now()})
           Process.sleep(20)
         end)
 
@@ -594,26 +594,31 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
     end
 
     test "buffer preserves event ordering during drain", %{coordinator: pid} do
-      # Set up :switching status with buffered events
+      # Set up a completed backfill with buffered events
       state = get_coordinator_state(pid)
       event1 = new_heads_event(100)
       event2 = new_heads_event(101)
       event3 = new_heads_event(102)
 
+      owner_id = make_ref()
+      owner_ref = Process.monitor(self())
+
       fake_context = %{
         old_provider_id: "p1",
         new_provider_id: "p2",
-        backfill_task_ref: make_ref(),
+        backfill_owner_id: owner_id,
+        backfill_owner_pid: self(),
+        backfill_owner_ref: owner_ref,
+        backfill_task_ref: owner_ref,
         started_at: now(),
         event_buffer: [event1, event2, event3],
         attempt_count: 1
       }
 
-      new_state = %{state | failover_status: :switching, failover_context: fake_context}
+      new_state = %{state | failover_status: :backfilling, failover_context: fake_context}
       :sys.replace_state(pid, fn _ -> new_state end)
 
-      # Complete failover (simulate subscription_confirmed)
-      send(pid, {:subscription_confirmed, "p2", "upstream_2"})
+      send(pid, {:backfill_result, owner_id, self(), :ok})
       Process.sleep(50)
 
       # Verify events were processed in order
@@ -708,7 +713,8 @@ defmodule Lasso.Core.Streaming.StreamCoordinatorTest do
         primary_provider_id: "provider_1",
         max_failover_attempts: 1,
         backfill_requester: requester,
-        backfill_provider_selector: &successful_backfill_provider/3
+        backfill_provider_selector: &successful_backfill_provider/3,
+        replacement_requester: &successful_replacement/5
       ]
 
       {:ok, pid} = StreamCoordinator.start_link({"public", chain, key, opts})

--- a/test/lasso/core/streaming/stream_state_test.exs
+++ b/test/lasso/core/streaming/stream_state_test.exs
@@ -1,0 +1,47 @@
+defmodule Lasso.Core.Streaming.StreamStateTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.Core.Streaming.StreamState
+
+  test "an out-of-order head does not move the continuity marker backward" do
+    state = StreamState.new()
+
+    {state, :emit} = StreamState.ingest_new_head(state, head(102, "0x102"))
+    {state, :emit} = StreamState.ingest_new_head(state, head(101, "0x101"))
+
+    assert StreamState.last_block_num(state) == 102
+  end
+
+  test "a removed log is emitted after the canonical log" do
+    state = StreamState.new()
+    log = log(101, "0xblock", "0x0")
+
+    {state, :emit} = StreamState.ingest_log(state, Map.put(log, "removed", false))
+    {_state, decision} = StreamState.ingest_log(state, Map.put(log, "removed", true))
+
+    assert decision == :emit
+  end
+
+  test "an out-of-order log does not move the continuity marker backward" do
+    state = StreamState.new()
+
+    {state, :emit} = StreamState.ingest_log(state, log(102, "0x102", "0x0"))
+    {state, :emit} = StreamState.ingest_log(state, log(101, "0x101", "0x0"))
+
+    assert StreamState.last_log_block(state) == 102
+  end
+
+  defp head(number, hash) do
+    %{"number" => encode_hex(number), "hash" => hash}
+  end
+
+  defp log(number, block_hash, log_index) do
+    %{
+      "blockNumber" => encode_hex(number),
+      "blockHash" => block_hash,
+      "logIndex" => log_index
+    }
+  end
+
+  defp encode_hex(number), do: "0x" <> Integer.to_string(number, 16)
+end

--- a/test/lasso/rpc/continuity_policy_test.exs
+++ b/test/lasso/rpc/continuity_policy_test.exs
@@ -4,8 +4,9 @@ defmodule Lasso.RPC.ContinuityPolicyTest do
   alias Lasso.Core.Support.ContinuityPolicy
 
   describe "needed_block_range/4" do
-    test "returns :none when head is at last_seen + 1" do
-      assert ContinuityPolicy.needed_block_range(100, 101, 32, :best_effort) == {:none}
+    test "backfills the next block because it may have arrived before replacement subscribed" do
+      assert ContinuityPolicy.needed_block_range(100, 101, 32, :best_effort) ==
+               {:range, 101, 101}
     end
 
     test "returns :none when head is behind last_seen" do

--- a/test/lasso/rpc/upstream_subscription_pool_test.exs
+++ b/test/lasso/rpc/upstream_subscription_pool_test.exs
@@ -19,73 +19,78 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
   use ExUnit.Case, async: false
 
-  alias Lasso.Core.Streaming.UpstreamSubscriptionPool
+  alias Lasso.Core.Streaming.{ClientSubscriptionRegistry, UpstreamSubscriptionPool}
   alias Lasso.Testing.MockWSProvider
 
   @default_profile "public"
+  # Synthetic chain_id base outside registry range
+  @chain_id_base 4_217_500
 
   setup do
     suffix = System.unique_integer([:positive])
-    test_chain = suffix
+    test_chain_id = @chain_id_base + rem(suffix, 100_000)
     test_provider = "mock_provider_#{suffix}"
     test_profile = @default_profile
 
     {:ok, ^test_provider} =
-      MockWSProvider.start_mock(test_chain, %{
+      MockWSProvider.start_mock(test_chain_id, %{
         id: test_provider,
         auto_confirm: true,
         priority: 1
       })
 
-    Process.sleep(200)
+    :ok = wait_for_ws_channel(test_profile, test_chain_id, test_provider)
 
     instance_id =
-      Lasso.Providers.Catalog.lookup_instance_id(test_profile, test_chain, test_provider)
+      Lasso.Providers.Catalog.lookup_instance_id(test_profile, test_chain_id, test_provider)
 
     on_exit(fn ->
-      MockWSProvider.stop_mock(test_chain, test_provider)
-      Lasso.ProfileChainSupervisor.stop_profile_chain(test_profile, test_chain)
-      Lasso.Config.ConfigStore.unregister_chain_runtime(test_profile, test_chain)
+      MockWSProvider.stop_mock(test_chain_id, test_provider)
+      Lasso.ProfileChainSupervisor.stop_profile_chain(test_profile, test_chain_id)
+      Lasso.Config.ConfigStore.unregister_chain_runtime(test_profile, test_chain_id)
       Process.sleep(50)
     end)
 
     {:ok,
-     chain: test_chain, provider: test_provider, profile: test_profile, instance_id: instance_id}
+     chain_id: test_chain_id,
+     provider: test_provider,
+     profile: test_profile,
+     instance_id: instance_id}
   end
 
   describe "refcount lifecycle and consistency" do
     test "maintains correct refcount through subscribe/unsubscribe cycle", %{
-      chain: chain,
+      chain_id: chain_id,
       profile: profile
     } do
       client1 = spawn(fn -> Process.sleep(:infinity) end)
       key = {:newHeads}
-      {:ok, sub1} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client1, key)
+      {:ok, sub1} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client1, key)
 
-      Process.sleep(150)
+      :ok = wait_until_key_active(chain_id, key)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].refcount == 1
       assert map_size(state.keys) == 1
 
       client2 = spawn(fn -> Process.sleep(:infinity) end)
-      {:ok, sub2} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client2, key)
+      {:ok, sub2} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client2, key)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].refcount == 2
       assert map_size(state.keys) == 1
 
-      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain, sub1)
-      Process.sleep(10)
+      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, sub1)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].refcount == 1
       assert state.keys[key] != nil
 
-      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain, sub2)
-      Process.sleep(100)
+      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, sub2)
 
-      state = get_pool_state(chain)
+      :ok = wait_until_keys_empty(chain_id)
+
+      state = get_pool_state(chain_id)
       assert state.keys == %{}
 
       Process.exit(client1, :kill)
@@ -95,7 +100,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
   describe "subscription state consistency" do
     test "keys map tracks primary_provider_id and instance_id correctly", %{
-      chain: chain,
+      chain_id: chain_id,
       profile: profile
     } do
       client = spawn(fn -> Process.sleep(:infinity) end)
@@ -103,12 +108,13 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       key1 = {:newHeads}
       key2 = {:logs, %{"address" => "0x123"}}
 
-      {:ok, sub1} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key1)
-      {:ok, sub2} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key2)
+      {:ok, sub1} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key1)
+      {:ok, sub2} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key2)
 
-      Process.sleep(200)
+      :ok = wait_until_key_active(chain_id, key1)
+      :ok = wait_until_key_active(chain_id, key2)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key1].primary_provider_id != nil
       assert state.keys[key2].primary_provider_id != nil
       assert state.keys[key1].instance_id != nil
@@ -116,17 +122,17 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       assert state.keys[key1].status == :active
       assert state.keys[key2].status == :active
 
-      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain, sub1)
-      Process.sleep(100)
+      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, sub1)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key1] == nil
       assert state.keys[key2] != nil
 
-      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain, sub2)
-      Process.sleep(100)
+      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, sub2)
 
-      state = get_pool_state(chain)
+      :ok = wait_until_keys_empty(chain_id)
+
+      state = get_pool_state(chain_id)
       assert state.keys == %{}
 
       Process.exit(client, :kill)
@@ -134,25 +140,44 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
   end
 
   describe "error handling boundaries" do
-    test "handles resubscribe when key no longer exists", %{chain: chain, profile: profile} do
+    test "rejects an unknown provider constraint without mutating pool state", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
+      assert {:error, %Lasso.JSONRPC.Error{code: -32_602}} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads},
+                 provider_id: "missing-provider"
+               )
+
+      assert get_pool_state(chain_id).keys == %{}
+    end
+
+    test "handles resubscribe when key no longer exists", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
       key = {:newHeads}
       coordinator_pid = self()
 
       GenServer.cast(
-        UpstreamSubscriptionPool.via(profile, chain),
+        UpstreamSubscriptionPool.via(profile, chain_id),
         {:resubscribe, key, "provider_2", coordinator_pid}
       )
 
       assert_receive {:subscription_failed, _reason}, 1000
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys == %{}
     end
   end
 
-  describe "provider readiness recovery" do
-    test "wakes a routed subscription when its provider reconnects", %{
-      chain: chain,
+  describe "provider constraints and readiness" do
+    test "reconsiders a transiently unavailable provider for a routed subscription", %{
+      chain_id: chain_id,
       provider: provider,
       profile: profile,
       instance_id: instance_id
@@ -169,15 +194,19 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
                ) == {:error, :not_connected}
              end)
 
-      assert {:ok, _subscription_id} =
-               UpstreamSubscriptionPool.subscribe_client(profile, chain, self(), {:newHeads})
+      client_pid = self()
+
+      subscribe_task =
+        Task.async(fn ->
+          UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client_pid, {:newHeads})
+        end)
 
       Process.sleep(25)
-      assert get_pool_state(chain).keys[{:newHeads}].status == :establishing
+      assert get_pool_state(chain_id).keys[{:newHeads}].status == :establishing
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
-        Lasso.Topics.ws_connection(profile, chain),
+        Lasso.Topics.ws_connection(profile, chain_id),
         {:ws_connected, provider, "conn-ready-routed"}
       )
 
@@ -187,75 +216,328 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
         {:ws_connected, instance_id, "conn-ready-routed"}
       )
 
-      assert TestHelper.eventually(fn ->
-               get_pool_state(chain).keys[{:newHeads}].status == :active
-             end)
+      :ok = wait_for_ws_channel(profile, chain_id, provider)
+      :ok = wait_until_key_active(chain_id, {:newHeads})
+      assert {:ok, _subscription_id} = Task.await(subscribe_task)
 
-      entry = get_pool_state(chain).keys[{:newHeads}]
+      entry = get_pool_state(chain_id).keys[{:newHeads}]
       assert entry.primary_provider_id == provider
       assert entry.provider_constraint == nil
     end
 
-    test "a stale readiness retry cannot resurrect an unsubscribed key", %{
-      chain: chain,
+    test "an active sole-provider route terminates and can be re-established after reconnect", %{
+      chain_id: chain_id,
       provider: provider,
-      profile: profile
+      profile: profile,
+      instance_id: instance_id
     } do
-      :ets.delete(:transport_channel_cache, {profile, chain, provider, :ws})
-
       assert {:ok, subscription_id} =
                UpstreamSubscriptionPool.subscribe_client(
                  profile,
-                 chain,
+                 chain_id,
+                 self(),
+                 {:newHeads}
+               )
+
+      :ok = wait_until_key_active(chain_id, {:newHeads})
+      [{manager_pid, _}] = Registry.lookup(Lasso.Registry, {:instance_sub_manager, instance_id})
+      send(manager_pid, {:ws_disconnected, instance_id, %{reason: :recovery_test}})
+      :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.provider_event(profile, chain_id),
+        %Lasso.Events.Provider.WSDisconnected{
+          ts: System.system_time(:millisecond),
+          chain_id: chain_id,
+          provider_id: provider,
+          reason: :recovery_test
+        }
+      )
+
+      assert_receive {:subscription_terminated, ^subscription_id, :continuity_exhausted}, 1_000
+      assert TestHelper.eventually(fn -> get_pool_state(chain_id).keys == %{} end)
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_connection(profile, chain_id),
+        {:ws_connected, provider, "conn-recovered"}
+      )
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_conn_instance(instance_id),
+        {:ws_connected, instance_id, "conn-recovered"}
+      )
+
+      :ok = wait_for_ws_channel(profile, chain_id, provider)
+
+      {:ok, replacement_subscription_id} =
+        UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:newHeads})
+
+      :ok = wait_until_key_active(chain_id, {:newHeads})
+      assert get_pool_state(chain_id).keys[{:newHeads}].refcount == 1
+
+      client_registry = :sys.get_state(ClientSubscriptionRegistry.via(profile, chain_id))
+      assert client_registry.by_id[replacement_subscription_id].client_pid == self()
+      assert client_registry.by_id[replacement_subscription_id].key == {:newHeads}
+
+      assert :ok =
+               UpstreamSubscriptionPool.unsubscribe_client(
+                 profile,
+                 chain_id,
+                 replacement_subscription_id
+               )
+    end
+
+    test "keeps routed subscriptions pending after provider readiness is exhausted", %{
+      chain_id: chain_id,
+      provider: provider,
+      profile: profile
+    } do
+      :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
+
+      client_pid = self()
+
+      subscribe_task =
+        Task.async(fn ->
+          UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client_pid, {:newHeads})
+        end)
+
+      pool = UpstreamSubscriptionPool.via(profile, chain_id)
+      Process.sleep(25)
+
+      entry = get_pool_state(chain_id).keys[{:newHeads}]
+      generation = entry.establishment_generation
+      token = entry.retry_token
+      assert is_reference(token)
+
+      send(GenServer.whereis(pool), {:retry_establish, {:newHeads}, generation, make_ref(), []})
+      Process.sleep(50)
+
+      unchanged_entry = get_pool_state(chain_id).keys[{:newHeads}]
+      assert unchanged_entry.status == :establishing
+      assert unchanged_entry.refcount == 1
+      assert unchanged_entry.retry_token == token
+
+      Process.sleep(700)
+      bounded_entry = get_pool_state(chain_id).keys[{:newHeads}]
+      assert bounded_entry.readiness_retries <= 4
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_connection(profile, chain_id),
+        {:ws_connected, provider, "conn-ready-after-exhaustion"}
+      )
+
+      :ok = wait_for_ws_channel(profile, chain_id, provider)
+      :ok = wait_until_key_active(chain_id, {:newHeads})
+      assert {:ok, _subscription_id} = Task.await(subscribe_task)
+    end
+
+    test "waits for the constrained provider channel and activates on that provider", %{
+      chain_id: chain_id,
+      provider: provider,
+      profile: profile
+    } do
+      :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
+
+      client_pid = self()
+
+      subscribe_task =
+        Task.async(fn ->
+          UpstreamSubscriptionPool.subscribe_client(
+            profile,
+            chain_id,
+            client_pid,
+            {:newHeads},
+            provider_id: provider
+          )
+        end)
+
+      pool_key = {:route, provider, {:newHeads}}
+
+      Process.sleep(25)
+      assert get_pool_state(chain_id).keys[pool_key].status == :establishing
+
+      Phoenix.PubSub.broadcast(
+        Lasso.PubSub,
+        Lasso.Topics.ws_connection(profile, chain_id),
+        {:ws_connected, provider, "conn-ready"}
+      )
+
+      :ok = wait_for_ws_channel(profile, chain_id, provider)
+      :ok = wait_until_key_active(chain_id, pool_key)
+
+      entry = get_pool_state(chain_id).keys[pool_key]
+      assert entry.primary_provider_id == provider
+      assert entry.provider_constraint == provider
+      assert {:ok, _subscription_id} = Task.await(subscribe_task)
+    end
+
+    test "selects a lower-priority constrained provider", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
+      secondary = "secondary_#{System.unique_integer([:positive])}"
+
+      assert {:ok, ^secondary} =
+               MockWSProvider.start_mock(chain_id, %{
+                 id: secondary,
+                 auto_confirm: true,
+                 priority: 2
+               })
+
+      :ok = wait_for_ws_channel(profile, chain_id, secondary)
+
+      assert {:ok, _subscription_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads},
+                 provider_id: secondary
+               )
+
+      pool_key = {:route, secondary, {:newHeads}}
+      :ok = wait_until_key_active(chain_id, pool_key)
+      assert get_pool_state(chain_id).keys[pool_key].primary_provider_id == secondary
+    end
+
+    test "keeps constrained and routed subscriptions independent", %{
+      chain_id: chain_id,
+      provider: provider,
+      profile: profile
+    } do
+      assert {:ok, _subscription_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
                  self(),
                  {:newHeads},
                  provider_id: provider
                )
 
+      assert {:ok, _subscription_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads}
+               )
+
+      pool_key = {:route, provider, {:newHeads}}
+      :ok = wait_until_key_active(chain_id, pool_key)
+      :ok = wait_until_key_active(chain_id, {:newHeads})
+
+      state = get_pool_state(chain_id)
+      assert state.keys[pool_key].refcount == 1
+      assert state.keys[{:newHeads}].refcount == 1
+    end
+
+    test "unsubscribing one routing group preserves another shared upstream", %{
+      chain_id: chain_id,
+      provider: provider,
+      profile: profile,
+      instance_id: instance_id
+    } do
+      assert {:ok, constrained_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads},
+                 provider_id: provider
+               )
+
+      assert {:ok, routed_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads}
+               )
+
+      constrained_key = {:route, provider, {:newHeads}}
+      :ok = wait_until_key_active(chain_id, constrained_key)
+      :ok = wait_until_key_active(chain_id, {:newHeads})
+
       assert :ok =
-               UpstreamSubscriptionPool.unsubscribe_client(profile, chain, subscription_id)
+               UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, constrained_id)
+
+      assert get_pool_state(chain_id).keys[{:newHeads}].status == :active
+
+      assert Lasso.Core.Streaming.InstanceSubscriptionRegistry.has_consumers?(
+               instance_id,
+               {:newHeads}
+             )
+
+      assert :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, routed_id)
+    end
+
+    test "a timed out establishment is client-visible and cannot be resurrected", %{
+      chain_id: chain_id,
+      provider: provider,
+      profile: profile
+    } do
+      :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
+
+      deadline_us = System.monotonic_time(:microsecond) + 100_000
+
+      assert {:error, :timeout} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads},
+                 provider_id: provider,
+                 request_owner_pid: self(),
+                 deadline_us: deadline_us
+               )
+
+      assert get_pool_state(chain_id).keys == %{}
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
-        Lasso.Topics.ws_connection(profile, chain),
+        Lasso.Topics.ws_connection(profile, chain_id),
         {:ws_connected, provider, "conn-after-unsubscribe"}
       )
 
       Process.sleep(150)
-      assert get_pool_state(chain).keys == %{}
+      assert get_pool_state(chain_id).keys == %{}
     end
   end
 
   describe "async subscription behavior" do
-    test "first subscriber gets immediate response while upstream establishes", %{
-      chain: chain,
+    test "first subscriber receives an id after upstream establishment", %{
+      chain_id: chain_id,
       profile: profile
     } do
       client = spawn(fn -> Process.sleep(:infinity) end)
       key = {:newHeads}
 
       start_time = System.monotonic_time(:millisecond)
-      {:ok, sub_id} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key)
+      {:ok, sub_id} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key)
       elapsed = System.monotonic_time(:millisecond) - start_time
 
       assert elapsed < 100
       assert is_binary(sub_id)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].status in [:establishing, :active]
       assert state.keys[key].refcount == 1
 
-      Process.sleep(200)
+      :ok = wait_until_key_active(chain_id, key)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].status == :active
       assert state.keys[key].primary_provider_id != nil
 
       Process.exit(client, :kill)
     end
 
-    test "multiple subscribers during establishment all get immediate response", %{
-      chain: chain,
+    test "multiple subscribers share the established upstream subscription", %{
+      chain_id: chain_id,
       profile: profile
     } do
       key = {:newHeads}
@@ -267,85 +549,187 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
       sub_ids =
         Enum.map(clients, fn client ->
-          {:ok, sub_id} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key)
+          {:ok, sub_id} =
+            UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key)
+
           sub_id
         end)
 
       assert length(Enum.uniq(sub_ids)) == 5
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].status in [:establishing, :active]
       assert state.keys[key].refcount == 5
 
-      Process.sleep(200)
+      :ok = wait_until_key_active(chain_id, key)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].status == :active
 
       Enum.each(clients, fn client -> Process.exit(client, :kill) end)
     end
 
-    test "client unsubscribes during or after establishment", %{chain: chain, profile: profile} do
+    test "subscription acknowledgement waits for the upstream confirmation", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
+      delayed = "delayed_#{System.unique_integer([:positive])}"
+
+      assert {:ok, ^delayed} =
+               MockWSProvider.start_mock(chain_id, %{
+                 id: delayed,
+                 auto_confirm: true,
+                 confirm_delay: 150,
+                 priority: 2
+               })
+
+      :ok = wait_for_ws_channel(profile, chain_id, delayed)
+
+      started_at = System.monotonic_time(:millisecond)
+
+      assert {:ok, subscription_id} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads},
+                 provider_id: delayed
+               )
+
+      elapsed_ms = System.monotonic_time(:millisecond) - started_at
+      assert is_binary(subscription_id)
+      assert elapsed_ms >= 100
+
+      pool_key = {:route, delayed, {:newHeads}}
+      assert get_pool_state(chain_id).keys[pool_key].status == :active
+    end
+
+    test "a slow upstream response cannot exceed the caller establishment deadline", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
+      delayed = "deadline-delayed-#{System.unique_integer([:positive])}"
+
+      assert {:ok, ^delayed} =
+               MockWSProvider.start_mock(chain_id, %{
+                 id: delayed,
+                 auto_confirm: true,
+                 confirm_delay: 1_000,
+                 priority: 2
+               })
+
+      :ok = wait_for_ws_channel(profile, chain_id, delayed)
+
+      {:ok, _primary_subscription} =
+        UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:newHeads})
+
+      deadline_us = System.monotonic_time(:microsecond) + 150_000
+      started_at = System.monotonic_time(:millisecond)
+      test_pid = self()
+
+      delayed_task =
+        Task.async(fn ->
+          UpstreamSubscriptionPool.subscribe_client(
+            profile,
+            chain_id,
+            test_pid,
+            {:newHeads},
+            provider_id: delayed,
+            request_owner_pid: test_pid,
+            deadline_us: deadline_us
+          )
+        end)
+
+      delayed_key = {:route, delayed, {:newHeads}}
+
+      assert TestHelper.eventually(fn ->
+               case get_pool_state(chain_id).keys[delayed_key] do
+                 %{establishment_attempt_pid: pid} when is_pid(pid) -> true
+                 _ -> false
+               end
+             end)
+
+      active_started_at = System.monotonic_time(:millisecond)
+
+      assert {:ok, _shared_subscription} =
+               UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:newHeads})
+
+      assert System.monotonic_time(:millisecond) - active_started_at < 100
+      assert {:error, :timeout} = Task.await(delayed_task)
+
+      assert System.monotonic_time(:millisecond) - started_at < 500
+      assert TestHelper.eventually(fn -> is_nil(get_pool_state(chain_id).keys[delayed_key]) end)
+    end
+
+    test "client unsubscribes during or after establishment", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
       client = spawn(fn -> Process.sleep(:infinity) end)
       key = {:newHeads}
 
-      {:ok, sub_id} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key)
+      {:ok, sub_id} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key] != nil
       assert state.keys[key].status in [:establishing, :active]
 
-      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain, sub_id)
-      Process.sleep(50)
+      :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, sub_id)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys == %{}
 
-      Process.sleep(200)
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys == %{}
 
       Process.exit(client, :kill)
     end
 
     test "rapid subscribe/unsubscribe cycles maintain consistency", %{
-      chain: chain,
+      chain_id: chain_id,
       profile: profile
     } do
       key = {:newHeads}
 
       for _ <- 1..10 do
         client = spawn(fn -> Process.sleep(:infinity) end)
-        {:ok, sub_id} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key)
+
+        {:ok, sub_id} =
+          UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key)
+
         Process.sleep(5)
-        :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain, sub_id)
+        :ok = UpstreamSubscriptionPool.unsubscribe_client(profile, chain_id, sub_id)
         Process.exit(client, :kill)
       end
 
-      Process.sleep(300)
+      :ok = wait_until_keys_empty(chain_id)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys == %{}
     end
 
-    test "subsequent subscribers after activation are instant", %{chain: chain, profile: profile} do
+    test "subsequent subscribers after activation are instant", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
       key = {:newHeads}
 
       client1 = spawn(fn -> Process.sleep(:infinity) end)
-      {:ok, _sub1} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client1, key)
+      {:ok, _sub1} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client1, key)
 
-      Process.sleep(200)
-      state = get_pool_state(chain)
+      :ok = wait_until_key_active(chain_id, key)
+
+      state = get_pool_state(chain_id)
       assert state.keys[key].status == :active
 
       client2 = spawn(fn -> Process.sleep(:infinity) end)
       start_time = System.monotonic_time(:millisecond)
-      {:ok, _sub2} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client2, key)
+      {:ok, _sub2} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client2, key)
       elapsed = System.monotonic_time(:millisecond) - start_time
 
       assert elapsed < 50
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       assert state.keys[key].refcount == 2
 
       Process.exit(client1, :kill)
@@ -354,18 +738,63 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
   end
 
   describe "transitioning_from race condition handling" do
-    test "tracks transitioning_from during resubscribe", %{chain: chain, profile: profile} do
+    test "slow replacement establishment does not block active subscription calls", %{
+      chain_id: chain_id,
+      profile: profile
+    } do
+      secondary = "slow-replacement-#{System.unique_integer([:positive])}"
+
+      assert {:ok, ^secondary} =
+               MockWSProvider.start_mock(chain_id, %{
+                 id: secondary,
+                 auto_confirm: true,
+                 confirm_delay: 1_000,
+                 priority: 2
+               })
+
+      :ok = wait_for_ws_channel(profile, chain_id, secondary)
+
+      {:ok, _first_subscription} =
+        UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:newHeads})
+
+      GenServer.cast(
+        UpstreamSubscriptionPool.via(profile, chain_id),
+        {:resubscribe, {:newHeads}, secondary, self()}
+      )
+
+      assert TestHelper.eventually(fn ->
+               case get_pool_state(chain_id).keys[{:newHeads}] do
+                 %{resubscribe_pid: pid} when is_pid(pid) -> true
+                 _ -> false
+               end
+             end)
+
+      started_at = System.monotonic_time(:millisecond)
+
+      assert {:ok, _shared_subscription} =
+               UpstreamSubscriptionPool.subscribe_client(
+                 profile,
+                 chain_id,
+                 self(),
+                 {:newHeads}
+               )
+
+      assert System.monotonic_time(:millisecond) - started_at < 100
+      assert_receive {:subscription_confirmed, ^secondary, nil}, 2_000
+    end
+
+    test "tracks transitioning_from during resubscribe", %{chain_id: chain_id, profile: profile} do
       client = spawn(fn -> Process.sleep(:infinity) end)
       key = {:newHeads}
 
-      {:ok, _sub} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key)
-      Process.sleep(200)
+      {:ok, _sub} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key)
+      :ok = wait_until_key_active(chain_id, key)
 
-      state = get_pool_state(chain)
+      state = get_pool_state(chain_id)
       _old_provider = state.keys[key].primary_provider_id
 
       GenServer.cast(
-        UpstreamSubscriptionPool.via(profile, chain),
+        UpstreamSubscriptionPool.via(profile, chain_id),
         {:resubscribe, key, "provider_2", self()}
       )
 
@@ -382,35 +811,116 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
   describe "manager restart recovery" do
     test "pool re-establishes subscriptions after manager restart broadcast", %{
-      chain: chain,
+      chain_id: chain_id,
       profile: profile,
       instance_id: instance_id
     } do
       client = spawn(fn -> Process.sleep(:infinity) end)
       key = {:newHeads}
 
-      {:ok, _sub} = UpstreamSubscriptionPool.subscribe_client(profile, chain, client, key)
-      Process.sleep(200)
+      {:ok, _sub} = UpstreamSubscriptionPool.subscribe_client(profile, chain_id, client, key)
+      :ok = wait_until_key_active(chain_id, key)
 
-      state_before = get_pool_state(chain)
+      state_before = get_pool_state(chain_id)
       assert state_before.keys[key].status == :active
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
-        "instance_sub_manager:restarted:#{chain}",
+        Lasso.Topics.instance_sub_manager_restarted(chain_id),
         {:instance_sub_manager_restarted, instance_id}
       )
 
-      Process.sleep(200)
+      :ok = wait_until_key_active(chain_id, key)
 
-      state_after = get_pool_state(chain)
+      state_after = get_pool_state(chain_id)
       assert state_after.keys[key].status == :active
 
       Process.exit(client, :kill)
     end
   end
 
-  defp get_pool_state(chain, profile \\ @default_profile) do
-    :sys.get_state(UpstreamSubscriptionPool.via(profile, chain))
+  test "coordinator loss terminates downstream subscriptions", %{
+    chain_id: chain_id,
+    profile: profile
+  } do
+    {:ok, subscription_id} =
+      UpstreamSubscriptionPool.subscribe_client(profile, chain_id, self(), {:newHeads})
+
+    coordinator =
+      GenServer.whereis(
+        Lasso.Core.Streaming.StreamCoordinator.via(profile, chain_id, {:newHeads})
+      )
+
+    assert is_pid(coordinator)
+    Process.exit(coordinator, :kill)
+
+    assert_receive {:subscription_terminated, ^subscription_id, :continuity_exhausted}, 1_000
+    assert TestHelper.eventually(fn -> get_pool_state(chain_id).keys == %{} end)
+  end
+
+  defp get_pool_state(chain_id, profile \\ @default_profile) do
+    :sys.get_state(UpstreamSubscriptionPool.via(profile, chain_id))
+  end
+
+  defp wait_for_ws_channel(profile, chain_id, provider, timeout_ms \\ 2000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_for_ws_channel(profile, chain_id, provider, deadline)
+  end
+
+  defp do_wait_for_ws_channel(profile, chain_id, provider, deadline) do
+    case :ets.lookup(:transport_channel_cache, {profile, chain_id, provider, :ws}) do
+      [_] ->
+        :ok
+
+      [] ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, :timeout}
+        else
+          Process.sleep(10)
+          do_wait_for_ws_channel(profile, chain_id, provider, deadline)
+        end
+    end
+  end
+
+  defp wait_until_key_active(chain_id, key, profile \\ @default_profile, timeout_ms \\ 2000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until_key_active(chain_id, key, profile, deadline)
+  end
+
+  defp do_wait_until_key_active(chain_id, key, profile, deadline) do
+    state = get_pool_state(chain_id, profile)
+
+    case Map.get(state.keys, key) do
+      %{status: :active} ->
+        :ok
+
+      _ ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, :timeout}
+        else
+          Process.sleep(10)
+          do_wait_until_key_active(chain_id, key, profile, deadline)
+        end
+    end
+  end
+
+  defp wait_until_keys_empty(chain_id, profile \\ @default_profile, timeout_ms \\ 2000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until_keys_empty(chain_id, profile, deadline)
+  end
+
+  defp do_wait_until_keys_empty(chain_id, profile, deadline) do
+    state = get_pool_state(chain_id, profile)
+
+    if state.keys == %{} do
+      :ok
+    else
+      if System.monotonic_time(:millisecond) >= deadline do
+        {:error, :timeout}
+      else
+        Process.sleep(10)
+        do_wait_until_keys_empty(chain_id, profile, deadline)
+      end
+    end
   end
 end

--- a/test/lasso_web/sockets/rpc_socket_item_owner_test.exs
+++ b/test/lasso_web/sockets/rpc_socket_item_owner_test.exs
@@ -475,6 +475,27 @@ defmodule LassoWeb.RPCSocketItemOwnerTest do
     assert state.forwarded_item_counts.stale_subscription_event == 1
   end
 
+  test "continuity exhaustion closes a socket that owns the subscription" do
+    state = %{socket_state() | subscriptions: %{"sub-1" => true}}
+
+    assert {:stop, :continuity_exhausted, {1011, "Lasso subscription continuity exhausted"},
+            ^state} =
+             RPCSocket.handle_info(
+               {:subscription_terminated, "sub-1", :continuity_exhausted},
+               state
+             )
+  end
+
+  test "continuity exhaustion for an unknown subscription leaves the socket open" do
+    state = socket_state()
+
+    assert {:ok, ^state} =
+             RPCSocket.handle_info(
+               {:subscription_terminated, "unknown", :continuity_exhausted},
+               state
+             )
+  end
+
   test "production subscription owner rejects an already-expired scope before validation" do
     item_ref = make_ref()
     now_us = System.monotonic_time(:microsecond)

--- a/test/support/lasso/testing/mock_ws_provider.ex
+++ b/test/support/lasso/testing/mock_ws_provider.ex
@@ -355,6 +355,8 @@ defmodule Lasso.Testing.MockWSProvider do
     # Handle eth_subscribe specially to return subscription ID synchronously
     case method do
       "eth_subscribe" ->
+        if state.confirm_delay > 0, do: Process.sleep(state.confirm_delay)
+
         # Generate subscription ID first
         sub_id = generate_sub_id(state)
 


### PR DESCRIPTION
## Summary

- upstream the reviewed WebSocket subscription continuity state machine from Lasso Cloud
- acknowledge subscriptions only after bounded upstream establishment
- establish replacements before replay, merge replay with bounded buffered live events, and preserve monotonic/deduplicated delivery
- surface replay overflow, recovery exhaustion, coordinator loss, and provider exhaustion as client-visible terminal failures
- keep establishment and replacement work off the shared pool process and make cleanup race-safe

## Source and scope

This is the generic routing portion of [Lasso Cloud PR #606](https://github.com/jaxernst/lasso-cloud/pull/606), whose 30-minute launch evidence recorded 119 forced failovers with zero gaps and zero replay-created duplicates. Cloud-only launch documents and the opt-in soak harness are intentionally excluded from OSS; durable behavior documentation remains in `docs/RPC_STANDARDS.md`.

No authentication, billing, metering, entitlement, persistence, or other proprietary Cloud code is included.

## Verification

- `mix format`
- `mix compile --warnings-as-errors`
- focused continuity/integration suite: 89 tests, 0 failures
- full `mix test --include integration`: 1,545 tests, 0 failures
- `mix credo --strict`
- proprietary-marker scan of every changed file
- `git diff --check`

Part of [Cloud reconciliation #607](https://github.com/jaxernst/lasso-cloud/issues/607).
