### PR TITLE
Harden block-height consensus and lag evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Time-aligned fast-chain consensus using bounded HTTP observation credit while preserving WebSocket heads as direct evidence
+- Rejected stale block observations from provider lag decisions instead of manufacturing current synchronization state
+- Stored each worker's effective freshness and polling cadence with block-height observations so routing and dashboard status share one contract
+
 ## [0.3.0] - 2026-08-28
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -492,19 +492,22 @@ EMA adapts to variable block production (e.g., Arbitrum's 100ms-5s range) while 
 
 ### Consensus Height Derivation
 
-Consensus height is the P75 of fresh provider heights (within the last 30s). With 4+ providers, this is the second-highest height, filtering out one outlier ahead-running provider. With 1–3 providers, it is the MAX height.
+Consensus height is the P75 of fresh provider observations. Freshness follows each worker's effective HTTP poll or WebSocket liveness window; callers can still supply an explicit override. With 4+ providers, P75 filters out an ahead-running outlier. With 1–3 providers, it is the maximum height.
+
+Before computing P75, HTTP samples are time-aligned toward the highest actually observed height using the measured block time and no more than one effective polling interval of advancement. WebSocket samples remain direct observations and are never projected. No aligned sample can exceed a height that was genuinely observed, so a single implausible head remains bounded by the percentile calculation.
 
 ### Optimistic Lag Calculation
 
-Compensates for observation delay on fast chains to prevent false lag detection.
+Compensates for bounded HTTP observation delay on fast chains to prevent false lag detection. Stale evidence is unavailable for routing, and WebSocket observations receive no inferred advancement.
 
 **Algorithm**:
 
 ```elixir
 elapsed_ms = now - timestamp
 block_time_ms = Registry.get_block_time_ms(chain) || config.block_time_ms
-staleness_credit = min(div(elapsed_ms, block_time_ms), div(30_000, block_time_ms))
-optimistic_height = height + staleness_credit
+credit_window_ms = observation.optimistic_credit_ms || div(observation.stale_after_ms, 3)
+staleness_credit = min(div(elapsed_ms, block_time_ms), div(credit_window_ms, block_time_ms))
+optimistic_height = min(height + staleness_credit, consensus_height)
 optimistic_lag = optimistic_height - consensus_height
 ```
 
@@ -520,7 +523,7 @@ optimistic_height: 421,535,503 + 8 = 421,535,511
 optimistic_lag: 0 blocks
 ```
 
-Bounded observation delay from HTTP polling enables accurate credit calculation. The 30s cap prevents runaway values on stale connections.
+The worker stores the effective freshness and advancement windows with every observation. This keeps selection, consensus, and dashboard projections on the same contract without adding database or network work to request routing.
 
 ### Health Probing
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -6,6 +6,16 @@ Lasso's observability system provides comprehensive visibility into RPC request 
 
 ## Architecture
 
+### Block-height evidence
+
+Provider synchronization is derived from typed block observations kept in ETS.
+Each observation records its transport, observation time, and effective freshness
+window. HTTP observations may receive bounded time-alignment credit up to one
+polling interval; WebSocket observations remain direct evidence. Stale evidence
+is excluded, and consensus never advances beyond a height actually observed from
+an upstream provider. These rules are shared by routing and dashboard status so
+operator displays do not disagree with route eligibility.
+
 ### Core Components
 
 1. **RequestContext** (`lib/lasso/core/request/request_context.ex`)

--- a/lib/lasso/core/block_sync/observation.ex
+++ b/lib/lasso/core/block_sync/observation.ex
@@ -1,0 +1,85 @@
+defmodule Lasso.BlockSync.Observation do
+  @moduledoc """
+  Reads block-height evidence under the instance's effective freshness contract.
+  """
+
+  alias Lasso.BlockSync.{Registry, Worker}
+
+  @default_stale_after_ms 60_000
+
+  @type t :: %{
+          height: non_neg_integer(),
+          observed_at_ms: integer(),
+          source: :http | :ws,
+          metadata: map(),
+          stale_after_ms: pos_integer(),
+          age_ms: non_neg_integer()
+        }
+
+  @spec read(pos_integer(), String.t(), integer()) ::
+          {:ok, t()} | {:error, :not_found | {:stale, t()}}
+  def read(chain_id, instance_id, now_ms \\ System.system_time(:millisecond))
+      when is_integer(chain_id) and chain_id > 0 and is_binary(instance_id) and
+             is_integer(now_ms) do
+    case Registry.get_height(chain_id, instance_id) do
+      {:ok, {height, observed_at_ms, source, metadata}} ->
+        stale_after_ms =
+          case Map.get(metadata, :stale_after_ms) do
+            value when is_integer(value) and value > 0 -> value
+            _missing_or_invalid -> stale_after_ms(instance_id, chain_id, source)
+          end
+
+        observation = %{
+          height: height,
+          observed_at_ms: observed_at_ms,
+          source: source,
+          metadata: metadata,
+          stale_after_ms: stale_after_ms,
+          age_ms: max(0, now_ms - observed_at_ms)
+        }
+
+        if fresh?(observation, now_ms),
+          do: {:ok, observation},
+          else: {:error, {:stale, observation}}
+
+      {:error, :not_found} ->
+        {:error, :not_found}
+    end
+  end
+
+  @spec fresh?(map(), integer()) :: boolean()
+  def fresh?(observation, now_ms \\ System.system_time(:millisecond))
+      when is_map(observation) and is_integer(now_ms) do
+    observed_at_ms = Map.get(observation, :observed_at_ms, Map.get(observation, :timestamp))
+    stale_after_ms = Map.get(observation, :stale_after_ms, @default_stale_after_ms)
+
+    is_integer(observed_at_ms) and is_integer(stale_after_ms) and stale_after_ms > 0 and
+      now_ms - observed_at_ms <= stale_after_ms
+  end
+
+  @spec stale_after_ms(String.t(), pos_integer(), :http | :ws | nil) :: pos_integer()
+  def stale_after_ms(instance_id, chain_id, source \\ nil)
+      when is_binary(instance_id) and is_integer(chain_id) and chain_id > 0 and
+             source in [:http, :ws, nil] do
+    config = Worker.load_config(instance_id, chain_id)
+
+    poll_window_ms =
+      positive(Map.get(config, :poll_interval_ms), div(@default_stale_after_ms, 3)) * 3
+
+    new_heads_window_ms =
+      positive(Map.get(config, :staleness_threshold_ms), @default_stale_after_ms)
+
+    case source do
+      :http -> poll_window_ms
+      :ws -> new_heads_window_ms
+      nil -> max(poll_window_ms, new_heads_window_ms)
+    end
+  rescue
+    _error -> @default_stale_after_ms
+  catch
+    :exit, _reason -> @default_stale_after_ms
+  end
+
+  defp positive(value, _fallback) when is_integer(value) and value > 0, do: value
+  defp positive(_value, fallback), do: fallback
+end

--- a/lib/lasso/core/block_sync/observation_projection.ex
+++ b/lib/lasso/core/block_sync/observation_projection.ex
@@ -1,0 +1,151 @@
+defmodule Lasso.BlockSync.ObservationProjection do
+  @moduledoc """
+  Time-aligns block observations before comparing them with newer evidence.
+
+  A raw height describes a provider at its observation time. Comparing an older
+  HTTP sample directly with a streaming head creates false lag on fast chains.
+  Fresh HTTP samples therefore receive bounded advancement credit for elapsed
+  time. WebSocket observations remain direct evidence and receive no inferred
+  advancement. A projection never advances past an observed reference height.
+  """
+
+  @type projection :: %{
+          raw_height: integer() | nil,
+          height: integer() | nil,
+          raw_lag: integer() | nil,
+          lag: integer() | nil,
+          credit_blocks: non_neg_integer(),
+          age_ms: non_neg_integer() | nil,
+          estimated?: boolean(),
+          evidence: :observed | :estimated | :stale | :unavailable
+        }
+
+  @spec project(map(), non_neg_integer(), integer()) :: projection()
+  def project(observation, block_time_ms, now_ms \\ System.system_time(:millisecond))
+
+  def project(observation, block_time_ms, now_ms)
+      when is_map(observation) and is_integer(now_ms) do
+    raw_height = Map.get(observation, :height)
+    raw_lag = Map.get(observation, :lag)
+    age_ms = observation_age_ms(observation, now_ms)
+    stale? = stale_for_age?(observation, age_ms)
+
+    credit_blocks = advancement_credit(observation, raw_lag, age_ms, stale?, block_time_ms)
+
+    %{
+      raw_height: raw_height,
+      height: advance_height(raw_height, credit_blocks),
+      raw_lag: raw_lag,
+      lag: advance_lag(raw_lag, credit_blocks),
+      credit_blocks: credit_blocks,
+      age_ms: age_ms,
+      estimated?: credit_blocks > 0,
+      evidence: evidence(raw_height, stale?, credit_blocks)
+    }
+  end
+
+  def project(_observation, _block_time_ms, _now_ms),
+    do: %{
+      raw_height: nil,
+      height: nil,
+      raw_lag: nil,
+      lag: nil,
+      credit_blocks: 0,
+      age_ms: nil,
+      estimated?: false,
+      evidence: :unavailable
+    }
+
+  @spec projected_lag(map(), non_neg_integer(), integer()) :: integer() | nil
+  def projected_lag(observation, block_time_ms, now_ms \\ System.system_time(:millisecond))
+
+  def projected_lag(observation, block_time_ms, now_ms),
+    do: project(observation, block_time_ms, now_ms).lag
+
+  @doc "Time-aligns an observation toward, but never beyond, an observed reference height."
+  @spec align_height(map(), integer(), non_neg_integer(), integer()) :: projection()
+  def align_height(
+        observation,
+        observed_height,
+        block_time_ms,
+        now_ms \\ System.system_time(:millisecond)
+      )
+
+  def align_height(observation, observed_height, block_time_ms, now_ms)
+      when is_map(observation) and is_integer(observed_height) do
+    lag =
+      case Map.get(observation, :height) do
+        height when is_integer(height) -> height - observed_height
+        _missing -> nil
+      end
+
+    observation
+    |> Map.put(:lag, lag)
+    |> project(block_time_ms, now_ms)
+  end
+
+  @spec stale?(map(), integer()) :: boolean()
+  def stale?(observation, now_ms) when is_map(observation) and is_integer(now_ms),
+    do: stale_for_age?(observation, observation_age_ms(observation, now_ms))
+
+  defp stale_for_age?(observation, age_ms) do
+    case {age_ms, Map.get(observation, :stale_after_ms)} do
+      {age, stale_after_ms}
+      when is_integer(age) and is_integer(stale_after_ms) and stale_after_ms > 0 ->
+        age > stale_after_ms
+
+      _ ->
+        false
+    end
+  end
+
+  defp observation_age_ms(observation, now_ms) do
+    case Map.get(observation, :observed_at_ms) do
+      observed_at_ms when is_integer(observed_at_ms) -> max(0, now_ms - observed_at_ms)
+      _ -> nil
+    end
+  end
+
+  defp advancement_credit(observation, raw_lag, age_ms, false, block_time_ms)
+       when is_integer(raw_lag) and raw_lag < 0 and is_integer(age_ms) and
+              is_integer(block_time_ms) and block_time_ms > 0 do
+    if Map.get(observation, :source) in [:http, "http"] do
+      observation
+      |> credit_window_ms()
+      |> credit_for_age(age_ms, block_time_ms, raw_lag)
+    else
+      0
+    end
+  end
+
+  defp advancement_credit(_observation, _raw_lag, _age_ms, _stale?, _block_time_ms), do: 0
+
+  defp credit_window_ms(%{credit_window_ms: value}) when is_integer(value) and value > 0,
+    do: value
+
+  defp credit_window_ms(%{stale_after_ms: value}) when is_integer(value) and value > 0,
+    do: div(value, 3)
+
+  defp credit_window_ms(_observation), do: 0
+
+  defp credit_for_age(credit_window_ms, age_ms, block_time_ms, raw_lag)
+       when credit_window_ms > 0 do
+    age_ms
+    |> min(credit_window_ms)
+    |> div(block_time_ms)
+    |> min(abs(raw_lag))
+  end
+
+  defp credit_for_age(_credit_window_ms, _age_ms, _block_time_ms, _raw_lag), do: 0
+
+  defp advance_height(height, credit) when is_integer(height), do: height + credit
+  defp advance_height(_height, _credit), do: nil
+
+  defp advance_lag(lag, credit) when is_integer(lag), do: lag + credit
+  defp advance_lag(_lag, _credit), do: nil
+
+  defp evidence(_height, true, _credit), do: :stale
+  defp evidence(height, _stale, _credit) when not is_integer(height), do: :unavailable
+  defp evidence(_height, _stale, credit) when credit > 0, do: :estimated
+  defp evidence(_height, _stale, _credit), do: :observed
+end

--- a/lib/lasso/core/block_sync/registry.ex
+++ b/lib/lasso/core/block_sync/registry.ex
@@ -23,6 +23,7 @@ defmodule Lasso.BlockSync.Registry do
 
   require Logger
 
+  alias Lasso.BlockSync.ObservationProjection
   alias Lasso.Core.BlockSync.BlockTimeMeasurement
 
   @table :block_sync_registry
@@ -71,13 +72,17 @@ defmodule Lasso.BlockSync.Registry do
   end
 
   @doc """
-  Get the consensus block height for a chain using P75 (75th percentile).
+  Get the time-aligned consensus block height for a chain using P75.
 
   With 1-3 providers, returns MAX (same as before). With 4+ providers, returns
   the second-highest height — filtering out one outlier fast provider that could
-  make all others appear lagged.
+  make all others appear lagged. When dynamic block time is available, fresh
+  HTTP samples are first advanced toward the highest actually observed height
+  by no more than their elapsed-time budget. WebSocket samples remain direct
+  evidence and no sample can be advanced beyond a real observation.
 
-  Only considers heights from the last `freshness_ms` milliseconds.
+  Each observation carries the effective freshness window from its worker
+  configuration. The explicit two-argument form overrides that window.
 
   Returns `{:ok, height}` or `{:error, :no_data}`.
   """
@@ -109,11 +114,19 @@ defmodule Lasso.BlockSync.Registry do
 
   Returns `{:ok, height}` or `{:error, :no_data}`.
   """
-  @spec get_consensus_height_filtered(pos_integer(), [String.t()] | nil, non_neg_integer()) ::
+  @spec get_consensus_height_filtered(
+          pos_integer(),
+          [String.t()] | nil,
+          non_neg_integer() | nil
+        ) ::
           {:ok, integer()} | {:error, :no_data}
-  def get_consensus_height_filtered(chain_id, provider_ids, freshness_ms \\ @default_freshness_ms)
-      when is_integer(chain_id) and chain_id > 0 do
-    calculate_consensus(chain_id, provider_ids, freshness_ms)
+  def get_consensus_height_filtered(chain_id, provider_ids, freshness_ms \\ nil)
+      when is_integer(chain_id) and chain_id > 0 and
+             (is_nil(freshness_ms) or
+                (is_integer(freshness_ms) and freshness_ms >= 0)) do
+    if is_nil(freshness_ms),
+      do: calculate_current_consensus(chain_id, provider_ids),
+      else: calculate_consensus(chain_id, provider_ids, freshness_ms)
   end
 
   @doc """
@@ -125,14 +138,17 @@ defmodule Lasso.BlockSync.Registry do
   - `{:error, :no_provider_data}` if provider has no height data
   - `{:error, :no_consensus}` if no consensus can be calculated
   """
-  @spec get_provider_lag(pos_integer(), String.t(), non_neg_integer()) ::
+  @spec get_provider_lag(pos_integer(), String.t(), non_neg_integer() | nil) ::
           {:ok, integer()} | {:error, :no_provider_data | :no_consensus | :stale_data}
-  def get_provider_lag(chain_id, provider_id, freshness_ms \\ @default_freshness_ms)
-      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) do
-    with {:ok, {height, timestamp, _source, _meta}} <- get_height(chain_id, provider_id),
-         age = System.system_time(:millisecond) - timestamp,
-         true <- age <= freshness_ms,
-         {:ok, consensus} <- get_consensus_height(chain_id, freshness_ms) do
+  def get_provider_lag(chain_id, provider_id, freshness_ms \\ nil)
+      when is_integer(chain_id) and chain_id > 0 and is_binary(provider_id) and
+             (is_nil(freshness_ms) or
+                (is_integer(freshness_ms) and freshness_ms >= 0)) do
+    now_ms = System.system_time(:millisecond)
+
+    with {:ok, {height, timestamp, _source, metadata}} <- get_height(chain_id, provider_id),
+         true <- observation_fresh?(timestamp, metadata, freshness_ms, now_ms),
+         {:ok, consensus} <- consensus_height(chain_id, freshness_ms) do
       {:ok, height - consensus}
     else
       false -> {:error, :stale_data}
@@ -244,16 +260,19 @@ defmodule Lasso.BlockSync.Registry do
   ## Private Functions
 
   defp refresh_consensus_cache(chain_id, now_ms, revision) do
-    cutoff = now_ms - @default_freshness_ms
-
-    case select_fresh_samples(chain_id, cutoff) do
+    case select_current_samples(chain_id, nil, now_ms) do
       [] ->
         {:error, :no_data}
 
       samples ->
-        height = consensus(Enum.map(samples, &elem(&1, 0)))
-        valid_through_ms = samples |> Enum.map(&elem(&1, 1)) |> Enum.min()
-        valid_through_ms = valid_through_ms + @default_freshness_ms
+        height = consensus_for_samples(samples, chain_id, now_ms)
+
+        valid_through_ms =
+          samples
+          |> Enum.map(fn {_height, timestamp, _source, metadata} ->
+            timestamp + stale_after_ms(metadata)
+          end)
+          |> Enum.min()
 
         publish_consensus(
           consensus_key(chain_id),
@@ -310,16 +329,53 @@ defmodule Lasso.BlockSync.Registry do
   defp publish_consensus(_key, _revision, _height, _valid_through_ms, 0), do: :ok
 
   defp calculate_consensus(chain_id, provider_ids, freshness_ms) do
-    cutoff = System.system_time(:millisecond) - freshness_ms
-    fresh_heights = select_fresh_heights(chain_id, provider_ids, cutoff)
+    now_ms = System.system_time(:millisecond)
+    samples = select_current_samples(chain_id, provider_ids, now_ms, freshness_ms)
 
-    case fresh_heights do
+    case samples do
       [] ->
         {:error, :no_data}
 
-      heights ->
-        {:ok, consensus(heights)}
+      current ->
+        {:ok, consensus_for_samples(current, chain_id, now_ms)}
     end
+  end
+
+  defp calculate_current_consensus(chain_id, provider_ids) do
+    now_ms = System.system_time(:millisecond)
+    samples = select_current_samples(chain_id, provider_ids, now_ms)
+
+    case samples do
+      [] -> {:error, :no_data}
+      current -> {:ok, consensus_for_samples(current, chain_id, now_ms)}
+    end
+  end
+
+  defp consensus_for_samples(samples, chain_id, now_ms) do
+    observed_height = samples |> Enum.map(&elem(&1, 0)) |> Enum.max()
+
+    heights =
+      case get_block_time_ms(chain_id) do
+        block_time_ms when is_integer(block_time_ms) and block_time_ms > 0 ->
+          Enum.map(samples, fn {height, timestamp, source, metadata} ->
+            metadata = metadata || %{}
+
+            %{
+              height: height,
+              source: source,
+              observed_at_ms: timestamp,
+              stale_after_ms: stale_after_ms(metadata),
+              credit_window_ms: Map.get(metadata, :optimistic_credit_ms)
+            }
+            |> ObservationProjection.align_height(observed_height, block_time_ms, now_ms)
+            |> Map.fetch!(:height)
+          end)
+
+        _unknown_block_time ->
+          Enum.map(samples, &elem(&1, 0))
+      end
+
+    consensus(heights)
   end
 
   defp consensus([single]), do: single
@@ -330,41 +386,42 @@ defmodule Lasso.BlockSync.Registry do
     Enum.at(sorted, idx)
   end
 
-  defp select_fresh_samples(chain_id, cutoff) do
+  defp select_current_samples(chain_id, provider_ids, now_ms, freshness_ms \\ nil) do
     :ets.select(@table, [
       {
-        {{:height, chain_id, :_}, {:"$1", :"$2", :_, :_}},
-        [{:>=, :"$2", cutoff}],
-        [{{:"$1", :"$2"}}]
+        {{:height, chain_id, :"$1"}, {:"$2", :"$3", :"$4", :"$5"}},
+        [],
+        [{{:"$1", :"$2", :"$3", :"$4", :"$5"}}]
       }
     ])
-  end
-
-  defp select_fresh_heights(chain_id, provider_ids, cutoff)
-       when provider_ids in [nil, []] do
-    :ets.select(@table, [
-      {
-        {{:height, chain_id, :_}, {:"$1", :"$2", :_, :_}},
-        [{:>=, :"$2", cutoff}],
-        [:"$1"]
-      }
-    ])
-  end
-
-  defp select_fresh_heights(chain_id, provider_ids, cutoff) when is_list(provider_ids) do
-    provider_set = MapSet.new(provider_ids)
-
-    :ets.select(@table, [
-      {
-        {{:height, chain_id, :"$1"}, {:"$2", :"$3", :_, :_}},
-        [{:>=, :"$3", cutoff}],
-        [{{:"$1", :"$2"}}]
-      }
-    ])
-    |> Enum.reduce([], fn {provider_id, height}, heights ->
-      if MapSet.member?(provider_set, provider_id), do: [height | heights], else: heights
+    |> Enum.filter(fn {provider_id, _height, timestamp, _source, metadata} ->
+      provider_selected?(provider_ids, provider_id) and
+        observation_fresh?(timestamp, metadata, freshness_ms, now_ms)
+    end)
+    |> Enum.map(fn {_provider_id, height, timestamp, source, metadata} ->
+      {height, timestamp, source, metadata}
     end)
   end
+
+  defp provider_selected?(provider_ids, _provider_id) when provider_ids in [nil, []], do: true
+  defp provider_selected?(provider_ids, provider_id), do: provider_id in provider_ids
+
+  defp observation_fresh?(timestamp, metadata, freshness_ms, now_ms) do
+    freshness_ms = freshness_ms || stale_after_ms(metadata)
+    now_ms - timestamp <= freshness_ms
+  end
+
+  defp stale_after_ms(metadata) when is_map(metadata) do
+    case Map.get(metadata, :stale_after_ms) do
+      value when is_integer(value) and value > 0 -> value
+      _missing_or_invalid -> @default_freshness_ms
+    end
+  end
+
+  defp stale_after_ms(_metadata), do: @default_freshness_ms
+
+  defp consensus_height(chain_id, nil), do: get_consensus_height(chain_id)
+  defp consensus_height(chain_id, freshness_ms), do: get_consensus_height(chain_id, freshness_ms)
 
   defp consensus_key(chain_id), do: {:consensus, chain_id}
 end

--- a/lib/lasso/core/block_sync/worker.ex
+++ b/lib/lasso/core/block_sync/worker.ex
@@ -212,6 +212,11 @@ defmodule Lasso.BlockSync.Worker do
       when instance_id == state.instance_id do
     source = if metadata[:latency_ms], do: :http, else: :ws
 
+    metadata =
+      metadata
+      |> Map.put(:stale_after_ms, observation_stale_after_ms(state, source))
+      |> maybe_put_optimistic_credit(state, source)
+
     BlockSyncRegistry.put_height(state.chain_id, instance_id, height, source, metadata)
     broadcast_height_update(state, height, source)
 
@@ -751,6 +756,15 @@ defmodule Lasso.BlockSync.Worker do
 
     %{state | http_strategy: new_http, http_reduced: false}
   end
+
+  defp observation_stale_after_ms(state, :http), do: state.config.poll_interval_ms * 3
+  defp observation_stale_after_ms(state, :ws), do: state.config.staleness_threshold_ms
+
+  defp maybe_put_optimistic_credit(metadata, state, :http) do
+    Map.put(metadata, :optimistic_credit_ms, state.config.poll_interval_ms)
+  end
+
+  defp maybe_put_optimistic_credit(metadata, _state, _source), do: metadata
 
   defp handle_ws_reconnected(%{mode: nil} = state), do: state
 

--- a/lib/lasso/providers/lag_calculation.ex
+++ b/lib/lasso/providers/lag_calculation.ex
@@ -1,10 +1,14 @@
 defmodule Lasso.Providers.LagCalculation do
   @moduledoc """
-  Shared optimistic lag calculation used by both CandidateListing (selection) and
-  StatusHelpers (dashboard display).
+  Shared time-aligned lag calculation used by provider selection and dashboards.
+
+  HTTP height samples receive bounded advancement credit based on their age and
+  effective poll cadence. WebSocket observations are compared directly, stale
+  evidence is rejected, and no projection can advance a provider past the
+  captured consensus height.
   """
 
-  alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
+  alias Lasso.BlockSync.{Observation, ObservationProjection, Registry}
   alias Lasso.Config.ConfigStore
   alias Lasso.RPC.ChainState
 
@@ -12,12 +16,12 @@ defmodule Lasso.Providers.LagCalculation do
           {:ok, integer(), integer()} | {:error, term()}
   def calculate_optimistic_lag(chain_id, provider_or_instance_id, block_time_ms)
       when is_integer(chain_id) and chain_id > 0 do
-    with {:ok, {height, timestamp, _source, _meta}} <-
-           BlockSyncRegistry.get_height(chain_id, provider_or_instance_id),
+    with {:ok, observation} <- Observation.read(chain_id, provider_or_instance_id),
          {:ok, consensus} <- ChainState.consensus_height(chain_id) do
-      calculate_from_height(height, timestamp, block_time_ms, consensus)
+      calculate_from_observation(observation, block_time_ms, consensus)
     else
       {:error, :not_found} -> {:error, :no_provider_data}
+      {:error, {:stale, _observation}} -> {:error, :stale_provider_data}
       {:error, :no_data} -> {:error, :no_consensus}
       error -> error
     end
@@ -37,33 +41,39 @@ defmodule Lasso.Providers.LagCalculation do
         consensus
       )
       when is_integer(chain_id) and chain_id > 0 and is_integer(consensus) and consensus >= 0 do
-    case BlockSyncRegistry.get_height(chain_id, provider_or_instance_id) do
-      {:ok, {height, timestamp, _source, _meta}} ->
-        calculate_from_height(height, timestamp, block_time_ms, consensus)
+    case Observation.read(chain_id, provider_or_instance_id) do
+      {:ok, observation} ->
+        calculate_from_observation(observation, block_time_ms, consensus)
 
       {:error, :not_found} ->
         {:error, :no_provider_data}
+
+      {:error, {:stale, _observation}} ->
+        {:error, :stale_provider_data}
     end
   end
 
-  defp calculate_from_height(height, timestamp, block_time_ms, consensus) do
-    now = System.system_time(:millisecond)
-    elapsed_ms = now - timestamp
-    raw_lag = height - consensus
+  defp calculate_from_observation(observation, block_time_ms, consensus) do
+    raw_lag = observation.height - consensus
 
-    staleness_credit =
-      if block_time_ms > 0, do: div(elapsed_ms, block_time_ms), else: 0
+    projected =
+      observation
+      |> Map.put(:lag, raw_lag)
+      |> Map.put(:credit_window_ms, credit_window_ms(observation.metadata))
+      |> ObservationProjection.project(block_time_ms)
 
-    max_credit = div(30_000, max(block_time_ms, 1))
-    capped_credit = min(staleness_credit, max_credit)
-    optimistic_lag = height + capped_credit - consensus
-
-    {:ok, optimistic_lag, raw_lag}
+    {:ok, projected.lag, raw_lag}
   end
+
+  defp credit_window_ms(%{optimistic_credit_ms: credit_ms})
+       when is_integer(credit_ms) and credit_ms > 0,
+       do: credit_ms
+
+  defp credit_window_ms(_metadata), do: nil
 
   @spec get_block_time_ms(pos_integer(), String.t() | nil) :: non_neg_integer()
   def get_block_time_ms(chain_id, profile \\ nil) when is_integer(chain_id) and chain_id > 0 do
-    case BlockSyncRegistry.get_block_time_ms(chain_id) do
+    case Registry.get_block_time_ms(chain_id) do
       ms when is_integer(ms) and ms > 0 ->
         ms
 

--- a/test/lasso/core/block_sync/consensus_p75_test.exs
+++ b/test/lasso/core/block_sync/consensus_p75_test.exs
@@ -2,6 +2,7 @@ defmodule Lasso.BlockSync.ConsensusP75Test do
   use ExUnit.Case, async: false
 
   alias Lasso.BlockSync.Registry, as: BlockSyncRegistry
+  alias Lasso.Core.BlockSync.BlockTimeMeasurement
 
   setup do
     chain = System.unique_integer([:positive])
@@ -81,6 +82,63 @@ defmodule Lasso.BlockSync.ConsensusP75Test do
       assert {:ok, 100} = BlockSyncRegistry.get_consensus_height(chain)
     end
 
+    test "time-aligns fresh sampled providers before rejecting a live head as an outlier", %{
+      chain: chain
+    } do
+      now_ms = System.system_time(:millisecond)
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:block_time, chain},
+         %BlockTimeMeasurement{ema_ms: 100.0, sample_count: 5, last_height: 1_200}}
+      )
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, chain, "live"}, {1_200, now_ms, :ws, %{stale_after_ms: 30_000}}}
+      )
+
+      for provider <- ~w(sampled-1 sampled-2 sampled-3 sampled-4) do
+        :ets.insert(
+          :block_sync_registry,
+          {{:height, chain, provider},
+           {1_000, now_ms - 20_000, :http,
+            %{stale_after_ms: 180_000, optimistic_credit_ms: 60_000}}}
+        )
+      end
+
+      assert {:ok, 1_200} = BlockSyncRegistry.get_consensus_height_filtered(chain, [])
+    end
+
+    test "bounded alignment does not let one implausible head dictate consensus", %{
+      chain: chain
+    } do
+      now_ms = System.system_time(:millisecond)
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:block_time, chain},
+         %BlockTimeMeasurement{ema_ms: 100.0, sample_count: 5, last_height: 1_500}}
+      )
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, chain, "outlier"}, {1_500, now_ms, :ws, %{stale_after_ms: 30_000}}}
+      )
+
+      for provider <- ~w(sampled-1 sampled-2 sampled-3 sampled-4) do
+        :ets.insert(
+          :block_sync_registry,
+          {{:height, chain, provider},
+           {1_000, now_ms - 1_000, :http,
+            %{stale_after_ms: 180_000, optimistic_credit_ms: 60_000}}}
+        )
+      end
+
+      assert {:ok, consensus} = BlockSyncRegistry.get_consensus_height_filtered(chain, [])
+      assert consensus in 1_009..1_011
+    end
+
     test "no providers: returns error", %{chain: chain} do
       assert {:error, :no_data} = BlockSyncRegistry.get_consensus_height(chain)
     end
@@ -100,6 +158,27 @@ defmodule Lasso.BlockSync.ConsensusP75Test do
 
       assert {999, ^stale_timestamp, :ws, %{payload: "stale"}} =
                BlockSyncRegistry.get_all_heights(chain)["stale"]
+    end
+
+    test "default consensus and lag honor the observation's configured freshness", %{
+      chain: chain
+    } do
+      observed_at_ms = System.system_time(:millisecond) - 45_000
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, chain, "slow-poll-provider"},
+         {500, observed_at_ms, :http, %{stale_after_ms: 90_000}}}
+      )
+
+      assert {:ok, 500} = BlockSyncRegistry.get_consensus_height(chain)
+      assert {:ok, 500} = BlockSyncRegistry.get_consensus_height_filtered(chain, [])
+      assert {:ok, 0} = BlockSyncRegistry.get_provider_lag(chain, "slow-poll-provider")
+
+      assert {:error, :no_data} = BlockSyncRegistry.get_consensus_height(chain, 30_000)
+
+      assert {:error, :stale_data} =
+               BlockSyncRegistry.get_provider_lag(chain, "slow-poll-provider", 30_000)
     end
 
     test "filtered consensus preserves provider and empty-list semantics", %{chain: chain} do

--- a/test/lasso/core/block_sync/observation_projection_test.exs
+++ b/test/lasso/core/block_sync/observation_projection_test.exs
@@ -1,0 +1,114 @@
+defmodule Lasso.BlockSync.ObservationProjectionTest do
+  use ExUnit.Case, async: true
+
+  alias Lasso.BlockSync.ObservationProjection
+
+  test "credits a fresh HTTP sample for elapsed blocks within its observation window" do
+    observation = %{
+      height: 1_000,
+      lag: -200,
+      source: :http,
+      observed_at_ms: 980_000,
+      stale_after_ms: 180_000
+    }
+
+    assert %{
+             raw_height: 1_000,
+             height: 1_200,
+             raw_lag: -200,
+             lag: 0,
+             credit_blocks: 200,
+             estimated?: true,
+             evidence: :estimated
+           } = ObservationProjection.project(observation, 100, 1_000_000)
+  end
+
+  test "caps HTTP credit at the explicit observation window" do
+    observation = %{
+      height: 300,
+      lag: -700,
+      source: :http,
+      observed_at_ms: 900_000,
+      stale_after_ms: 300_000,
+      credit_window_ms: 60_000
+    }
+
+    assert ObservationProjection.projected_lag(observation, 100, 1_000_000) == -100
+  end
+
+  test "never infers a sampled provider past observed evidence" do
+    observation = %{
+      height: 995,
+      lag: -5,
+      source: :http,
+      observed_at_ms: 900_000,
+      stale_after_ms: 180_000
+    }
+
+    assert %{height: 1_000, lag: 0, credit_blocks: 5} =
+             ObservationProjection.project(observation, 100, 1_000_000)
+  end
+
+  test "stale samples receive no advancement credit" do
+    observation = %{
+      height: 900,
+      lag: -100,
+      source: :http,
+      observed_at_ms: 819_999,
+      stale_after_ms: 180_000
+    }
+
+    assert %{height: 900, lag: -100, credit_blocks: 0, evidence: :stale} =
+             ObservationProjection.project(observation, 100, 1_000_000)
+  end
+
+  test "clock skew cannot produce negative age or advancement" do
+    observation = %{
+      height: 995,
+      lag: -5,
+      source: :http,
+      observed_at_ms: 1_000_100,
+      stale_after_ms: 180_000
+    }
+
+    assert %{height: 995, lag: -5, age_ms: 0, credit_blocks: 0, evidence: :observed} =
+             ObservationProjection.project(observation, 100, 1_000_000)
+  end
+
+  test "does not estimate event-driven WebSocket observations" do
+    observation = %{
+      height: 996,
+      lag: -4,
+      source: :ws,
+      observed_at_ms: 900_000,
+      stale_after_ms: 180_000
+    }
+
+    assert %{height: 996, lag: -4, credit_blocks: 0, evidence: :observed} =
+             ObservationProjection.project(observation, 100, 1_000_000)
+  end
+
+  test "aligns sampled evidence toward but never beyond an observed height" do
+    observation = %{
+      height: 1_000,
+      source: :http,
+      observed_at_ms: 980_000,
+      stale_after_ms: 180_000
+    }
+
+    assert %{height: 1_200, lag: 0, estimated?: true} =
+             ObservationProjection.align_height(observation, 1_200, 100, 1_000_000)
+  end
+
+  test "does not move WebSocket evidence while aligning observations" do
+    observation = %{
+      height: 1_000,
+      source: :ws,
+      observed_at_ms: 980_000,
+      stale_after_ms: 180_000
+    }
+
+    assert %{height: 1_000, lag: -200, estimated?: false} =
+             ObservationProjection.align_height(observation, 1_200, 100, 1_000_000)
+  end
+end

--- a/test/lasso/core/block_sync/observation_test.exs
+++ b/test/lasso/core/block_sync/observation_test.exs
@@ -1,0 +1,56 @@
+defmodule Lasso.BlockSync.ObservationTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.BlockSync.{Observation, Registry}
+
+  setup do
+    chain_id = System.unique_integer([:positive])
+    Registry.clear_chain(chain_id)
+    on_exit(fn -> Registry.clear_chain(chain_id) end)
+    {:ok, chain_id: chain_id}
+  end
+
+  test "evaluates freshness against the observation-specific window" do
+    now_ms = 1_000_000
+
+    assert Observation.fresh?(
+             %{observed_at_ms: now_ms - 19_999, stale_after_ms: 20_000},
+             now_ms
+           )
+
+    refute Observation.fresh?(
+             %{observed_at_ms: now_ms - 20_001, stale_after_ms: 20_000},
+             now_ms
+           )
+  end
+
+  test "accepts the timestamp shape used by dashboard observations" do
+    assert Observation.fresh?(%{timestamp: 10_000, stale_after_ms: 5_000}, 15_000)
+    refute Observation.fresh?(%{timestamp: 10_000, stale_after_ms: 5_000}, 15_001)
+  end
+
+  test "uses the freshness contract stored with a worker observation", %{chain_id: chain_id} do
+    instance_id = "stored-freshness"
+    observed_at_ms = System.system_time(:millisecond) - 45_000
+
+    :ets.insert(
+      :block_sync_registry,
+      {{:height, chain_id, instance_id}, {123, observed_at_ms, :http, %{stale_after_ms: 90_000}}}
+    )
+
+    assert {:ok, %{height: 123, stale_after_ms: 90_000}} =
+             Observation.read(chain_id, instance_id)
+  end
+
+  test "rejects observations beyond their stored freshness contract", %{chain_id: chain_id} do
+    instance_id = "stale-observation"
+    observed_at_ms = System.system_time(:millisecond) - 90_001
+
+    :ets.insert(
+      :block_sync_registry,
+      {{:height, chain_id, instance_id}, {123, observed_at_ms, :ws, %{stale_after_ms: 90_000}}}
+    )
+
+    assert {:error, {:stale, %{height: 123}}} = Observation.read(chain_id, instance_id)
+  end
+end

--- a/test/lasso/rpc/optimistic_lag_test.exs
+++ b/test/lasso/rpc/optimistic_lag_test.exs
@@ -1,6 +1,6 @@
 defmodule Lasso.RPC.OptimisticLagTest do
   @moduledoc """
-  Tests for the optimistic lag calculation used in provider selection.
+  Tests for the time-aligned lag calculation used in provider selection.
 
   The optimistic lag formula accounts for observation delay on HTTP providers:
 
@@ -8,9 +8,9 @@ defmodule Lasso.RPC.OptimisticLagTest do
       optimistic_height = reported_height + staleness_credit
       optimistic_lag = optimistic_height - consensus_height
 
-  This prevents HTTP providers from being unfairly excluded on fast chains
-  like Arbitrum (0.25s blocks) where polling intervals (2s) cause providers
-  to always appear ~8 blocks behind.
+  This prevents HTTP providers from being unfairly excluded on fast chains.
+  Production credit is bounded by the effective poll cadence and never applies
+  to WebSocket observations.
   """
 
   use ExUnit.Case, async: true
@@ -154,6 +154,46 @@ defmodule Lasso.RPC.OptimisticLagTest do
 
       assert {:ok, -5, -5} =
                LagCalculation.calculate_optimistic_lag(@chain, provider_id, 12_000, 1_000)
+    end
+
+    test "uses the observation cadence as the advancement bound" do
+      provider_id = "managed_cadence_#{System.unique_integer()}"
+      timestamp = System.system_time(:millisecond) - 60_000
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, @chain, provider_id},
+         {1_000, timestamp, :http, %{optimistic_credit_ms: 60_000, stale_after_ms: 180_000}}}
+      )
+
+      assert {:ok, 0, -240} =
+               LagCalculation.calculate_optimistic_lag(@chain, provider_id, 250, 1_240)
+    end
+
+    test "does not infer advancement for WebSocket observations" do
+      provider_id = "ws_evidence_#{System.unique_integer()}"
+      timestamp = System.system_time(:millisecond) - 2_000
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, @chain, provider_id}, {1_000, timestamp, :ws, %{stale_after_ms: 30_000}}}
+      )
+
+      assert {:ok, -8, -8} =
+               LagCalculation.calculate_optimistic_lag(@chain, provider_id, 250, 1_008)
+    end
+
+    test "rejects stale evidence instead of manufacturing a current lag" do
+      provider_id = "stale_evidence_#{System.unique_integer()}"
+      timestamp = System.system_time(:millisecond) - 60_001
+
+      :ets.insert(
+        :block_sync_registry,
+        {{:height, @chain, provider_id}, {1_000, timestamp, :http, %{stale_after_ms: 60_000}}}
+      )
+
+      assert {:error, :stale_provider_data} =
+               LagCalculation.calculate_optimistic_lag(@chain, provider_id, 250, 1_240)
     end
 
     test "optimistic lag passes threshold when raw lag would fail" do


### PR DESCRIPTION
## Summary

- model provider block heights as freshness-bounded observations
- time-align only fresh HTTP samples using bounded polling-cadence credit
- preserve WebSocket heads as direct evidence and reject stale lag inputs
- compute P75 consensus from aligned samples without exceeding an observed height
- document the shared routing/dashboard contract

## Hot-path impact

No database, network, or process coordination is added to request routing. Consensus remains an ETS-backed cached read. Cache refresh performs bounded arithmetic over the already-small fresh observation set when a height update invalidates the snapshot.

## Verification

- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
- `mix test` — 1,590 tests, 0 failures, 160 excluded
- focused observation/consensus/lag suite — 41 tests, 0 failures

Cloud provenance: lasso-cloud #912 and #913, adapted to the OSS single-node runtime without Cloud cluster replication, billing, or UI code.