### PR TITLE
Prepare Lasso RPC v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-09-04
+
 ### Fixed
 
 - Time-aligned fast-chain consensus using bounded HTTP observation credit while preserving WebSocket heads as direct evidence
@@ -108,7 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/jaxernst/lasso-rpc/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/jaxernst/lasso-rpc/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jaxernst/lasso-rpc/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-26A5E4?style=flat-square&labelColor=19202E&logo=telegram&logoColor=white)](https://t.me/+79pFERTlZPIzZTZh)
 [![X](https://img.shields.io/badge/follow-%40lassoRPC-19202E?style=flat-square&labelColor=19202E&logo=x&logoColor=white)](https://x.com/lassoRPC)
 [![License](https://img.shields.io/badge/license-Apache--2.0-19202E?style=flat-square&labelColor=19202E)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.3.0-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.3.1-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
 [![Elixir](https://img.shields.io/badge/built%20with-Elixir%2FOTP-19202E?style=flat-square&labelColor=19202E&logo=elixir&logoColor=white)](https://elixir-lang.org)
 
 Lasso is a smart proxy/router that turns your node infrastructure and RPC providers into a **fast, observable, configurable, and resilient** multi-chain JSON-RPC layer.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],


### PR DESCRIPTION
## Summary

- bump the OSS release version and README badge to `0.3.1`
- publish the block observation, lag, and consensus corrections in the versioned changelog
- advance changelog comparison links

## Verification

- exact release candidate: 1,590 tests, 0 failures, 160 excluded
- `mix compile --warnings-as-errors`
- `mix format --check-formatted`
- production asset build succeeded
- `MIX_ENV=prod mix release` assembled `lasso-0.3.1` successfully
- upstream correctness PR #123 passed unit, hermetic integration, Docker boot, Credo, Dialyzer, and review checks

This is a patch release: no configuration or public API migration is required.