### PR TITLE
Reconcile dashboard routing truth from Cloud

### DIFF
--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -62,6 +62,7 @@ defmodule Lasso.Application do
 
         # Task supervisor for async operations (needed by Topology)
         {Task.Supervisor, name: Lasso.TaskSupervisor},
+        LassoWeb.Dashboard.TrafficCounters,
 
         # Fixed, sharded admission ledger for aggregate in-flight request bytes.
         Lasso.Core.Request.ByteBudget,

--- a/lib/lasso/core/request/request_projection.ex
+++ b/lib/lasso/core/request/request_projection.ex
@@ -1,8 +1,10 @@
 defmodule Lasso.RPC.RequestProjection do
   @moduledoc false
 
+  alias Lasso.Core.Benchmarking.Metrics
   alias Lasso.Core.ProjectionDispatcher
   alias Lasso.Events.RoutingDecision
+  alias LassoWeb.Dashboard.TrafficCounters
 
   alias Lasso.RPC.{
     AttemptIdentity,
@@ -67,6 +69,7 @@ defmodule Lasso.RPC.RequestProjection do
 
   @spec enqueue(t(), atom()) :: term()
   def enqueue(%__MODULE__{} = event, dispatcher \\ @dispatcher) when is_atom(dispatcher) do
+    _counter_result = TrafficCounters.record(event)
     enqueue_lazy(event, dispatcher, fn -> encode(event) end)
   end
 
@@ -89,7 +92,7 @@ defmodule Lasso.RPC.RequestProjection do
       )
       when is_atom(dispatcher) do
     event = new(fact, method, route_identity, failover_count, request_origin)
-    enqueue_lazy(event, dispatcher, fn -> encode_validated(event) end)
+    enqueue(event, dispatcher)
   end
 
   @spec record_and_enqueue(
@@ -109,9 +112,11 @@ defmodule Lasso.RPC.RequestProjection do
         dispatcher \\ @dispatcher
       )
       when is_atom(dispatcher) do
+    _counter_result = TrafficCounters.record_request(fact, request_origin, failover_count)
+
     case RequestAggregate.record_and_reserve_detail(fact, request_origin) do
       :detail ->
-        new_and_enqueue(
+        new_and_enqueue_without_counting(
           fact,
           method,
           route_identity,
@@ -124,7 +129,7 @@ defmodule Lasso.RPC.RequestProjection do
         {:drop, :sampled_out, :untracked}
 
       :untracked ->
-        new_and_enqueue(
+        new_and_enqueue_without_counting(
           fact,
           method,
           route_identity,
@@ -133,6 +138,18 @@ defmodule Lasso.RPC.RequestProjection do
           dispatcher
         )
     end
+  end
+
+  defp new_and_enqueue_without_counting(
+         fact,
+         method,
+         route_identity,
+         failover_count,
+         request_origin,
+         dispatcher
+       ) do
+    event = new(fact, method, route_identity, failover_count, request_origin)
+    enqueue_lazy(event, dispatcher, fn -> encode_validated(event) end)
   end
 
   defp enqueue_lazy(event, dispatcher, encoder) do
@@ -348,8 +365,30 @@ defmodule Lasso.RPC.RequestProjection do
     publish_routing_decision(event)
     emit_terminal_telemetry(event)
     emit_request_telemetry(event)
+    record_dashboard_metric(event)
     :ok
   end
+
+  defp record_dashboard_metric(%__MODULE__{
+         request_origin: :client,
+         provider_id: provider_id,
+         transport: transport,
+         fact: fact,
+         method: method
+       })
+       when is_binary(provider_id) and transport in [:http, :ws] do
+    Metrics.record_request(
+      Map.fetch!(fact, :profile),
+      Map.fetch!(fact, :chain_id),
+      provider_id,
+      method,
+      div(Map.fetch!(fact, :elapsed_us), 1_000),
+      result(fact),
+      transport: transport
+    )
+  end
+
+  defp record_dashboard_metric(%__MODULE__{}), do: :ok
 
   defp publish_routing_decision(event) do
     with {:ok, decision} <- routing_decision(event),

--- a/lib/lasso_web/dashboard/components/activity_feed_panel.ex
+++ b/lib/lasso_web/dashboard/components/activity_feed_panel.ex
@@ -47,8 +47,16 @@ defmodule LassoWeb.Dashboard.Components.ActivityFeedPanel do
           <% else %>
             <div
               data-event-id={e[:ts_ms]}
+              data-request-origin={e[:request_origin] || :client}
               class="text-[9px] text-gray-300 flex items-center gap-1 shrink-0"
             >
+              <span
+                :if={e[:request_origin] in [:system, "system"]}
+                class="inline-flex items-center rounded bg-gray-700/50 px-1 py-px text-[7px] font-bold tracking-wide text-gray-400"
+                title="Internal provider health or synchronization request"
+              >
+                SYSTEM
+              </span>
               <span class="text-purple-300">{e.chain}</span>
               <span class="text-sky-300">{e.method}</span>
               → <span class="text-emerald-300">{String.slice(e.provider_id || "", 0, 14)}…</span>

--- a/lib/lasso_web/dashboard/components/provider_details_panel.ex
+++ b/lib/lasso_web/dashboard/components/provider_details_panel.ex
@@ -74,6 +74,7 @@ defmodule LassoWeb.Dashboard.Components.ProviderDetailsPanel do
       consensus_height: nil,
       optimistic_lag: nil,
       effective_lag: 0,
+      height_estimated?: false,
       sync_status: :healthy,
       mode: :aggregate
     })
@@ -206,7 +207,8 @@ defmodule LassoWeb.Dashboard.Components.ProviderDetailsPanel do
          chain_consensus
        ) do
     conn = provider_connection || %{}
-    chain = Map.get(conn, :chain)
+    chain_id = Map.get(conn, :chain_id)
+    instance_id = Map.get(conn, :instance_id) || provider_id
 
     {block_height, block_lag, consensus_height} =
       resolve_block_heights(
@@ -219,8 +221,8 @@ defmodule LassoWeb.Dashboard.Components.ProviderDetailsPanel do
       )
 
     optimistic_lag =
-      if chain do
-        case StatusHelpers.calculate_optimistic_lag(chain, provider_id) do
+      if is_integer(chain_id) do
+        case StatusHelpers.calculate_optimistic_lag(chain_id, instance_id) do
           {:ok, lag} -> lag
           {:error, _} -> nil
         end
@@ -228,7 +230,14 @@ defmodule LassoWeb.Dashboard.Components.ProviderDetailsPanel do
         nil
       end
 
-    effective_lag = resolve_effective_lag(block_lag, optimistic_lag, conn)
+    current_raw_lag =
+      if is_integer(block_height) and is_integer(consensus_height) do
+        block_height - consensus_height
+      else
+        block_lag
+      end
+
+    effective_lag = resolve_effective_lag(current_raw_lag, optimistic_lag, conn)
 
     display_block_height =
       if is_integer(optimistic_lag) and is_integer(consensus_height) and is_integer(block_height) do
@@ -242,6 +251,7 @@ defmodule LassoWeb.Dashboard.Components.ProviderDetailsPanel do
       consensus_height: consensus_height,
       optimistic_lag: optimistic_lag,
       effective_lag: effective_lag,
+      height_estimated?: display_block_height != block_height,
       sync_status: sync_status_level(effective_lag),
       mode: if(selected_region == "aggregate", do: :aggregate, else: :region)
     }
@@ -564,7 +574,7 @@ defmodule LassoWeb.Dashboard.Components.ProviderDetailsPanel do
       <div :if={@sync_data.block_height && @sync_data.consensus_height}>
         <div class="flex items-center justify-between text-sm mb-2">
           <span class="text-gray-400">
-            Block Height:
+            {if @sync_data.height_estimated?, do: "Estimated Height:", else: "Block Height:"}
             <span class="text-white font-mono">
               {Formatting.format_number(@sync_data.block_height)}
             </span>

--- a/lib/lasso_web/dashboard/dashboard.ex
+++ b/lib/lasso_web/dashboard/dashboard.ex
@@ -72,6 +72,7 @@ defmodule LassoWeb.Dashboard do
       |> assign(:selected_chain, nil)
       |> assign(:selected_provider, nil)
       |> assign(:routing_events, [])
