### PR TITLE
Release Lasso RPC v0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-09-07
+
+### Compatibility
+
+- Configuration validation now rejects unsupported settings that were previously ignored. Check custom profiles against `docs/CONFIGURATION.md` before upgrading; the bundled profiles use the supported schema. A rejected reload retains the active configuration.
+
 ### Configuration and operator controls
 
 - Reject unsupported YAML fields, invalid values, duplicate provider IDs, and unresolved credentials before activation; retain the active configuration on a failed reload or missing public profile.
 - Honor profile WebSocket backfill limits and application circuit-breaker thresholds. Read the documented `LW_BETA` setting.
 - Clamp request tester rates across profile changes and distinguish HTTP strategy selection from priority-based subscriptions.
 - Correct obsolete provider capability settings in the example profiles. Remove unused configuration facades, controls, and logging claims; document the supported routing and observability contracts.
-
 
 ### Changed
 
@@ -25,6 +30,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Load the profiles seeded under `LASSO_DATA_DIR` and allow explicit runtime profile/history directories
 - Resolve benchmark snapshot storage when the collector starts instead of when the code is compiled
 - Use local HTTP URLs and persistent storage in the Docker helper
+- Stop and clear request tester runs when switching between profiles, including profiles with identical chain lists
+- Keep the profile selector accessible above floating dashboard panels
 
 ## [0.3.3] - 2026-09-07
 
@@ -167,7 +174,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.4...HEAD
+[0.3.4]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-26A5E4?style=flat-square&labelColor=19202E&logo=telegram&logoColor=white)](https://t.me/+79pFERTlZPIzZTZh)
 [![X](https://img.shields.io/badge/follow-%40lassoRPC-19202E?style=flat-square&labelColor=19202E&logo=x&logoColor=white)](https://x.com/lassoRPC)
 [![License](https://img.shields.io/badge/license-Apache--2.0-19202E?style=flat-square&labelColor=19202E)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.3.3-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.3.4-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
 [![Elixir](https://img.shields.io/badge/built%20with-Elixir%2FOTP-19202E?style=flat-square&labelColor=19202E&logo=elixir&logoColor=white)](https://elixir-lang.org)
 
 Lasso is a smart proxy/router that turns your node infrastructure and RPC providers into a **fast, observable, configurable, and resilient** multi-chain JSON-RPC layer.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.3.3",
+      version: "0.3.4",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],


### PR DESCRIPTION
Prepare v0.3.4 with the configuration-contract, dashboard tester, and Docker/Compose fixes merged since v0.3.3. Update the application version, README badge, changelog, and comparison links together.

The compatibility note explicitly states that unsupported custom configuration fields that were previously ignored now fail validation. Rejected reloads retain the active configuration; bundled profiles use the supported schema.

Validation: all five [CI jobs](https://github.com/jaxernst/lasso-rpc/actions/runs/34161918759) pass, including 1,670 integration-inclusive tests, compilation/formatting, Credo, Dialyzer, and a clean AMD64 Docker build and boot. Local verification passed five JavaScript tests, all 1,670 integration tests, production asset/release assembly, a clean ARM64 Docker build, Compose boot and persistent storage, live HTTP/WS dashboard checks, profile switching, and rejected-reload preservation.

One initial local run concurrent with the Docker build hit a 100 ms task-crash test deadline. All 23 request-owner tests and the full suite subsequently passed without the competing build. Existing dependency-audit exclusions and Dialyzer filters are unchanged and will be identified in the release verification report.
