### PR TITLE
Make container configuration persistent and simplify runtime packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Run Docker containers as UID/GID 10001 with a smaller runtime image, an image health check, and OCI source/license metadata
+- Add a Compose deployment with persistent profiles/history, a read-only root filesystem, and upgrade guidance
+
+### Fixed
+
+- Load the profiles seeded under `LASSO_DATA_DIR` and allow explicit runtime profile/history directories
+- Resolve benchmark snapshot storage when the collector starts instead of when the code is compiled
+- Use local HTTP URLs and persistent storage in the Docker helper
+
 ## [0.3.3] - 2026-09-07
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,33 +48,31 @@ RUN mix tailwind.install && \
 RUN mix release
 
 # Runtime stage
-FROM hexpm/elixir:1.18.4-erlang-28.0-debian-bookworm-20260610-slim@sha256:0e0f0fc71e298dc9517f825d4076af5235617b70a48b6394a055dd1800fe34ef
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 
-# Install runtime dependencies
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    nodejs && \
-    rm -rf /var/lib/apt/lists/*
+    ca-certificates curl libstdc++6 libtinfo6 libssl3 && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --gid 10001 lasso && \
+    useradd --uid 10001 --gid 10001 --no-create-home --home-dir /data --shell /usr/sbin/nologin lasso && \
+    mkdir -p /data && chown 10001:10001 /data
 
-# Set working directory
+LABEL org.opencontainers.image.source="https://github.com/jaxernst/lasso-rpc" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.title="Lasso RPC" \
+      org.opencontainers.image.description="Ethereum JSON-RPC routing, provider failover, and operational observability"
+
 WORKDIR /app
+ENV MIX_ENV=prod PHX_SERVER=true LASSO_DATA_DIR=/data RELEASE_TMP=/tmp/lasso LANG=C.UTF-8
 
-# Set environment
-ENV MIX_ENV=prod
-ENV PHX_SERVER=true
-
-# Copy built release from builder stage
 COPY --from=builder /app/_build/prod/rel/lasso ./
-# Copy config/profiles for runtime (seeded to /data/config/profiles by entrypoint if needed)
 COPY --from=builder /app/config/profiles ./config/profiles
-# Copy entrypoint script
-COPY deployment/entrypoint.sh /app/entrypoint.sh
-RUN chmod +x /app/entrypoint.sh
+COPY --chmod=755 deployment/entrypoint.sh /app/entrypoint.sh
 
-# Expose port
+USER 10001:10001
 EXPOSE 4000
-
-# Use entrypoint script to handle profile seeding before starting the app
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl --fail --silent "http://127.0.0.1:${PORT:-4000}/api/health" > /dev/null || exit 1
 ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["start"]

--- a/README.md
+++ b/README.md
@@ -125,12 +125,15 @@ The self-hosted dashboard uses YAML profiles, including your own nodes and provi
 
 ### Docker
 
+From a checkout of the release you want to run:
+
 ```bash
-# Run with Docker
-./run-docker.sh
+# Build and run with persistent profiles and history
+export SECRET_KEY_BASE="$(openssl rand -hex 64)"
+docker compose up --build -d
 ```
 
-The application will be available at `http://localhost:4000`. The helper supplies a local `LASSO_NODE_ID`; set it yourself when you need a stable deployment identity.
+The application will be available at `http://localhost:4000`. Compose supplies `LASSO_NODE_ID=docker-local` unless you override it. This builds locally; see the [deployment guide](docs/DEPLOYMENT.md#docker) for storage, upgrades, and the foreground helper.
 
 For production deployments, see the [deployment guide](docs/DEPLOYMENT.md). Lasso has no built-in client authentication, so expose RPC and the dashboard only behind your preferred authentication or network boundary.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,25 @@
+services:
+  lasso:
+    build: .
+    image: lasso-rpc:local
+    ports:
+      - "127.0.0.1:4000:4000"
+    environment:
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?Set SECRET_KEY_BASE to a random secret of at least 64 bytes}
+      LASSO_NODE_ID: ${LASSO_NODE_ID:-docker-local}
+      PHX_HOST: localhost
+      PHX_SCHEME: http
+    volumes:
+      - lasso-data:/data
+    read_only: true
+    tmpfs:
+      - /tmp:mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    stop_grace_period: 30s
+
+volumes:
+  lasso-data:

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -31,6 +31,24 @@ if System.get_env("PHX_SERVER") do
   config :lasso, LassoWeb.Endpoint, server: true
 end
 
+data_dir = System.get_env("LASSO_DATA_DIR")
+
+profiles_dir =
+  System.get_env("LASSO_PROFILES_DIR") ||
+    if(data_dir, do: Path.join(data_dir, "config/profiles"))
+
+if profiles_dir do
+  config :lasso, :backend_config,
+    backend: Lasso.Config.Backend.File,
+    config: [profiles_dir: profiles_dir]
+end
+
+snapshots_dir =
+  System.get_env("LASSO_SNAPSHOTS_DIR") ||
+    if(data_dir, do: Path.join(data_dir, "benchmark_snapshots"), else: "priv/benchmark_snapshots")
+
+config :lasso, :snapshots_dir, snapshots_dir
+
 # VM Metrics configuration
 # Enable collection with LASSO_VM_METRICS_ENABLED=true
 vm_metrics_enabled =

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,27 +1,13 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
-# Entrypoint script for Lasso RPC Docker container
-# Handles profile seeding and starts the Elixir release
-
-echo "Lasso RPC starting..."
-
-# Optional: Seed profiles to a data directory if LASSO_DATA_DIR is set
-if [ -n "$LASSO_DATA_DIR" ]; then
-  PROFILE_DIR="${LASSO_DATA_DIR}/config/profiles"
-
-  # Create directory if it doesn't exist
-  mkdir -p "$PROFILE_DIR"
-
-  # Copy default profiles if they don't exist in the data directory
-  if [ -z "$(ls -A "$PROFILE_DIR" 2>/dev/null)" ]; then
-    echo "Seeding profiles to $PROFILE_DIR"
-    cp -r /app/config/profiles/* "$PROFILE_DIR/"
-  else
-    echo "Using existing profiles from $PROFILE_DIR"
+# Seed bundled profiles only when using the managed data directory.
+if [ -n "${LASSO_DATA_DIR:-}" ] && [ -z "${LASSO_PROFILES_DIR:-}" ]; then
+  profile_dir="${LASSO_DATA_DIR}/config/profiles"
+  mkdir -p "$profile_dir"
+  if [ -z "$(ls -A "$profile_dir")" ]; then
+    cp /app/config/profiles/*.yml "$profile_dir/"
   fi
 fi
 
-# Start the Elixir release
-# Use 'start' for foreground execution (required for Docker containers)
-exec /app/bin/lasso start
+exec /app/bin/lasso "$@"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,11 +35,77 @@ ALCHEMY_API_KEY=your-key-here
 
 ### Docker
 
+From a checkout of the release you intend to run:
+
 ```bash
-./run-docker.sh
+export SECRET_KEY_BASE="$(openssl rand -hex 64)"
+docker compose up --build -d
+curl --fail http://localhost:4000/api/health
 ```
 
-The helper sets `LASSO_NODE_ID=docker-local` unless you provide one. See the `Dockerfile` for build customization.
+Open <http://localhost:4000/dashboard>. The included Compose file builds the image
+locally; it does not pull an officially published registry image. Keep the same
+secret in your deployment's environment or secret manager across restarts.
+
+Compose binds port 4000 to localhost, runs as UID/GID `10001:10001`, and keeps the
+root filesystem read-only. `/tmp` is temporary; the named `/data` volume retains
+profiles and benchmark history. `docker compose down` retains that volume;
+`docker compose down --volumes` deletes it.
+
+The foreground helper `./run-docker.sh` also builds locally, generates a secret
+when one is not supplied, and persists data in its own `lasso-rpc-data` volume.
+It sets `LASSO_NODE_ID=docker-local` unless you provide one.
+
+#### Profile and history storage
+
+The image defaults `LASSO_DATA_DIR` to `/data`. An empty data volume is seeded
+with bundled profiles in `/data/config/profiles`. Existing files are preserved
+on restart and upgrade. Benchmark snapshots use `/data/benchmark_snapshots`.
+
+To use configuration maintained on the host instead, mount an existing directory
+containing profile YAML files and set `LASSO_PROFILES_DIR`:
+
+```bash
+docker run --rm --name lasso-rpc \
+  --publish 127.0.0.1:4000:4000 \
+  --env SECRET_KEY_BASE --env LASSO_NODE_ID=docker-local \
+  --env PHX_HOST=localhost --env PHX_SCHEME=http \
+  --env LASSO_PROFILES_DIR=/profiles \
+  --mount type=bind,source="$(pwd)/config/profiles",target=/profiles,readonly \
+  --volume lasso-rpc-history:/data \
+  lasso-rpc:local
+```
+
+The `lasso-rpc:local` image is produced by the Compose build above. Mounted files
+must be readable by UID 10001; host directories used for writable storage must
+also be writable by that UID. `LASSO_PROFILES_DIR` overrides profile seeding and
+selection. `LASSO_SNAPSHOTS_DIR` independently overrides the history directory at
+runtime. A read-only profile mount supports loading/reloading configuration;
+application-side configuration saves require a writable mount.
+
+Reload after editing YAML:
+
+```bash
+docker compose exec lasso /app/bin/lasso rpc 'Lasso.Config.ConfigStore.reload()'
+```
+
+#### Upgrade and rollback
+
+1. Back up the profile files and any history you intend to retain.
+2. Read the target release's changelog and select its Git tag before rebuilding.
+3. Run `docker compose up --build -d` and verify health, a real RPC request, and the dashboard.
+4. Existing volume profiles are not replaced by newer bundled defaults. Compare
+   provider changes with `config/profiles/` in the target release and merge them deliberately.
+5. To roll back, select the previous release's Git tag and rebuild with the same
+   environment. Review its storage layout and restore the corresponding backup
+   if the target release changed that layout.
+
+Images built before the persistent `/data` layout used `/app/config/profiles`
+and `/app/priv/benchmark_snapshots`. Copy any customized configuration or history
+out of the old container before replacing it; a new empty volume cannot recover
+files from a deleted container. Existing volumes created by a root-running image
+may also need their writable directories assigned to UID/GID `10001:10001` before
+upgrading. Preserve a backup before changing volume contents or ownership.
 
 ---
 
@@ -113,6 +179,7 @@ Clustering uses Erlang distribution with DNS-based node discovery (`libcluster`)
 1. **DNS service discovery**: A DNS name that resolves to all node IPs (e.g., internal DNS in your orchestrator, Consul, or a headless Kubernetes service)
 2. **Erlang distribution port access**: Nodes must be able to reach each other on the EPMD port (4369) and distribution ports
 3. **Unique node IDs**: Each node needs a distinct `LASSO_NODE_ID`
+4. **Distribution secret**: Set the same private `RELEASE_COOKIE` on the nodes in your cluster; do not rely on a cookie bundled in a distributed image
 
 ### Configuration
 
@@ -163,6 +230,9 @@ The dashboard aggregates data across all nodes for unified observability with re
 | `PHX_SERVER` | Prod | Set to `true` to start HTTP server | - |
 | `PORT` | No | HTTP listener port | `4000` |
 | `LASSO_NODE_ID` | Prod | Unique node identifier | `"local"` in dev |
+| `LASSO_DATA_DIR` | No | Base directory for profiles and snapshots | `/data` in Docker; unset outside Docker |
+| `LASSO_PROFILES_DIR` | No | Profile YAML directory; overrides the data directory | `config/profiles` outside Docker |
+| `LASSO_SNAPSHOTS_DIR` | No | Snapshot directory, selected at runtime | `priv/benchmark_snapshots` outside Docker |
 | `LASSO_VM_METRICS_ENABLED` | No | Set to `true` to enable VM metrics | `false` |
 | `LASSO_COWBOY_TELEMETRY_ENABLED` | No | Set to `false` to disable Cowboy per-request telemetry; Lasso application and dashboard events remain enabled | `true` |
 | `LASSO_HTTP_RESPONSE_HEAP_TUNING_ENABLED` | No | Use a larger short-lived heap while validating completed HTTP upstream responses; benchmark before enabling for latency-bound traffic | `false` |

--- a/lib/lasso/core/benchmarking/persistence.ex
+++ b/lib/lasso/core/benchmarking/persistence.ex
@@ -2,15 +2,12 @@ defmodule Lasso.Benchmarking.Persistence do
   @moduledoc """
   Stores hourly benchmark snapshots as JSON files for historical analysis.
 
-  Snapshots are grouped by profile and chain under a directory selected at
-  build time by `LASSO_SNAPSHOTS_DIR` (default: `priv/benchmark_snapshots`).
-  Configure a persistent volume to
-  retain them across container replacements.
+  Snapshots are grouped by profile and chain under `:snapshots_dir` application
+  configuration, read when the collector starts (default: `priv/benchmark_snapshots`).
+  Configure a persistent volume to retain them across container replacements.
   """
 
   require Logger
-
-  @snapshots_dir System.get_env("LASSO_SNAPSHOTS_DIR") || "priv/benchmark_snapshots"
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
@@ -55,17 +52,18 @@ defmodule Lasso.Benchmarking.Persistence do
 
   @impl true
   def init(_opts) do
-    File.mkdir_p!(@snapshots_dir)
+    snapshots_dir = Application.get_env(:lasso, :snapshots_dir, "priv/benchmark_snapshots")
+    File.mkdir_p!(snapshots_dir)
     schedule_cleanup()
 
-    {:ok, %{}}
+    {:ok, %{snapshots_dir: snapshots_dir}}
   end
 
   @impl true
   def handle_cast({:save_snapshot, profile, chain_name, snapshot_data}, state) do
     timestamp = System.system_time(:second)
     filename = "#{profile}_#{chain_name}_#{timestamp}.json"
-    filepath = Path.join(@snapshots_dir, filename)
+    filepath = Path.join(state.snapshots_dir, filename)
 
     snapshot_with_metadata = %{
       profile: profile,
@@ -96,7 +94,7 @@ defmodule Lasso.Benchmarking.Persistence do
   def handle_cast({:cleanup_snapshots, days_to_keep}, state) do
     cutoff_timestamp = System.system_time(:second) - days_to_keep * 24 * 60 * 60
 
-    case File.ls(@snapshots_dir) do
+    case File.ls(state.snapshots_dir) do
       {:ok, files} ->
         files_to_delete =
           files
@@ -108,7 +106,7 @@ defmodule Lasso.Benchmarking.Persistence do
           end)
 
         Enum.each(files_to_delete, fn filename ->
-          filepath = Path.join(@snapshots_dir, filename)
+          filepath = Path.join(state.snapshots_dir, filename)
 
           case File.rm(filepath) do
             :ok ->
@@ -135,14 +133,14 @@ defmodule Lasso.Benchmarking.Persistence do
     cutoff_timestamp = System.system_time(:second) - hours_back * 60 * 60
 
     snapshots =
-      case File.ls(@snapshots_dir) do
+      case File.ls(state.snapshots_dir) do
         {:ok, files} ->
           files
           |> Enum.filter(fn filename ->
             String.starts_with?(filename, "#{profile}_#{chain_name}_") and
               String.ends_with?(filename, ".json")
           end)
-          |> Enum.map(&load_snapshot_file(&1, cutoff_timestamp))
+          |> Enum.map(&load_snapshot_file(state.snapshots_dir, &1, cutoff_timestamp))
           |> Enum.filter(&(&1 != nil))
           |> Enum.map(fn {:ok, data} -> data end)
           |> Enum.sort_by(fn data -> Map.get(data, "timestamp", 0) end, :desc)
@@ -158,7 +156,7 @@ defmodule Lasso.Benchmarking.Persistence do
   @impl true
   def handle_call(:get_summary, _from, state) do
     summary =
-      case File.ls(@snapshots_dir) do
+      case File.ls(state.snapshots_dir) do
         {:ok, files} ->
           json_files = Enum.filter(files, &String.ends_with?(&1, ".json"))
 
@@ -185,7 +183,7 @@ defmodule Lasso.Benchmarking.Persistence do
             total_snapshots: length(json_files),
             chains_tracked: chains,
             oldest_snapshot: oldest_timestamp,
-            storage_directory: @snapshots_dir
+            storage_directory: state.snapshots_dir
           }
 
         {:error, reason} ->
@@ -206,8 +204,8 @@ defmodule Lasso.Benchmarking.Persistence do
 
   # Private functions
 
-  defp load_snapshot_file(filename, cutoff_timestamp) do
-    filepath = Path.join(@snapshots_dir, filename)
+  defp load_snapshot_file(snapshots_dir, filename, cutoff_timestamp) do
+    filepath = Path.join(snapshots_dir, filename)
 
     case File.read(filepath) do
       {:ok, content} ->

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-# Simple Docker runner for Lasso RPC
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Local Docker runner for Lasso RPC
 echo "🚀 Starting Lasso RPC with Docker..."
 
 # Check if Docker is installed and running
@@ -28,13 +32,13 @@ else
 fi
 
 echo "🚀 Starting Lasso RPC container..."
-echo "📊 Live Dashboard: http://localhost:4000"
+echo "📊 Live Dashboard: http://localhost:4000/dashboard"
 echo "🔌 RPC Endpoint: http://localhost:4000/rpc/fastest/ethereum"
 echo ""
 echo "Press Ctrl+C to stop the server"
 
 # Generate SECRET_KEY_BASE if not set
-if [ -z "$SECRET_KEY_BASE" ]; then
+if [ -z "${SECRET_KEY_BASE:-}" ]; then
     echo "Generating SECRET_KEY_BASE..."
     SECRET_KEY_BASE=$(openssl rand -base64 48)
 fi
@@ -45,8 +49,11 @@ LASSO_NODE_ID="${LASSO_NODE_ID:-docker-local}"
 
 # Run the container
 docker run --rm \
-    -p 4000:4000 \
+    -p 127.0.0.1:4000:4000 \
     -e SECRET_KEY_BASE="$SECRET_KEY_BASE" \
     -e LASSO_NODE_ID="$LASSO_NODE_ID" \
+    -e PHX_HOST=localhost \
+    -e PHX_SCHEME=http \
+    --volume lasso-rpc-data:/data \
     --name lasso-rpc \
     lasso-rpc

--- a/test/lasso/config/storage_runtime_config_test.exs
+++ b/test/lasso/config/storage_runtime_config_test.exs
@@ -1,0 +1,45 @@
+defmodule Lasso.Config.StorageRuntimeConfigTest do
+  use ExUnit.Case, async: false
+
+  @variables ~w(LASSO_DATA_DIR LASSO_PROFILES_DIR LASSO_SNAPSHOTS_DIR)
+
+  setup do
+    original = Map.new(@variables, &{&1, System.get_env(&1)})
+    Enum.each(@variables, &System.delete_env/1)
+
+    on_exit(fn ->
+      Enum.each(original, fn
+        {key, nil} -> System.delete_env(key)
+        {key, value} -> System.put_env(key, value)
+      end)
+    end)
+  end
+
+  test "data directory selects both persisted profiles and snapshots" do
+    System.put_env("LASSO_DATA_DIR", "/data")
+    config = runtime_config()
+    assert config[:lasso][:backend_config][:config][:profiles_dir] == "/data/config/profiles"
+    assert config[:lasso][:snapshots_dir] == "/data/benchmark_snapshots"
+  end
+
+  test "explicit directories override the shared data directory" do
+    System.put_env("LASSO_DATA_DIR", "/data")
+    System.put_env("LASSO_PROFILES_DIR", "/config")
+    System.put_env("LASSO_SNAPSHOTS_DIR", "/history")
+    config = runtime_config()
+    assert config[:lasso][:backend_config][:config][:profiles_dir] == "/config"
+    assert config[:lasso][:snapshots_dir] == "/history"
+  end
+
+  test "without overrides existing backend configuration is preserved" do
+    config = runtime_config()
+    assert config[:lasso][:backend_config][:config][:profiles_dir] == "test/support/profiles"
+    assert config[:lasso][:snapshots_dir] == "priv/benchmark_snapshots"
+  end
+
+  defp runtime_config do
+    base = Config.Reader.read!(Path.expand("config/config.exs"), env: :test)
+    runtime = Config.Reader.read!(Path.expand("config/runtime.exs"), env: :test)
+    Config.Reader.merge(base, runtime)
+  end
+end

--- a/test/lasso/core/benchmarking/persistence_directory_test.exs
+++ b/test/lasso/core/benchmarking/persistence_directory_test.exs
@@ -1,0 +1,45 @@
+defmodule Lasso.Benchmarking.PersistenceDirectoryTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.Benchmarking.Persistence
+
+  @tag :tmp_dir
+  test "runtime configuration reads a snapshot override without recompilation", %{tmp_dir: dir} do
+    original = System.get_env("LASSO_SNAPSHOTS_DIR")
+    System.put_env("LASSO_SNAPSHOTS_DIR", dir)
+
+    on_exit(fn ->
+      if original,
+        do: System.put_env("LASSO_SNAPSHOTS_DIR", original),
+        else: System.delete_env("LASSO_SNAPSHOTS_DIR")
+    end)
+
+    config = Config.Reader.read!(Path.expand("config/runtime.exs"), env: :test)
+    assert config[:lasso][:snapshots_dir] == dir
+  end
+
+  @tag :tmp_dir
+  test "a runtime-selected directory retains snapshots across collector restarts", %{tmp_dir: dir} do
+    previous = Application.fetch_env(:lasso, :snapshots_dir)
+    Application.put_env(:lasso, :snapshots_dir, dir)
+
+    on_exit(fn ->
+      case previous do
+        {:ok, value} -> Application.put_env(:lasso, :snapshots_dir, value)
+        :error -> Application.delete_env(:lasso, :snapshots_dir)
+      end
+    end)
+
+    {:ok, state} = Persistence.init([])
+    {:noreply, _} = Persistence.handle_cast({:save_snapshot, "public", "1", %{calls: 7}}, state)
+    assert [_] = File.ls!(dir)
+
+    {:ok, restarted} = Persistence.init([])
+
+    assert {:reply, [%{"data" => %{"calls" => 7}}], _} =
+             Persistence.handle_call({:load_snapshots, "public", "1", 24}, self(), restarted)
+
+    assert {:reply, %{storage_directory: ^dir, total_snapshots: 1}, _} =
+             Persistence.handle_call(:get_summary, self(), restarted)
+  end
+end


### PR DESCRIPTION
The Docker helper generated HTTPS endpoints for local HTTP use, and the entrypoint seeded profiles under `LASSO_DATA_DIR` while the application continued reading bundled files. Snapshot storage was fixed at compile time. These behaviors made configuration and history unreliable across container replacements.

Use runtime profile/snapshot directory settings, preserve existing seeded profiles, and keep collector storage selection consistent across saves, reads, cleanup, and summaries. Package the existing OTP release on Debian slim without the extra Elixir/Erlang installation or Node tooling. Run as UID/GID 10001, include source/license metadata and a health check, and support standard release subcommands through the entrypoint.

Add a Compose example with persistent `/data`, a read-only root filesystem, temporary `/tmp`, localhost exposure, and documented upgrades/rollback. Fix the foreground helper's working directory, local URLs, and persistence. The documented image is built locally; this PR does not claim a published registry image.

Compatibility: Docker storage defaults to `/data`; operators must migrate customized files from older container paths before replacement and ensure writable volumes permit UID/GID 10001. Explicit `LASSO_PROFILES_DIR` bypasses default seeding and permits a read-only configuration mount. `LASSO_SNAPSHOTS_DIR` is now a runtime setting.

Validation:
- Full hermetic suite: 1,657 tests passed; five focused storage tests passed after adding the final runtime-override regression.
- Compilation, formatting, strict Credo, and Dialyzer passed.
- Docker build and boot passed with non-root execution, read-only root filesystem, dropped capabilities, and persistent storage. Local reported image size decreased from 467 MB to 229 MB on the tested ARM64 build; these are not compressed download sizes.
- Compose configuration and shell syntax checks passed.