+      |> assign(:traffic_metrics, nil)
       |> assign(:provider_events, [])
       |> assign(:latest_blocks, [])
       |> assign(:events, [])
@@ -227,6 +228,7 @@ defmodule LassoWeb.Dashboard do
     |> assign(:details_collapsed, true)
     |> assign(:events, [])
     |> assign(:routing_events, [])
+    |> assign(:traffic_metrics, nil)
     |> assign(:provider_events, [])
     |> assign(:metrics_selected_chain, default_metrics_chain)
     # Reset aggregator state for new profile
@@ -244,6 +246,8 @@ defmodule LassoWeb.Dashboard do
   # Coalesced batch from EventStream — single message per tick replaces individual handlers
   @impl true
   def handle_info({:dashboard_batch, batch}, socket) do
+    batch = Map.put_new(batch, :traffic_metrics, nil)
+
     socket =
       socket
       |> apply_health(batch.health)
@@ -252,6 +256,7 @@ defmodule LassoWeb.Dashboard do
       |> apply_cluster(batch.cluster)
       |> apply_node_ids(batch.node_ids)
       |> apply_metrics(batch.metrics)
+      |> apply_traffic_metrics(batch.traffic_metrics)
       |> apply_routing_events(batch.routing_events)
       |> apply_circuit_events(batch.circuit_events)
       |> apply_provider_events(batch.provider_events)
@@ -399,6 +404,7 @@ defmodule LassoWeb.Dashboard do
       |> assign(:cluster_status, cluster)
       |> assign(:available_node_ids, cluster.node_ids || [])
       |> assign(:metrics_coverage, %{responding: cluster.responding, total: cluster.connected})
+      |> apply_traffic_metrics(Map.get(snapshot, :traffic_metrics))
       |> recompute_provider_statuses()
       |> MessageHandlers.handle_events_snapshot(snapshot.events)
       |> refresh_selected_chain_events()
@@ -440,6 +446,7 @@ defmodule LassoWeb.Dashboard do
             <.dashboard_tab_content
               connections={@connections}
               routing_events={@routing_events}
+              traffic_metrics={@traffic_metrics}
               provider_events={@provider_events}
               latest_blocks={@latest_blocks}
               events={@events}
@@ -520,6 +527,7 @@ defmodule LassoWeb.Dashboard do
   # Dashboard tab content attrs
   attr(:connections, :list)
   attr(:routing_events, :list)
+  attr(:traffic_metrics, :map, default: nil)
   attr(:provider_events, :list)
   attr(:latest_blocks, :list)
   attr(:events, :list)
@@ -600,6 +608,7 @@ defmodule LassoWeb.Dashboard do
         details_collapsed={@details_collapsed}
         connections={@connections}
         routing_events={@routing_events}
+        traffic_metrics={@traffic_metrics}
         provider_events={@provider_events}
         latest_blocks={@latest_blocks}
         events={@events}
@@ -631,6 +640,7 @@ defmodule LassoWeb.Dashboard do
   attr(:details_collapsed, :boolean)
   attr(:connections, :list)
   attr(:routing_events, :list)
+  attr(:traffic_metrics, :map, default: nil)
   attr(:provider_events, :list)
   attr(:latest_blocks, :list)
   attr(:events, :list)
@@ -699,6 +709,7 @@ defmodule LassoWeb.Dashboard do
       |> assign(:status, status)
       |> assign(:title, title)
       |> assign(:on_toggle, on_toggle)
