### PR TITLE
Stabilize blocked telemetry delivery test

### DIFF
--- a/test/lasso/core/request/request_projection_test.exs
+++ b/test/lasso/core/request/request_projection_test.exs
@@ -447,7 +447,7 @@ defmodule Lasso.RPC.RequestProjectionTest do
     assert_receive {:terminal_handler_entered, delivery_pid}, 1_000
     refute Task.yield(delivery, 0)
     send(delivery_pid, :release_terminal_handler)
-    assert :ok = Task.await(delivery)
+    assert :ok = Task.await(delivery, 15_000)
   end
 
   test "a terminal without an upstream route remains telemetry-only" do


### PR DESCRIPTION
## Summary

Give the request-projection test that deliberately blocks a telemetry consumer an explicit cleanup timeout instead of relying on `Task.await/1`'s 5-second default. The ordering assertions retain their existing strict 1-second bounds.

## Evidence

- failed in two separate clean GitHub unit jobs only at the final `Task.await/1` cleanup boundary
- exact failed CI seeds pass locally
- focused test passes 25/25 with the explicit cleanup budget
- no runtime code changes

This removes a release-blocking CI flake without weakening the behavior under test: routing publication must still arrive before the synchronous terminal handler is released.