### PR TITLE
Prepare Lasso RPC v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-28
+
+### Added
+
+- Bounded request execution with explicit ownership, deadlines, byte budgets, terminal facts, and projection lanes for HTTP and WebSocket traffic
+- Precompiled routing plans, candidate cursors, and bounded routing evidence used by every public selection strategy
+- Generation-bound transport dispatch and strict upstream JSON-RPC response validation
+- A validated Mint WebSocket client that resolves each configured origin once, pins the connection to that address set, and preserves the original HTTP and TLS authority
+- Cluster-aware circuit-breaker admission, recovery control, and transport diagnostics
+
+### Changed
+
+- Upgraded the release runtime to Erlang/OTP 28 and the routing stack to Phoenix 1.8 and Finch 0.23
+- Reworked provider selection to defer cold evidence, reuse immutable routing state, and avoid unnecessary materialization on the request path
+- Strengthened WebSocket subscription ownership, reconnection, gap-fill bounds, and stale-generation handling
+- Aggregated request and dashboard diagnostics through bounded local projection lanes
+- Kept self-hosted localhost and private-network providers supported while pinning each WebSocket connection to its resolved address set
+
+### Fixed
+
+- Applied provider-specific error rules consistently to live HTTP and WebSocket transports
+- Preserved provider metadata on WebSocket errors and classified structural execution evidence before ambiguous provider messages
+- Prevented stale or cancelled transport attempts from being accepted after their request owner or connection generation changed
+- Made provider capability reads safe when configuration fields are absent
+- Corrected dashboard routing counters, provider details, and cluster-wide activity reconciliation
+- Hardened response-size admission, batch accounting, circuit recovery races, and WebSocket continuity cleanup
+
 ## [0.2.0] - 2026-08-05
 
 ### Fixed
@@ -75,6 +102,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/jaxernst/lasso-rpc/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jaxernst/lasso-rpc/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jaxernst/lasso-rpc/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.2.0-blue.svg)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.3.0-blue.svg)](https://github.com/jaxernst/lasso-rpc/releases)
 
 ### Smart RPC aggregation for fault-tolerant and performant blockchain apps.
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.2.0",
+      version: "0.3.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],


### PR DESCRIPTION
## Release

Prepare the v0.3.0 public release after the final Cloud-to-OSS reconciliation.

## Changes

- bump the application and README version to 0.3.0
- publish a scoped changelog for bounded request execution, routing, transport, WebSocket, and observability hardening
- advance changelog comparison links

## Verification

- compile with warnings as errors
- mix format check
- full unit suite: 1,572 tests passing
- diff check

The preceding code-sync PR passed the full CI matrix, including hermetic integration, Docker build and boot, Credo, Dialyzer, and independent review.