+      |> assign(:traffic_headline, traffic_headline(assigns.traffic_metrics))
 
     ~H"""
     <.floating_window
@@ -729,23 +740,23 @@ defmodule LassoWeb.Dashboard do
           <DetailPanelComponents.metrics_strip class="border-y border-gray-800">
             <:metric
               label="RPS"
-              value={format_rps(MetricsHelpers.rpc_calls_per_second(@routing_events))}
+              value={format_rps(@traffic_headline.rps)}
               value_class="text-sky-400"
             />
             <:metric
-              label={"Sampled success (#{MetricsHelpers.routing_sample_count(@routing_events)})"}
-              value={format_success_rate(MetricsHelpers.success_rate_percent(@routing_events))}
-              value_class={success_rate_class(MetricsHelpers.success_rate_percent(@routing_events))}
-              title="Delivered client routing events from the last 60 seconds. Optional diagnostics may be sampled under load."
+              label={"Success (#{@traffic_headline.count})"}
+              value={format_success_rate(@traffic_headline.success_rate)}
+              value_class={success_rate_class(@traffic_headline.success_rate)}
+              title="Client request outcomes from all responding cluster nodes over the last 60 seconds."
             />
             <:metric
               label="Latency"
-              value={format_latency(MetricsHelpers.avg_latency_ms(@routing_events))}
+              value={format_latency(@traffic_headline.latency_ms)}
               value_class="text-purple-400"
             />
             <:metric
               label="Failovers"
-              value={format_failovers(MetricsHelpers.failovers_last_minute(@routing_events))}
+              value={format_failovers(@traffic_headline.failovers)}
               value_class="text-yellow-300"
             />
           </DetailPanelComponents.metrics_strip>
@@ -763,8 +774,16 @@ defmodule LassoWeb.Dashboard do
               <%= for e <- Enum.take(@routing_events, 100) do %>
                 <div
                   data-event-id={e[:ts_ms]}
+                  data-request-origin={e[:request_origin] || :client}
                   class="text-[9px] text-gray-300 flex items-center gap-1 shrink-0"
                 >
+                  <span
+                    :if={e[:request_origin] in [:system, "system"]}
+                    class="inline-flex items-center rounded bg-gray-700/50 px-1 py-px text-[7px] font-bold tracking-wide text-gray-400"
+                    title="Internal provider health or synchronization request"
+                  >
+                    SYSTEM
+                  </span>
                   <span class="text-purple-300">{e[:chain]}</span>
                   <span class="text-sky-300">{e[:method]}</span>
                   →
@@ -1252,18 +1271,16 @@ defmodule LassoWeb.Dashboard do
   defp apply_block_states(socket, blocks) do
     current = socket.assigns.cluster_block_heights
 
-    {changed?, merged} =
-      Enum.reduce(blocks, {false, current}, fn {key, data}, {changed, acc} ->
-        new_entry = %{height: data.height, lag: data.lag}
-
-        if Map.get(acc, key) == new_entry do
-          {changed, acc}
+    merged =
+      Enum.reduce(blocks, current, fn {key, data}, acc ->
+        if data[:stale?] == true or is_nil(data.height) do
+          Map.delete(acc, key)
         else
-          {true, Map.put(acc, key, new_entry)}
+          Map.put(acc, key, %{height: data.height, lag: data.lag})
         end
       end)
 
-    if changed?, do: assign(socket, :cluster_block_heights, merged), else: socket
+    if merged == current, do: socket, else: assign(socket, :cluster_block_heights, merged)
   end
 
   defp apply_cluster(socket, nil), do: socket
@@ -1308,6 +1325,18 @@ defmodule LassoWeb.Dashboard do
     else
       socket
       |> assign(:live_provider_metrics, merged)
+      |> mark_not_stale()
+    end
+  end
+
+  defp apply_traffic_metrics(socket, nil), do: socket
+
+  defp apply_traffic_metrics(socket, traffic_metrics) do
+    if socket.assigns.traffic_metrics == traffic_metrics do
+      socket
+    else
+      socket
+      |> assign(:traffic_metrics, traffic_metrics)
       |> mark_not_stale()
     end
   end
@@ -1769,6 +1798,30 @@ defmodule LassoWeb.Dashboard do
   # Formatting helpers for metrics display
   defp format_success_rate(nil), do: "—"
   defp format_success_rate(rate), do: "#{rate}%"
+
+  defp traffic_headline(%{
+         count: count,
+         successes: successes,
+         errors: errors,
+         elapsed_us: elapsed_us,
+         failovers: failovers,
+         window_seconds: window_seconds,
+         coverage: %{responding: responding, total: total, lossless: true}
+       })
+       when responding == total and total > 0 and count == successes + errors and count >= 0 and
+              elapsed_us >= 0 and failovers >= 0 and window_seconds > 0 do
+    %{
+      count: count,
+      rps: Float.round(count / window_seconds, 1),
+      success_rate: if(count > 0, do: Float.round(successes * 100.0 / count, 1)),
+      latency_ms: if(count > 0, do: round(elapsed_us / count / 1_000)),
+      failovers: failovers
+    }
+  end
+
+  defp traffic_headline(_metrics) do
+    %{count: 0, rps: 0.0, success_rate: nil, latency_ms: nil, failovers: 0}
+  end
 
   defp success_rate_class(nil), do: "text-gray-500"
   defp success_rate_class(rate) when rate >= 99.0, do: "text-emerald-400"

--- a/lib/lasso_web/dashboard/event_stream.ex
+++ b/lib/lasso_web/dashboard/event_stream.ex
@@ -27,12 +27,12 @@ defmodule LassoWeb.Dashboard.EventStream do
   ## Messages Sent to Subscribers
 
   On subscribe (initial state):
-  - `{:dashboard_snapshot, %{metrics, circuits, health_counters, cluster, events}}`
+  - `{:dashboard_snapshot, %{metrics, traffic_metrics, circuits, health_counters, cluster, events}}`
 
   Batched updates (coalesced per 175ms tick):
-  - `{:dashboard_batch, %{health, circuit_states, block_states, cluster, metrics, node_ids,
-     heartbeat, routing_events, circuit_events, provider_events, subscription_events,
-     block_events, sync_updates, block_cache_updates}}`
+  - `{:dashboard_batch, %{health, circuit_states, block_states, cluster, metrics,
+     traffic_metrics, node_ids, heartbeat, routing_events, circuit_events, provider_events,
+     subscription_events, block_events, sync_updates, block_cache_updates}}`
 
   All event types are buffered and flushed as a single structured batch per tick.
   Latest-wins coalescing applies to health, circuit_states, block_states, cluster, and metrics.
@@ -45,6 +45,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   alias Lasso.Cluster.Topology
   alias Lasso.Config.ConfigStore
   alias Lasso.Events.{RoutingDecision, Subscription}
+  alias LassoWeb.Dashboard.TrafficCounters
 
   @batch_interval_ms 175
   @max_batch_size 100
@@ -59,6 +60,7 @@ defmodule LassoWeb.Dashboard.EventStream do
   @max_seen_request_ids 50_000
   @heartbeat_interval_ms 2_000
   @idle_timeout_ms 30_000
+  @traffic_refresh_interval_ms 1_000
 
   defstruct [
     :profile,
@@ -106,6 +108,7 @@ defmodule LassoWeb.Dashboard.EventStream do
     pending_block_states: %{},
     pending_cluster: nil,
     pending_metrics: nil,
+    pending_traffic_metrics: %{},
     # Accumulated lists
     pending_routing_events: [],
     pending_circuit_events: [],
@@ -116,7 +119,10 @@ defmodule LassoWeb.Dashboard.EventStream do
     pending_sync_updates: [],
     pending_block_cache_updates: [],
     # Flags
-    pending_heartbeat: false
+    pending_heartbeat: false,
+    traffic_metrics: %{},
+    traffic_task: nil,
+    last_traffic_refresh: 0
   ]
 
   # Client API
@@ -244,6 +250,8 @@ defmodule LassoWeb.Dashboard.EventStream do
        cluster_state: default_cluster_state(),
        last_tick: now,
        last_heartbeat: now - @heartbeat_interval_ms,
+       last_seen_ids_cleanup: now,
+       last_traffic_refresh: now - @traffic_refresh_interval_ms,
        tick_scheduled: false
      }, {:continue, :fetch_cluster_state}}
   end
@@ -266,6 +274,7 @@ defmodule LassoWeb.Dashboard.EventStream do
       |> maybe_cleanup(now)
       |> maybe_cleanup_seen_request_ids(now)
       |> maybe_set_heartbeat(now)
+      |> maybe_start_traffic_refresh(now)
       |> flush_pending()
 
     state = schedule_tick(state)
@@ -304,6 +313,29 @@ defmodule LassoWeb.Dashboard.EventStream do
          %{state | pending_events: pending, pending_count: count, seen_request_ids: seen}}
       end
     end
+  end
+
+  def handle_info({ref, metrics}, %{traffic_task: %Task{ref: ref}} = state)
+      when is_map(metrics) do
+    Process.demonitor(ref, [:flush])
+    traffic_metrics = traffic_metrics_by_scope(metrics)
+
+    state = %{
+      state
+      | traffic_task: nil,
+        traffic_metrics: traffic_metrics,
+        pending_traffic_metrics: traffic_metrics,
+        last_traffic_refresh: now()
+    }
+
+    {:noreply, schedule_tick(state)}
+  end
+
+  def handle_info(
+        {:DOWN, ref, :process, _pid, _reason},
+        %{traffic_task: %Task{ref: ref}} = state
+      ) do
+    {:noreply, %{state | traffic_task: nil, last_traffic_refresh: now()}}
   end
 
   # Circuit breaker events - buffer state + raw event for next batch flush
@@ -515,6 +547,7 @@ defmodule LassoWeb.Dashboard.EventStream do
 
     snapshot = %{
       metrics: state.provider_metrics,
+      traffic_metrics: Map.get(state.traffic_metrics, scope),
       circuits: state.circuit_states,
       health_counters: state.health_counters,
       cluster: state.cluster_state,
@@ -566,6 +599,39 @@ defmodule LassoWeb.Dashboard.EventStream do
       state
     end
   end
+
+  defp maybe_start_traffic_refresh(state, now) do
+    scopes = state.subscriber_scopes |> Map.values() |> Enum.uniq()
+
+    if scopes != [] and is_nil(state.traffic_task) and
+         now - state.last_traffic_refresh >= @traffic_refresh_interval_ms do
+      task =
+        Task.Supervisor.async_nolink(Lasso.TaskSupervisor, fn ->
+          TrafficCounters.cluster_windows(state.profile, scopes)
+        end)
+
+      %{state | traffic_task: task, last_traffic_refresh: now}
+    else
+      state
+    end
+  end
+
+  defp traffic_metrics_by_scope(%{
+         scopes: scopes,
+         coverage: coverage,
+         window_seconds: window_seconds,
+         as_of_second: as_of_second
+       }) do
+    Map.new(scopes, fn {scope, stats} ->
+      {scope,
+       stats
+       |> Map.put(:coverage, coverage)
+       |> Map.put(:window_seconds, window_seconds)
+       |> Map.put(:as_of_second, as_of_second)}
+    end)
+  end
+
+  defp traffic_metrics_by_scope(_metrics), do: %{}
 
   defp schedule_idle_termination(state) do
     # Cancel any existing timer first
@@ -671,9 +737,24 @@ defmodule LassoWeb.Dashboard.EventStream do
 
     new_heights =
       state.block_heights
-      |> Enum.reject(fn {_, %{timestamp: ts}} -> ts < stale_cutoff end)
+      |> Enum.filter(fn {_, %{timestamp: ts}} -> ts >= stale_cutoff end)
       |> Map.new()
       |> truncate_by_recency(@max_block_height_entries, & &1.timestamp)
+
+    removed_heights =
+      Enum.reject(state.block_heights, fn {key, _data} -> Map.has_key?(new_heights, key) end)
+
+    stale_block_states =
+      Map.new(removed_heights, fn {{provider_id, _chain_id, node_id}, _data} ->
+        {{provider_id, node_id},
+         %{provider_id: provider_id, node_id: node_id, height: nil, lag: nil, stale?: true}}
+      end)
+
+    new_consensus_heights =
+      Enum.reduce(new_heights, %{}, fn
+        {{_provider_id, chain_id, node_id}, %{height: height}}, consensus ->
+          Map.update(consensus, {chain_id, node_id}, height, &max(&1, height))
+      end)
 
     new_circuit_states =
       state.circuit_states
@@ -696,6 +777,8 @@ defmodule LassoWeb.Dashboard.EventStream do
       state
       | event_windows: new_windows,
         block_heights: new_heights,
+        consensus_heights: new_consensus_heights,
+        pending_block_states: Map.merge(state.pending_block_states, stale_block_states),
         circuit_states: new_circuit_states,
         health_counters: new_health_counters
     }
@@ -1057,6 +1140,7 @@ defmodule LassoWeb.Dashboard.EventStream do
       block_states: state.pending_block_states,
       cluster: state.pending_cluster,
       metrics: state.pending_metrics,
+      traffic_metrics: state.pending_traffic_metrics,
       node_ids: Enum.reverse(state.pending_node_ids),
       heartbeat: state.pending_heartbeat,
       routing_events: Enum.reverse(state.pending_routing_events),
@@ -1075,6 +1159,7 @@ defmodule LassoWeb.Dashboard.EventStream do
       map_size(batch.block_states) == 0 and
       is_nil(batch.cluster) and
       is_nil(batch.metrics) and
+      map_size(batch.traffic_metrics) == 0 and
       batch.node_ids == [] and
       batch.heartbeat == false and
       batch.routing_events == [] and
@@ -1089,7 +1174,8 @@ defmodule LassoWeb.Dashboard.EventStream do
   defp filter_batch(batch, scope) do
     %{
       batch
-      | routing_events:
+      | traffic_metrics: Map.get(batch.traffic_metrics, scope),
+        routing_events:
           batch.routing_events
           |> Enum.filter(&event_visible_for_scope?(&1, scope))
           |> Enum.map(&sanitize_routing_event/1),
@@ -1105,6 +1191,7 @@ defmodule LassoWeb.Dashboard.EventStream do
         pending_block_states: %{},
         pending_cluster: nil,
         pending_metrics: nil,
+        pending_traffic_metrics: %{},
         pending_routing_events: [],
         pending_circuit_events: [],
         pending_provider_events: [],

--- a/lib/lasso_web/dashboard/metrics_helpers.ex
+++ b/lib/lasso_web/dashboard/metrics_helpers.ex
@@ -23,6 +23,12 @@ defmodule LassoWeb.Dashboard.MetricsHelpers do
   # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
   defp score_table_name(profile, chain_name), do: :"provider_scores_#{profile}_#{chain_name}"
 
+  # Request-rate measurement windows, narrowest first, with the sample floor a
+  # window must clear before it is trusted.
+  @rps_windows_ms [5_000, 15_000, 60_000]
+  @rps_min_samples 5
+  @rps_min_span_ms 1_000
+
   # ---------------------------------------------------------------------------
   # ETS-Based Time-Windowed Metrics
   # ---------------------------------------------------------------------------
@@ -443,27 +449,51 @@ defmodule LassoWeb.Dashboard.MetricsHelpers do
     }
   end
 
-  @doc "Calculate RPC calls per second from routing events"
+  @doc """
+  Calculate RPC calls per second from routing events.
+
+  The rate is measured over the narrowest window that still holds enough
+  samples to be meaningful, so a burst registers within seconds instead of
+  being diluted across a minute of mostly-idle history. Sparse traffic falls
+  back to wider windows so low-volume readings stay stable.
+  """
   def rpc_calls_per_second(routing_events) when is_list(routing_events) do
-    routing_events = client_routing_events(routing_events)
     now = System.system_time(:millisecond)
-    one_minute_ago = now - 60_000
+    widest = List.last(@rps_windows_ms)
 
-    recent_events = Enum.filter(routing_events, fn e -> (e[:ts_ms] || 0) >= one_minute_ago end)
-    count = length(recent_events)
+    timestamps =
+      routing_events
+      |> client_routing_events()
+      |> Enum.map(&(&1[:ts_ms] || 0))
+      |> Enum.filter(&(&1 >= now - widest))
 
-    # If we have no events, return 0
-    if count == 0 do
-      0.0
-    else
-      oldest_event_time =
-        recent_events
-        |> Enum.map(&(&1[:ts_ms] || now))
-        |> Enum.min()
+    buffered = length(timestamps)
 
-      actual_duration_seconds = max(1, (now - oldest_event_time) / 1000)
-      Float.round(count / actual_duration_seconds, 1)
+    @rps_windows_ms
+    |> Enum.map(fn window -> {window, Enum.filter(timestamps, &(&1 >= now - window))} end)
+    |> Enum.find(fn {_window, in_window} -> length(in_window) >= @rps_min_samples end)
+    |> case do
+      nil -> rps_rate(timestamps, widest, now, buffered)
+      {window, in_window} -> rps_rate(in_window, window, now, buffered)
     end
+  end
+
+  defp rps_rate([], _window_ms, _now, _buffered), do: 0.0
+
+  # A window that holds every buffered event may have opened before the buffer
+  # starts, so the observed span is used instead of the nominal window to keep
+  # high-volume rates from reading low.
+  defp rps_rate(timestamps, window_ms, now, buffered) do
+    count = length(timestamps)
+
+    span_ms =
+      if count == buffered do
+        max(now - Enum.min(timestamps), @rps_min_span_ms)
+      else
+        window_ms
+      end
+
+    Float.round(count * 1000 / span_ms, 1)
   end
 
   @doc "Calculate error rate percentage from routing events"

--- a/lib/lasso_web/dashboard/provider_connection.ex
+++ b/lib/lasso_web/dashboard/provider_connection.ex
@@ -35,9 +35,11 @@ defmodule LassoWeb.Dashboard.ProviderConnection do
     end)
   end
 
-  defp build_provider_connection(profile_provider, _profile, chain_name, consensus_height) do
+  defp build_provider_connection(profile_provider, profile, chain_name, consensus_height) do
     instance_id = profile_provider.instance_id
     provider_id = profile_provider.provider_id
+
+    chain_id = resolve_chain_id(profile, chain_name)
 
     instance_config =
       case Catalog.get_instance(instance_id) do
@@ -89,6 +91,7 @@ defmodule LassoWeb.Dashboard.ProviderConnection do
     %{
       id: provider_id,
       chain: chain_name,
+      chain_id: chain_id,
       name: provider_name,
       status: health.status,
       health_status: derive_health_status(availability),
@@ -118,6 +121,13 @@ defmodule LassoWeb.Dashboard.ProviderConnection do
       consensus_height: consensus_height,
       blocks_behind: blocks_behind
     }
+  end
+
+  defp resolve_chain_id(profile, chain_name) do
+    case ConfigStore.get_chain(profile, chain_name) do
+      {:ok, %{chain_id: value}} when is_integer(value) -> value
+      _ -> nil
+    end
   end
 
   defp derive_health_status(:up), do: :healthy

--- a/lib/lasso_web/dashboard/traffic_counters.ex
+++ b/lib/lasso_web/dashboard/traffic_counters.ex
@@ -1,0 +1,313 @@
+defmodule LassoWeb.Dashboard.TrafficCounters do
+  @moduledoc false
+
+  use GenServer
+
+  alias Lasso.RPC.{RequestProjection, RequestTerminal}
+
+  @table :lasso_dashboard_traffic_counters
+  @runtime_key {__MODULE__, :runtime}
+  @default_max_rows 65_536
+  @retention_seconds 65
+  @cleanup_interval_ms 5_000
+
+  @type scope :: :profile
+  @type stats :: %{
+          count: non_neg_integer(),
+          successes: non_neg_integer(),
+          errors: non_neg_integer(),
+          elapsed_us: non_neg_integer(),
+          failovers: non_neg_integer()
+        }
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @spec record(RequestProjection.t()) :: :ok | :ignored | :dropped
+  def record(%RequestProjection{request_origin: :system}), do: :ignored
+
+  def record(%RequestProjection{} = event) do
+    record_request(event.fact, event.request_origin, event.failover_count, event.emitted_at_ms)
+  end
+
+  @spec record_request(RequestTerminal.t(), :client | :system, non_neg_integer()) ::
+          :ok | :ignored | :dropped
+  def record_request(fact, request_origin, failovers) do
+    record_request(fact, request_origin, failovers, System.system_time(:millisecond))
+  end
+
+  defp record_request(_fact, :system, _failovers, _emitted_at_ms), do: :ignored
+
+  defp record_request(fact, :client, failovers, emitted_at_ms) do
+    %{table: table, rows: rows, max_rows: max_rows} = :persistent_term.get(@runtime_key)
+    second = div(emitted_at_ms, 1_000)
+    profile = Map.fetch!(fact, :profile)
+    delta = counter_delta(fact, failovers)
+
+    record_scope(table, rows, max_rows, {profile, :profile, second}, delta)
+  rescue
+    ArgumentError ->
+      mark_drop()
+      :dropped
+  end
+
+  defp record_scope(table, rows, max_rows, key, delta) do
+    case :ets.lookup(table, key) do
+      [_row] -> update_existing(table, key, delta)
+      [] -> insert_or_update(table, rows, max_rows, key, delta)
+    end
+  end
+
+  @spec windows(binary(), [scope()], pos_integer(), integer()) :: %{scope() => stats()}
+  def windows(profile, scopes, window_seconds, now_second)
+      when is_binary(profile) and is_list(scopes) and is_integer(window_seconds) and
+             window_seconds > 0 and is_integer(now_second) do
+    start_second = now_second - window_seconds + 1
+
+    scopes
+    |> Enum.uniq()
+    |> Map.new(fn scope ->
+      {scope, window(profile, scope, start_second, now_second)}
+    end)
+  rescue
+    ArgumentError -> %{}
+  end
+
+  @spec cluster_windows(binary(), [scope()], pos_integer()) :: map()
+  def cluster_windows(profile, scopes, window_seconds \\ 60) do
+    now_second = System.system_time(:second)
+    nodes = [node() | connected_nodes()] |> Enum.uniq()
+
+    {results, bad_nodes} =
+      :rpc.multicall(
+        nodes,
+        __MODULE__,
+        :node_windows,
+        [profile, scopes, window_seconds, now_second],
+        750
+      )
+
+    valid = Enum.filter(results, &match?(%{scopes: %{}, last_drop_second: _}, &1))
+    start_second = now_second - window_seconds + 1
+
+    %{
+      scopes: merge_node_windows(Enum.map(valid, & &1.scopes), scopes),
+      coverage: %{
+        responding: length(valid),
+        total: length(nodes),
+        bad_nodes: bad_nodes,
+        lossless: Enum.all?(valid, &(&1.last_drop_second < start_second))
+      },
+      window_seconds: window_seconds,
+      as_of_second: now_second
+    }
+  end
+
+  @doc false
+  def node_windows(profile, scopes, window_seconds, now_second) do
+    %{dropped_at_second: dropped_at_second} = :persistent_term.get(@runtime_key)
+
+    %{
+      scopes: windows(profile, scopes, window_seconds, now_second),
+      last_drop_second: :atomics.get(dropped_at_second, 1)
+    }
+  end
+
+  @spec stats() :: map()
+  def stats do
+    %{
+      table: table,
+      rows: rows,
+      max_rows: max_rows,
+      dropped: dropped,
+      dropped_at_second: dropped_at_second
+    } =
+      :persistent_term.get(@runtime_key)
+
+    %{
+      rows: :atomics.get(rows, 1),
+      actual_rows: :ets.info(table, :size),
+      max_rows: max_rows,
+      dropped: :atomics.get(dropped, 1),
+      last_drop_second: :atomics.get(dropped_at_second, 1)
+    }
+  end
+
+  @impl true
+  def init(opts) do
+    table =
+      :ets.new(@table, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true,
+        write_concurrency: true
+      ])
+
+    rows = :atomics.new(1, signed: false)
+    dropped = :atomics.new(1, signed: false)
+    dropped_at_second = :atomics.new(1, signed: false)
+    max_rows = Keyword.get(opts, :max_rows, @default_max_rows)
+
+    runtime = %{
+      table: table,
+      rows: rows,
+      dropped: dropped,
+      dropped_at_second: dropped_at_second,
+      max_rows: max_rows
+    }
+
+    :persistent_term.put(@runtime_key, runtime)
+    schedule_cleanup()
+    {:ok, runtime}
+  end
+
+  @impl true
+  def handle_info(:cleanup, state) do
+    cutoff = System.system_time(:second) - @retention_seconds
+
+    removed =
+      :ets.foldl(
+        fn
+          {{_profile, _scope, second} = key, _total, _successes, _errors, _elapsed_us, _failovers},
+          count
+          when second < cutoff ->
+            :ets.delete(state.table, key)
+            count + 1
+
+          _row, count ->
+            count
+        end,
+        0,
+        state.table
+      )
+
+    if removed > 0, do: :atomics.sub(state.rows, 1, removed)
+    schedule_cleanup()
+    {:noreply, state}
+  end
+
+  defp insert_or_update(table, rows, max_rows, key, delta) do
+    case reserve_row(rows, max_rows) do
+      :ok ->
+        row = row(key, delta)
+
+        if :ets.insert_new(table, row) do
+          :ok
+        else
+          :atomics.sub(rows, 1, 1)
+          update_existing(table, key, delta)
+        end
+
+      :full ->
+        mark_drop()
+        :dropped
+    end
+  end
+
+  defp reserve_row(rows, max_rows) do
+    if :atomics.add_get(rows, 1, 1) <= max_rows do
+      :ok
+    else
+      :atomics.sub(rows, 1, 1)
+      :full
+    end
+  end
+
+  defp update_existing(table, key, {success, error, elapsed_us, failovers}) do
+    :ets.update_counter(table, key, [
+      {2, 1},
+      {3, success},
+      {4, error},
+      {5, elapsed_us},
+      {6, failovers}
+    ])
+
+    :ok
+  rescue
+    ArgumentError ->
+      mark_drop()
+      :dropped
+  end
+
+  defp row(key, {success, error, elapsed_us, failovers}),
+    do: {key, 1, success, error, elapsed_us, failovers}
+
+  defp counter_delta(
+         %RequestTerminal.UpstreamResponse{attempt: %{kind: :success}} = fact,
+         failovers
+       ),
+       do: {1, 0, Map.fetch!(fact, :elapsed_us), failovers}
+
+  defp counter_delta(fact, failovers),
+    do: {0, 1, Map.fetch!(fact, :elapsed_us), failovers}
+
+  defp window(profile, :profile, start_second, now_second) do
+    Enum.reduce(start_second..now_second, empty_stats(), fn second, acc ->
+      merge_key({profile, :profile, second}, acc)
+    end)
+  end
+
+  defp window(_profile, _scope, _start_second, _now_second), do: empty_stats()
+
+  defp merge_key(key, acc) do
+    case :ets.lookup(@table, key) do
+      [row] -> merge_row(row, acc)
+      [] -> acc
+    end
+  end
+
+  defp merge_row({_key, total, successes, errors, elapsed_us, failovers}, acc) do
+    %{
+      count: acc.count + total,
+      successes: acc.successes + successes,
+      errors: acc.errors + errors,
+      elapsed_us: acc.elapsed_us + elapsed_us,
+      failovers: acc.failovers + failovers
+    }
+  end
+
+  defp merge_node_windows(results, scopes) do
+    Map.new(scopes, fn scope ->
+      stats =
+        Enum.reduce(results, empty_stats(), fn result, acc ->
+          Map.get(result, scope, empty_stats()) |> merge_stats(acc)
+        end)
+
+      {scope, stats}
+    end)
+  end
+
+  defp merge_stats(stats, acc) do
+    %{
+      count: acc.count + stats.count,
+      successes: acc.successes + stats.successes,
+      errors: acc.errors + stats.errors,
+      elapsed_us: acc.elapsed_us + stats.elapsed_us,
+      failovers: acc.failovers + stats.failovers
+    }
+  end
+
+  defp empty_stats,
+    do: %{count: 0, successes: 0, errors: 0, elapsed_us: 0, failovers: 0}
+
+  defp mark_drop do
+    case :persistent_term.get(@runtime_key, nil) do
+      %{dropped: dropped, dropped_at_second: dropped_at_second} ->
+        :atomics.add(dropped, 1, 1)
+        :atomics.put(dropped_at_second, 1, System.system_time(:second))
+
+      _unavailable ->
+        :ok
+    end
+  end
+
+  defp connected_nodes do
+    Lasso.Cluster.Topology.get_connected_nodes()
+  catch
+    :exit, _reason -> Node.list()
+  end
+
+  defp schedule_cleanup, do: Process.send_after(self(), :cleanup, @cleanup_interval_ms)
+end

--- a/test/integration/dashboard_routing_live_test.exs
+++ b/test/integration/dashboard_routing_live_test.exs
@@ -13,12 +13,16 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
 
   test "canonical routing decisions propagate through EventStream into LiveView", %{chain: chain} do
     request_id = "dashboard-live-#{System.unique_integer([:positive])}"
+    profile = "dashboard-live-#{System.unique_integer([:positive])}"
 
-    setup_providers([
-      %{id: "dashboard-live-provider", priority: 10, behavior: :healthy, profile: "public"}
-    ])
+    setup_providers(
+      [
+        %{id: "dashboard-live-provider", priority: 10, behavior: :healthy}
+      ],
+      profile: profile
+    )
 
-    {:ok, view, _html} = live(build_conn(), "/dashboard/public?tab=overview")
+    {:ok, view, _html} = live(build_conn(), "/dashboard/#{profile}?tab=overview")
     assert has_element?(view, "details#profile-selector")
 
     assert {:ok, _result, _ctx} =
@@ -27,6 +31,7 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
                "eth_blockNumber",
                [],
                %RequestOptions{
+                 profile: profile,
                  strategy: :load_balanced,
                  timeout_ms: 30_000,
                  request_id: request_id
@@ -42,7 +47,7 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
              result: :success
            } = await_live_routing_event(view, request_id)
 
-    state = :sys.get_state(view.pid)
+    state = await_exact_traffic(view, 1)
 
     assert Enum.any?(state.socket.assigns.routing_events, fn event ->
              event.provider_id == "dashboard-live-provider" and
@@ -50,7 +55,9 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
                event.result == :success
            end)
 
-    assert render(view) =~ "Sampled success ("
+    html = render(view)
+    assert html =~ "Success (1)"
+    refute html =~ "Sampled success"
     assert MetricsHelpers.routing_sample_count(state.socket.assigns.routing_events) >= 1
 
     assert is_binary(render_click(view, "select_chain", %{"chain" => to_string(chain)}))
@@ -63,13 +70,17 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
   test "system failures remain visible without lowering client routing success", %{chain: chain} do
     system_request_id = "dashboard-system-#{System.unique_integer([:positive])}"
     client_request_id = "dashboard-client-#{System.unique_integer([:positive])}"
+    profile = "dashboard-origin-#{System.unique_integer([:positive])}"
 
-    setup_providers([
-      %{id: "dashboard-system-failure", priority: 10, behavior: :always_fail, profile: "public"},
-      %{id: "dashboard-client-success", priority: 20, behavior: :healthy, profile: "public"}
-    ])
+    setup_providers(
+      [
+        %{id: "dashboard-system-failure", priority: 10, behavior: :always_fail},
+        %{id: "dashboard-client-success", priority: 20, behavior: :healthy}
+      ],
+      profile: profile
+    )
 
-    {:ok, view, _html} = live(build_conn(), "/dashboard/public?tab=overview")
+    {:ok, view, _html} = live(build_conn(), "/dashboard/#{profile}?tab=overview")
 
     assert {:error, _error, _ctx} =
              RequestPipeline.execute_via_channels(
@@ -77,6 +88,7 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
                "eth_blockNumber",
                [],
                %RequestOptions{
+                 profile: profile,
                  provider_override: "dashboard-system-failure",
                  failover_on_override: false,
                  strategy: :priority,
@@ -92,6 +104,7 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
                "eth_blockNumber",
                [],
                %RequestOptions{
+                 profile: profile,
                  provider_override: "dashboard-client-success",
                  failover_on_override: false,
                  strategy: :priority,
@@ -106,8 +119,16 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
     assert %{request_origin: :client, result: :success} =
              await_live_routing_event(view, client_request_id)
 
-    state = :sys.get_state(view.pid)
+    state = await_exact_traffic(view, 1)
     assert MetricsHelpers.success_rate_percent(state.socket.assigns.routing_events) == 100.0
+    assert state.socket.assigns.traffic_metrics.count == 1
+    assert state.socket.assigns.traffic_metrics.successes == 1
+    assert state.socket.assigns.traffic_metrics.errors == 0
+
+    html = render(view)
+    assert html =~ "Success (1)"
+    assert html =~ "SYSTEM"
+    assert html =~ ~s(data-request-origin="system")
   end
 
   defp await_live_routing_event(view, request_id, attempts \\ 50)
@@ -126,6 +147,23 @@ defmodule LassoWeb.DashboardRoutingLiveTest do
 
       event ->
         event
+    end
+  end
+
+  defp await_exact_traffic(view, count, attempts \\ 60)
+
+  defp await_exact_traffic(_view, count, 0),
+    do: flunk("LiveView did not receive exact traffic count #{count}")
+
+  defp await_exact_traffic(view, count, attempts) do
+    _html = render(view)
+    state = :sys.get_state(view.pid)
+
+    if get_in(state.socket.assigns, [:traffic_metrics, :count]) == count do
+      state
+    else
+      Process.sleep(50)
+      await_exact_traffic(view, count, attempts - 1)
     end
   end
 end

--- a/test/lasso/core/request/request_projection_test.exs
+++ b/test/lasso/core/request/request_projection_test.exs
@@ -1,6 +1,7 @@
 defmodule Lasso.RPC.RequestProjectionTest do
   use ExUnit.Case, async: false
 
+  alias Lasso.Benchmarking.BenchmarkStore
   alias Lasso.Core.ProjectionDispatcher
   alias Lasso.Events.RoutingDecision
 
@@ -13,6 +14,7 @@ defmodule Lasso.RPC.RequestProjectionTest do
   }
 
   alias Lasso.RPC.ExecutionFact.Codec
+  alias LassoWeb.Dashboard.TrafficCounters
 
   @fast_dispatcher Lasso.TestRequestProjectionFastDispatcher
 
@@ -172,6 +174,43 @@ defmodule Lasso.RPC.RequestProjectionTest do
     end
   end
 
+  test "exact traffic counts are independent of diagnostic sampling" do
+    suffix = System.unique_integer([:positive])
+    profile = "projection-exact-#{suffix}"
+    chain_id = 80_000 + rem(suffix, 9_000)
+    fact = terminal(profile, chain_id)
+    route = %{provider_id: "provider-a", instance_id: "instance-a", transport: :http}
+
+    for _index <- 1..258 do
+      _result =
+        RequestProjection.record_and_enqueue(
+          fact,
+          "eth_blockNumber",
+          route,
+          0,
+          :client
+        )
+    end
+
+    assert %{count: 258, successes: 258, errors: 0} =
+             TrafficCounters.windows(profile, [:profile], 60, System.system_time(:second))[
+               :profile
+             ]
+
+    _result =
+      RequestProjection.record_and_enqueue(
+        fact,
+        "eth_blockNumber",
+        route,
+        0,
+        :system
+      )
+
+    assert TrafficCounters.windows(profile, [:profile], 60, System.system_time(:second))[
+             :profile
+           ].count == 258
+  end
+
   test "application errors retain their complete native classification" do
     attempt =
       AttemptTerminal.Response.new(identity(), :application_error, 7_000,
@@ -327,6 +366,52 @@ defmodule Lasso.RPC.RequestProjectionTest do
     }
   end
 
+  test "client delivery records provider dashboard metrics without recording system traffic" do
+    suffix = System.unique_integer([:positive])
+    profile = "projection-metrics-#{suffix}"
+    chain_id = 90_000 + rem(suffix, 9_000)
+    method = "eth_blockNumber"
+
+    on_exit(fn -> BenchmarkStore.clear_chain_metrics(profile, chain_id) end)
+
+    route = %{provider_id: "client-provider", instance_id: "client-instance", transport: :http}
+    client_event = RequestProjection.new(terminal(profile, chain_id), method, route, 0)
+
+    assert :ok = RequestProjection.deliver(client_event)
+
+    assert %{
+             total_calls: 1,
+             success_calls: 1,
+             success_rate: 1.0,
+             avg_latency: 12
+           } =
+             BenchmarkStore.get_rpc_performance(
+               profile,
+               chain_id,
+               "client-provider",
+               "#{method}@http"
+             )
+
+    system_route = %{
+      provider_id: "system-provider",
+      instance_id: "system-instance",
+      transport: :http
+    }
+
+    system_event =
+      RequestProjection.new(terminal(profile, chain_id), method, system_route, 0, :system)
+
+    assert :ok = RequestProjection.deliver(system_event)
+
+    assert %{total_calls: 0} =
+             BenchmarkStore.get_rpc_performance(
+               profile,
+               chain_id,
+               "system-provider",
+               "#{method}@http"
+             )
+  end
+
   test "routing publication precedes potentially blocking telemetry consumers" do
     event = request_projection()
     topic = Lasso.Topics.routing_decision("public")
@@ -415,8 +500,8 @@ defmodule Lasso.RPC.RequestProjectionTest do
     )
   end
 
-  defp terminal do
-    attempt = AttemptTerminal.Response.new(identity(), :success, 7_000)
+  defp terminal(profile \\ "public", chain_id \\ 1) do
+    attempt = AttemptTerminal.Response.new(identity(profile, chain_id), :success, 7_000)
 
     RequestTerminal.UpstreamResponse.new(
       [
@@ -455,12 +540,12 @@ defmodule Lasso.RPC.RequestProjectionTest do
     )
   end
 
-  defp identity do
+  defp identity(profile \\ "public", chain_id \\ 1) do
     AttemptIdentity.new(
       request_id: "projection-request",
       attempt_id: "projection-attempt",
-      profile: "public",
-      chain_id: 1,
+      profile: profile,
+      chain_id: chain_id,
       upstream_instance_id: "instance-a",
       transport: :http,
       route_generation: 1,

--- a/test/lasso_web/dashboard/dashboard_live_test.exs
+++ b/test/lasso_web/dashboard/dashboard_live_test.exs
@@ -55,4 +55,67 @@ defmodule LassoWeb.DashboardLiveTest do
     assert conn.status == 200
     assert Plug.Conn.get_resp_header(conn, "content-type") == ["image/png"]
   end
+
+  test "accepts live block state and removes it after a stale tombstone" do
+    {:ok, view, _html} = live(build_conn(), "/dashboard/public?tab=overview")
+    key = {"height-provider", "sjc-node"}
+
+    send(
+      view.pid,
+      {:dashboard_batch,
+       dashboard_batch(%{
+         key => %{
+           provider_id: "height-provider",
+           node_id: "sjc-node",
+           height: 25_000_000,
+           lag: 0,
+           stale?: nil
+         }
+       })}
+    )
+
+    _html = render(view)
+
+    assert :sys.get_state(view.pid).socket.assigns.cluster_block_heights[key] == %{
+             height: 25_000_000,
+             lag: 0
+           }
+
+    send(
+      view.pid,
+      {:dashboard_batch,
+       dashboard_batch(%{
+         key => %{
+           provider_id: "height-provider",
+           node_id: "sjc-node",
+           height: nil,
+           lag: nil,
+           stale?: true
+         }
+       })}
+    )
+
+    _html = render(view)
+    refute Map.has_key?(:sys.get_state(view.pid).socket.assigns.cluster_block_heights, key)
+    assert Process.alive?(view.pid)
+  end
+
+  defp dashboard_batch(block_states) do
+    %{
+      health: %{},
+      circuit_states: %{},
+      block_states: block_states,
+      cluster: nil,
+      metrics: nil,
+      node_ids: [],
+      heartbeat: false,
+      routing_events: [],
+      circuit_events: [],
+      provider_events: [],
+      subscription_events: [],
+      block_events: [],
+      sync_updates: [],
+      block_cache_updates: []
+    }
+  end
 end

--- a/test/lasso_web/dashboard/event_stream_test.exs
+++ b/test/lasso_web/dashboard/event_stream_test.exs
@@ -2,6 +2,7 @@ defmodule LassoWeb.Dashboard.EventStreamTest do
   use ExUnit.Case, async: false
 
   alias Lasso.Events.RoutingDecision
+  alias LassoWeb.Dashboard.EventStream
 
   @max_batch_size 100
   @seen_request_id_ttl_ms 120_000
@@ -130,6 +131,58 @@ defmodule LassoWeb.Dashboard.EventStreamTest do
   end
 
   describe "stale data cleanup" do
+    test "retracts stale block heights and recomputes consensus" do
+      profile = "event-stream-stale-#{System.unique_integer([:positive])}"
+      {:ok, pid} = EventStream.ensure_started(profile)
+
+      on_exit(fn ->
+        if Process.alive?(pid) do
+          DynamicSupervisor.terminate_child(Lasso.Dashboard.StreamSupervisor, pid)
+        end
+      end)
+
+      assert :ok = EventStream.subscribe(profile)
+      assert_receive {:dashboard_snapshot, _snapshot}
+
+      system_now = System.system_time(:millisecond)
+      monotonic_now = System.monotonic_time(:millisecond)
+
+      :sys.replace_state(pid, fn state ->
+        %{
+          state
+          | block_heights: %{
+              {"stale", 1, "iad"} => %{
+                height: 100,
+                timestamp: system_now - 300_001,
+                source: :http
+              },
+              {"fresh", 1, "iad"} => %{
+                height: 105,
+                timestamp: system_now,
+                source: :http
+              }
+            },
+            consensus_heights: %{{1, "iad"} => 999},
+            pending_block_states: %{},
+            last_cleanup: monotonic_now - 30_001
+        }
+      end)
+
+      send(pid, :tick)
+
+      assert_receive {:dashboard_batch,
+                      %{
+                        block_states: %{
+                          {"stale", "iad"} => %{height: nil, lag: nil, stale?: true}
+                        }
+                      }}
+
+      state = :sys.get_state(pid)
+      refute Map.has_key?(state.block_heights, {"stale", 1, "iad"})
+      assert state.block_heights[{"fresh", 1, "iad"}].height == 105
+      assert state.consensus_heights == %{{1, "iad"} => 105}
+    end
+
     test "circuit states older than cutoff are removed" do
       now = System.system_time(:millisecond)
       stale_cutoff = now - 300_000

--- a/test/lasso_web/dashboard/metrics_helpers_test.exs
+++ b/test/lasso_web/dashboard/metrics_helpers_test.exs
@@ -39,4 +39,37 @@ defmodule LassoWeb.Dashboard.MetricsHelpersTest do
     assert MetricsHelpers.routing_sample_count(events) == 2
     assert MetricsHelpers.success_rate_percent(events) == 50.0
   end
+
+  describe "rpc_calls_per_second/1" do
+    test "returns 0 with no events" do
+      assert MetricsHelpers.rpc_calls_per_second([]) == 0.0
+    end
+
+    test "reports the burst rate instead of averaging it over idle history" do
+      now = System.system_time(:millisecond)
+
+      idle_history =
+        for i <- 1..20, do: %{ts_ms: now - 55_000 + i * 100, request_origin: :client}
+
+      burst = for i <- 1..60, do: %{ts_ms: now - 3_000 + i * 50, request_origin: :client}
+
+      assert MetricsHelpers.rpc_calls_per_second(burst ++ idle_history) >= 10.0
+    end
+
+    test "falls back to a wider window when traffic is sparse" do
+      now = System.system_time(:millisecond)
+      events = for i <- 1..3, do: %{ts_ms: now - 40_000 + i * 1_000, request_origin: :client}
+
+      rps = MetricsHelpers.rpc_calls_per_second(events)
+      assert rps > 0.0
+      assert rps < 1.0
+    end
+
+    test "ignores events older than the widest window" do
+      now = System.system_time(:millisecond)
+      events = for i <- 1..50, do: %{ts_ms: now - 120_000 - i * 100, request_origin: :client}
+
+      assert MetricsHelpers.rpc_calls_per_second(events) == 0.0
+    end
+  end
 end

--- a/test/lasso_web/dashboard/provider_details_panel_test.exs
+++ b/test/lasso_web/dashboard/provider_details_panel_test.exs
@@ -1,0 +1,99 @@
+defmodule LassoWeb.Dashboard.ProviderDetailsPanelTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias Lasso.Core.BlockSync.BlockTimeMeasurement
+  alias LassoWeb.Dashboard.Components.ProviderDetailsPanel
+
+  setup do
+    TestHelper.ensure_test_environment_ready()
+
+    chain_id = 9_700_000 + rem(System.unique_integer([:positive]), 100_000)
+    instance_id = "#{chain_id}:http:instance"
+    Lasso.BlockSync.Registry.clear_chain(chain_id)
+
+    on_exit(fn -> Lasso.BlockSync.Registry.clear_chain(chain_id) end)
+
+    {:ok, chain_id: chain_id, instance_id: instance_id}
+  end
+
+  test "uses the instance identity to display a consistent estimated height", %{
+    chain_id: chain_id,
+    instance_id: instance_id
+  } do
+    now = System.system_time(:millisecond)
+
+    :ets.insert(:block_sync_registry, [
+      {{:height, chain_id, instance_id}, {990, now - 5_500, :http, %{latency_ms: 10}}},
+      {{:height, chain_id, "#{chain_id}:ws:peer"}, {1_000, now, :ws, %{}}},
+      {{:block_time, chain_id},
+       %BlockTimeMeasurement{
+         ema_ms: 1_000.0,
+         sample_count: 5,
+         last_height: 1_000,
+         last_mono_ms: System.monotonic_time(:millisecond)
+       }}
+    ])
+
+    html =
+      draw(
+        chain_id,
+        instance_id,
+        chain_consensus_height: 1_000,
+        cluster_block_heights: %{{"p1", "iad-node"} => %{height: 990, lag: -3}}
+      )
+
+    assert html =~ "Estimated Height:"
+    assert html =~ "995"
+    assert html =~ "-5"
+    refute html =~ ">990<"
+  end
+
+  test "recomputes raw lag against the displayed consensus", %{chain_id: chain_id} do
+    html =
+      draw(
+        chain_id,
+        "#{chain_id}:missing:instance",
+        chain_consensus_height: 1_000,
+        cluster_block_heights: %{{"p1", "iad-node"} => %{height: 990, lag: -3}}
+      )
+
+    assert html =~ "Block Height:"
+    assert html =~ "990"
+    assert html =~ "-10"
+    refute html =~ ">-3<"
+  end
+
+  defp draw(chain_id, instance_id, opts) do
+    connection = %{
+      id: "p1",
+      name: "Provider",
+      url: "https://example.test",
+      ws_url: nil,
+      chain: "test-chain",
+      chain_id: chain_id,
+      instance_id: instance_id,
+      block_height: 990,
+      consensus_height: 1_000,
+      blocks_behind: 10
+    }
+
+    base = %{
+      id: "provider-details-p1",
+      provider_id: "p1",
+      connections: [connection],
+      selected_profile: "public",
+      selected_provider_unified_events: [],
+      selected_provider_metrics: %{},
+      live_provider_metrics: %{},
+      cluster_circuit_states: %{},
+      cluster_health_counters: %{},
+      cluster_block_heights: %{},
+      chain_consensus_height: nil,
+      available_node_ids: []
+    }
+
+    render_component(ProviderDetailsPanel, Map.merge(base, Map.new(opts)))
+  end
+end

--- a/test/lasso_web/dashboard/traffic_counters_test.exs
+++ b/test/lasso_web/dashboard/traffic_counters_test.exs
@@ -1,0 +1,134 @@
+defmodule LassoWeb.Dashboard.TrafficCountersTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.RPC.{
+    AttemptIdentity,
+    AttemptTerminal,
+    RequestProjection,
+    RequestTerminal
+  }
+
+  alias LassoWeb.Dashboard.TrafficCounters
+
+  setup do
+    TestHelper.ensure_test_environment_ready()
+    :ok
+  end
+
+  test "counts exact client outcomes by profile while excluding system work" do
+    unique = System.unique_integer([:positive])
+    profile = "traffic-profile-#{unique}"
+    now_second = System.system_time(:second)
+
+    assert :ok = TrafficCounters.record(success_event(profile, 2, :client))
+    assert :ok = TrafficCounters.record(error_event(profile, 1))
+    assert :ok = TrafficCounters.record(success_event(profile, 0, :client))
+    assert :ignored = TrafficCounters.record(success_event(profile, 0, :system))
+
+    windows = TrafficCounters.windows(profile, [:profile], 60, now_second)
+
+    assert windows[:profile] == %{
+             count: 3,
+             successes: 2,
+             errors: 1,
+             elapsed_us: 30_000,
+             failovers: 3
+           }
+  end
+
+  test "does not include outcomes outside the requested window" do
+    unique = System.unique_integer([:positive])
+    profile = "traffic-window-#{unique}"
+    now_second = System.system_time(:second)
+
+    old = %{
+      success_event(profile, 0, :client)
+      | emitted_at_ms: (now_second - 60) * 1_000
+    }
+
+    current = %{success_event(profile, 0, :client) | emitted_at_ms: now_second * 1_000}
+
+    assert :ok = TrafficCounters.record(old)
+    assert :ok = TrafficCounters.record(current)
+
+    assert %{count: 1, successes: 1, errors: 0} =
+             TrafficCounters.windows(profile, [:profile], 60, now_second)[:profile]
+  end
+
+  defp success_event(profile, failovers, origin) do
+    identity =
+      AttemptIdentity.new(
+        request_id: "request-#{System.unique_integer([:positive])}",
+        attempt_id: "attempt-#{System.unique_integer([:positive])}",
+        profile: profile,
+        chain_id: 1,
+        upstream_instance_id: "instance-a",
+        transport: :http,
+        route_generation: 1,
+        circuit_scope: :broad,
+        circuit_epoch: 1,
+        execution_safety: :replay_safe,
+        routing_intent: "fastest",
+        workload_key: "default",
+        request_budget_ms: 100,
+        candidate_admission_count: 1,
+        dispatch_count: 1
+      )
+
+    attempt = AttemptTerminal.Response.new(identity, :success, 7_000)
+
+    terminal =
+      RequestTerminal.UpstreamResponse.new(
+        [
+          request_id: identity.request_id,
+          profile: profile,
+          subject_token: nil,
+          chain_id: 1,
+          execution_safety: :replay_safe,
+          routing_intent: "fastest",
+          workload_key: "default",
+          elapsed_us: 10_000,
+          candidate_admission_count: 1,
+          dispatch_count: 1,
+          observed_at: nil
+        ],
+        attempt
+      )
+
+    RequestProjection.new(
+      terminal,
+      "eth_blockNumber",
+      %{provider_id: "provider-a", instance_id: "instance-a", transport: :http},
+      failovers,
+      origin
+    )
+  end
+
+  defp error_event(profile, failovers) do
+    terminal =
+      RequestTerminal.LocalFailure.new(
+        [
+          request_id: "request-#{System.unique_integer([:positive])}",
+          profile: profile,
+          subject_token: nil,
+          chain_id: 1,
+          execution_safety: :replay_safe,
+          routing_intent: "fastest",
+          workload_key: "default",
+          elapsed_us: 10_000,
+          candidate_admission_count: 0,
+          dispatch_count: 0,
+          observed_at: nil
+        ],
+        :capacity
+      )
+
+    RequestProjection.new(
+      terminal,
+      "eth_blockNumber",
+      nil,
+      failovers,
+      :client
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- show exact 60-second client request counts, success rate, latency, RPS, and failovers independently of sampled diagnostics
- keep system-origin routing events visible while labeling them clearly and excluding them from client success metrics
- restore canonical request metrics for provider/method dashboard views
- retract stale provider heights, recompute consensus, and keep displayed HTTP lag consistent with canonical instance observations
- preserve OSS profile-wide scope without importing Cloud account, billing, or control-plane concepts

## Sync boundary
This is the generic dashboard half of the dedicated bidirectional reconciliation tracked by Lasso Cloud issue #607. It ports applicable behavior from Cloud PRs #535, #559, #560, #568, #570, and #571 while retaining the OSS profile/chain model.

Cloud-only account scoping, authentication, billing, profile editing, and launch UI remain excluded.

## Verification
- `mix format`
- `MIX_ENV=test mix compile --warnings-as-errors`
- focused dashboard/projection/integration suites: 47 tests, 0 failures across seeded runs
- full `mix test --include integration`: 1,557 tests, 0 failures
- strict Credo on all 16 changed files
- `git diff --check`
