### PR TITLE
Publish and verify versioned container distributions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Run tests
         run: mix test
 
+      - name: Verify container publication guards
+        run: python3 -m unittest discover -s scripts/distribution -p "test_*.py"
+
   integration:
     name: Hermetic Integration Test
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,207 @@
+name: Publish container
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Published source release (for example v0.3.4)
+        type: string
+        required: true
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: container-publication
+  cancel-in-progress: false
+
+env:
+  RELEASE_TAG: ${{ inputs.tag || github.event.release.tag_name }}
+
+jobs:
+  prepare:
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      tag: ${{ steps.source.outputs.tag }}
+      version: ${{ steps.source.outputs.version }}
+      revision: ${{ steps.source.outputs.revision }}
+      image: ${{ steps.source.outputs.image }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Require published source and successful CI at its exact commit
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/distribution/release.py prepare --tag "$RELEASE_TAG"
+
+  build:
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-24.04
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Build the released public Git commit on its native architecture
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: https://github.com/${{ github.repository }}.git#${{ needs.prepare.outputs.revision }}
+          platforms: linux/${{ matrix.architecture }}
+          outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
+          pull: true
+          provenance: mode=max
+          sbom: true
+          labels: |
+            org.opencontainers.image.version=${{ needs.prepare.outputs.tag }}
+            org.opencontainers.image.revision=${{ needs.prepare.outputs.revision }}
+      - name: Record immutable platform digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          REVISION: ${{ needs.prepare.outputs.revision }}
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run: |
+          python3 - <<'PY'
+          import json, os
+          from pathlib import Path
+          data = {key.lower(): os.environ[key] for key in ['DIGEST', 'REVISION', 'ARCHITECTURE']}
+          Path(os.environ['RUNNER_TEMP'], 'image-' + data['architecture'] + '.json').write_text(json.dumps(data))
+          PY
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: image-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/image-${{ matrix.architecture }}.json
+          if-no-files-found: error
+
+  assemble:
+    needs: [prepare, build]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      actions: read
+      packages: write
+      id-token: write
+      attestations: write
+    outputs:
+      digest: ${{ steps.index.outputs.digest }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: image-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/distribution
+      - name: Assemble candidate index from recorded platform digests
+        id: index
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/distribution/release.py assemble --tag "$RELEASE_TAG" --directory "$RUNNER_TEMP/distribution"
+      - name: Sign publication provenance for the final index
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4
+        with:
+          subject-name: ${{ needs.prepare.outputs.image }}
+          subject-digest: ${{ steps.index.outputs.digest }}
+          push-to-registry: true
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: container-release
+          path: ${{ runner.temp }}/distribution/container-release.json
+          if-no-files-found: error
+
+  verify:
+    needs: [prepare, assemble]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - architecture: amd64
+            runner: ubuntu-24.04
+          - architecture: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Pull immutable image without registry credentials
+        env:
+          IMAGE: ${{ needs.prepare.outputs.image }}@${{ needs.assemble.outputs.digest }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/anonymous-docker"
+          echo "DOCKER_CONFIG=$RUNNER_TEMP/anonymous-docker" >> "$GITHUB_ENV"
+          DOCKER_CONFIG="$RUNNER_TEMP/anonymous-docker" docker pull "$IMAGE"
+      - name: Verify signed publication provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE: ${{ needs.prepare.outputs.image }}@${{ needs.assemble.outputs.digest }}
+        run: gh attestation verify "oci://$IMAGE" --repo "$GITHUB_REPOSITORY"
+      - name: Install and exercise the distribution on a native runner
+        env:
+          IMAGE: ${{ needs.prepare.outputs.image }}@${{ needs.assemble.outputs.digest }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          REVISION: ${{ needs.prepare.outputs.revision }}
+          ARCHITECTURE: ${{ matrix.architecture }}
+        run: python3 scripts/distribution/verify.py --image "$IMAGE" --version "$VERSION" --revision "$REVISION" --report "$RUNNER_TEMP/verification-$ARCHITECTURE.json"
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: verification-${{ matrix.architecture }}
+          path: ${{ runner.temp }}/verification-${{ matrix.architecture }}.json*
+          if-no-files-found: warn
+
+  promote:
+    needs: [prepare, assemble, verify]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          merge-multiple: true
+          path: ${{ runner.temp }}/distribution
+      - name: Publish verified version, current latest, Compose recipe, and evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 scripts/distribution/release.py promote --tag "$RELEASE_TAG" --directory "$RUNNER_TEMP/distribution"

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ deployment/.env.staging
 
 # Internal working docs (keep local, don't commit)
 /docs/internal/
+
+# Python verification tools
+__pycache__/

--- a/deployment/compose.release.yml
+++ b/deployment/compose.release.yml
@@ -1,0 +1,27 @@
+services:
+  lasso:
+    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.3.4}
+    ports:
+      - "127.0.0.1:${LASSO_PORT:-4000}:4000"
+    env_file:
+      - .env
+    environment:
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?Set SECRET_KEY_BASE in .env}
+      RELEASE_COOKIE: ${RELEASE_COOKIE:?Set RELEASE_COOKIE in .env}
+      LASSO_NODE_ID: ${LASSO_NODE_ID:-docker-local}
+      PHX_HOST: localhost
+      PHX_SCHEME: http
+    volumes:
+      - lasso-data:/data
+    read_only: true
+    tmpfs:
+      - /tmp:mode=1777
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    restart: unless-stopped
+    stop_grace_period: 30s
+
+volumes:
+  lasso-data:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,48 +1,108 @@
 # Releasing Lasso RPC
 
-This checklist is for maintainers preparing a public release. It intentionally separates release preparation from publishing a tag, so version selection and publication stay explicit decisions.
+Source releases and container publication are separate steps. A container is built
+from an exact published Git commit and promoted only after both native platforms
+pass installation checks. A green build alone is not distribution verification.
 
-## Prepare the release candidate
+## Prepare and verify the source release
 
-1. Start from a clean checkout of the intended commit and review `git status`.
-2. Review every entry in `CHANGELOG.md` under `Unreleased`. Move it into a new versioned section only after choosing the release version and date.
-3. Update `version` in `mix.exs`, the README version badge, and the comparison links at the end of `CHANGELOG.md` together.
-4. Confirm the public surface: README quick start, `docs/API_REFERENCE.md`, `docs/CONFIGURATION.md`, `docs/DEPLOYMENT.md`, and `SECURITY.md` accurately describe the current release.
-5. Verify that no credentials, `.env` files, local database files, or machine metadata are staged.
+1. Start from a clean checkout; review the changes since the previous release.
+2. Update `mix.exs`, the README version badge, and the changelog/version comparison
+   links together. Describe any configuration or storage compatibility changes.
+3. Review public setup, API, configuration, deployment, and security guidance.
+   Keep private operational material, credentials, `.env` files, local data, and
+   generated build artifacts out of the commit.
+4. Run `mix format` before committing Elixir changes. Run the repository CI checks
+   and any focused regressions needed for the change. Container publication reuses
+   successful CI for the exact release commit; it does not repeat the full suite.
+5. Merge the release PR and require the merged commit's CI to pass before tagging.
+6. Create an annotated version tag and publish the GitHub source release with its
+   finalized changelog and compatibility notes. Keep previous tags unchanged.
 
-## Verify
-
-Run these from the repository root:
-
-```bash
-mix deps.get
-mix compile --warnings-as-errors
-mix format --check-formatted
-mix credo --strict
-mix test --include integration
-MIX_ENV=prod mix assets.setup
-MIX_ENV=prod mix assets.deploy
-MIX_ENV=prod mix release
-docker build --pull --no-cache --tag lasso-rpc:rc .
+```sh
+git tag -a vX.Y.Z RELEASE_COMMIT -m 'Lasso RPC vX.Y.Z'
+git push jaxernst refs/tags/vX.Y.Z
+gh release create vX.Y.Z --repo jaxernst/lasso-rpc --verify-tag \
+  --title 'Lasso RPC vX.Y.Z' --notes-file release-notes.md
 ```
 
-Then boot the release or container with `SECRET_KEY_BASE`, `LASSO_NODE_ID`, `PHX_HOST`, and `PHX_SERVER=true` configured. Confirm:
+A release containing `publish-container.yml` starts container publication when
+published. To publish an existing source release, or retry explicitly:
 
-- `GET /api/health` returns `200`.
-- `GET /api/chains` lists the expected public chains.
-- An HTTP request to `/rpc/ethereum` succeeds.
-- The dashboard loads at `/dashboard` and the profile selector works.
-- An invalid profile and invalid provider override return clear client errors.
+```sh
+gh workflow run publish-container.yml --repo jaxernst/lasso-rpc --ref main -f tag=vX.Y.Z
+gh run list --repo jaxernst/lasso-rpc --workflow publish-container.yml
+```
 
-## Publish
+## Container publication contract
 
-1. Commit the release-version and changelog changes.
-2. Create and push an annotated tag: `git tag -a vX.Y.Z -m "Lasso RPC vX.Y.Z"`.
-3. Create the GitHub release from that tag using the finalized changelog section as release notes.
-4. Announce the release with its compatibility notes, Docker image/reference if published, and the security boundary: Lasso OSS has no built-in client authentication.
+The workflow has five stages:
 
-## Post-release
+1. **Resolve source:** require a stable published release, a matching application
+   version, and successful main-branch CI at the exact tagged commit.
+2. **Build:** native Linux AMD64 and ARM64 runners build the pinned public Git
+   source, embedding version/revision labels, BuildKit provenance, and SBOMs.
+   Platform images are pushed by digest using the workflow's `GITHUB_TOKEN`.
+3. **Assemble:** combine the recorded digests into a candidate multi-platform
+   index and sign a GitHub publication attestation for that index. The source
+   revision and publication-tooling revision are recorded separately.
+4. **Verify:** fresh native runners pull that index without registry credentials,
+   verify its signed attestation, and run `scripts/distribution/verify.py` against
+   the downloadable Compose recipe. Failures preserve available JSON evidence.
+5. **Promote:** create the version tag only after both architectures pass. An
+   existing version with a different digest is rejected. `latest` moves only when
+   the selected version is GitHub's current latest release. Attach `compose.yml`,
+   the release manifest, and verification reports to the source release.
 
-1. Verify the published source archive and release/container boot from a clean environment.
-2. Watch health, provider failures, and dashboard errors during the launch window.
-3. Open a new `Unreleased` section and record any follow-ups discovered during the release.
+The acceptance suite requires Docker Compose, Python 3, and Node.js 22 or newer
+for its built-in WebSocket client. These are verification-tool dependencies;
+end users need Docker Compose and the downloaded configuration.
+
+### First publication and package access
+
+GHCR packages initially default to private. After the first candidate is built,
+open the repository-linked `lasso-rpc` package settings and make that specific OSS
+package public. Do not change visibility of other packages. Then rerun failed
+verification jobs. An authenticated push is not evidence that a user can pull.
+
+If package access or runner capacity blocks a stage, retain the run and report the
+actual blocker. Do not bypass anonymous verification or publish version tags to
+make a failed run appear complete.
+
+### Retries and immutable versions
+
+A failed verification can be rerun against its already assembled digest using
+GitHub's **Re-run failed jobs**. Rerunning all jobs rebuilds images and may yield a
+different digest. If a version was already promoted, a rebuild with different
+contents requires a new source version; never overwrite the existing version.
+Use the run's retained platform digests, `container-release.json`, and native
+verification reports to distinguish build, access, acceptance, and promotion
+failures. Candidate tags are not supported installation references.
+
+## Verify the delivered artifact
+
+Download the source archive and compare its contents to the tag. For the container,
+use the immutable reference recorded in `container-release.json`:
+
+```sh
+docker pull ghcr.io/jaxernst/lasso-rpc@sha256:DIGEST
+gh attestation verify oci://ghcr.io/jaxernst/lasso-rpc@sha256:DIGEST \
+  --repo jaxernst/lasso-rpc
+```
+
+Follow the public setup instructions from an empty directory, without a checkout
+or existing Docker login. Verify health, an upstream-backed request such as
+`eth_blockNumber` or `eth_getBalance`, and the browser dashboard. `eth_chainId`
+can be answered locally and is not sufficient evidence of upstream connectivity.
+The deterministic suite uses a controlled upstream so public-provider outages do
+not masquerade as packaging failures; record live-provider checks separately.
+
+Confirm custom profile mounts, environment substitution, reload rejection,
+container replacement, history persistence, and rollback instructions against the
+actual installed version. Inspect available SBOMs and dependency advisories;
+record exclusions and limits rather than claiming zero vulnerabilities.
+
+Link the image reference and attached verification evidence from the release
+notes. Maintain an `Unreleased` changelog section for follow-ups. Document only
+behavior established by source review or executed checks; keep broad capacity,
+continuity, and security claims within their separately measured scope.

--- a/scripts/distribution/release.py
+++ b/scripts/distribution/release.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Resolve released source and promote verified container digests without replacing versions."""
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+
+
+def command(*args):
+    return subprocess.check_output(args, text=True).strip()
+
+
+def api(path):
+    return json.loads(command("gh", "api", path))
+
+
+def identity(tag):
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", tag):
+        raise ValueError("Select a stable release tag such as v0.3.4")
+    repo = os.environ["GITHUB_REPOSITORY"]
+    release = api(f"repos/{repo}/releases/tags/{tag}")
+    if release["draft"] or release["prerelease"]:
+        raise ValueError("Container publication requires a published stable source release")
+    sha = api(f"repos/{repo}/commits/{tag}")["sha"]
+    source = api(f"repos/{repo}/contents/mix.exs?ref={sha}")
+    version = re.search(r'version:\s*"([^"]+)"', base64.b64decode(source["content"]).decode()).group(1)
+    if tag != "v" + version:
+        raise ValueError("Tag and application version disagree")
+    runs = api(f"repos/{repo}/actions/workflows/ci.yml/runs?head_sha={sha}&status=success&per_page=100")["workflow_runs"]
+    if not any(r["head_sha"] == sha and r["event"] == "push" and r["head_branch"] == "main" and r["conclusion"] == "success" for r in runs):
+        raise ValueError("The exact released commit needs a successful main-branch CI run")
+    return {"tag": tag, "version": version, "revision": sha, "image": "ghcr.io/" + repo.lower(), "source": "https://github.com/" + repo}
+
+
+def output(values):
+    with open(os.environ["GITHUB_OUTPUT"], "a") as stream:
+        for key, value in values.items():
+            stream.write(f"{key}={value}\n")
+
+
+def descriptor(reference):
+    return json.loads(command("docker", "buildx", "imagetools", "inspect", reference, "--format", "{{json .Manifest}}"))
+
+
+def checked_digest(value):
+    if not re.fullmatch(r"sha256:[a-f0-9]{64}", value):
+        raise ValueError("Invalid image digest")
+    return value
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["prepare", "assemble", "promote"])
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--directory", default=".")
+    args = parser.parse_args()
+    meta = identity(args.tag)
+    directory = Path(args.directory)
+    if args.action == "prepare":
+        output(meta)
+        return
+    if args.action == "assemble":
+        platforms = [json.loads((directory / f"image-{arch}.json").read_text()) for arch in ["amd64", "arm64"]]
+        for arch, image in zip(["amd64", "arm64"], platforms):
+            if image["architecture"] != arch or image["revision"] != meta["revision"]:
+                raise ValueError("Platform builds must use the same released source")
+            checked_digest(image["digest"])
+        candidate = meta["image"] + ":candidate-" + os.environ["GITHUB_RUN_ID"] + "-" + os.environ["GITHUB_RUN_ATTEMPT"]
+        command("docker", "buildx", "imagetools", "create", "--tag", candidate, *[meta["image"] + "@" + p["digest"] for p in platforms])
+        meta.update(digest=checked_digest(descriptor(candidate)["digest"]), platforms=platforms)
+        meta["workflow_revision"] = os.environ["GITHUB_SHA"]
+        meta["workflow_run"] = meta["source"] + "/actions/runs/" + os.environ["GITHUB_RUN_ID"]
+        (directory / "container-release.json").write_text(json.dumps(meta, indent=2) + "\n")
+        output({"image": meta["image"], "digest": meta["digest"]})
+        return
+    saved = json.loads((directory / "container-release.json").read_text())
+    if any(saved[key] != meta[key] for key in ["tag", "version", "revision", "image"]):
+        raise ValueError("Released source identity changed during publication")
+    digest = checked_digest(saved["digest"])
+    for arch in ["amd64", "arm64"]:
+        result = json.loads((directory / f"verification-{arch}.json").read_text())
+        if result["result"] != "pass" or result["image"] != meta["image"] + "@" + digest or result["revision"] != meta["revision"] or result["architecture"] != arch:
+            raise ValueError("Both native architectures must pass anonymous distribution verification")
+    version_ref = meta["image"] + ":" + meta["tag"]
+    # Only a confirmed absent manifest allows creating a version tag.
+    probe = subprocess.run(["docker", "buildx", "imagetools", "inspect", version_ref, "--format", "{{json .Manifest}}"], text=True, capture_output=True)
+    if probe.returncode == 0:
+        if json.loads(probe.stdout)["digest"] != digest:
+            raise ValueError("Version tag already exists with a different digest; publish a new version")
+    elif "not found" in probe.stderr.lower() or "manifest unknown" in probe.stderr.lower():
+        command("docker", "buildx", "imagetools", "create", "--tag", version_ref, meta["image"] + "@" + digest)
+    else:
+        raise RuntimeError("Cannot establish whether the version exists: " + probe.stderr)
+    if descriptor(version_ref)["digest"] != digest:
+        raise ValueError("Published version digest differs from verified image")
+    latest = api(f"repos/{os.environ['GITHUB_REPOSITORY']}/releases/latest")["tag_name"]
+    if latest == meta["tag"]:
+        command("docker", "buildx", "imagetools", "create", "--tag", meta["image"] + ":latest", meta["image"] + "@" + digest)
+    recipe = Path("deployment/compose.release.yml").read_text()
+    recipe = re.sub(r"ghcr.io/jaxernst/lasso-rpc:v[0-9]+\.[0-9]+\.[0-9]+", meta["image"] + ":" + meta["tag"], recipe)
+    (directory / "compose.yml").write_text(recipe)
+    report = f'''# Container distribution verification: {meta['tag']}
+
+- Image: `{version_ref}`
+- Immutable reference: `{meta['image']}@{digest}`
+- Application source: `{meta['revision']}`
+- Publication tooling: `{saved['workflow_revision']}`
+- Native platforms: Linux AMD64 and ARM64
+- [Publication and verification run]({saved['workflow_run']})
+
+Both native runners pulled the multi-platform image without registry credentials and passed the downloadable Compose installation checks. The attached JSON reports list the checks and exact image identity. These cover controlled upstream requests, HTTP failover, WebSocket RPC and newHeads delivery, configuration reload rejection, saved history across container replacement, and read-only profile mounts. This is finite release verification, not a security certification or capacity guarantee.
+
+The signed attestation identifies the publication workflow. Each platform's BuildKit provenance records the pinned public Git source used for its build; SBOMs are included in the OCI index. Verify the attestation with:
+
+```sh
+gh attestation verify oci://{meta['image']}@{digest} --repo {os.environ['GITHUB_REPOSITORY']}
+```
+
+The Compose attachment defaults to the version tag. For digest-pinned deployment, set `LASSO_IMAGE={meta['image']}@{digest}` in `.env`.
+'''
+    (directory / "container-verification.md").write_text(report)
+    assets = [directory / name for name in ["compose.yml", "container-release.json", "container-verification.md", "verification-amd64.json", "verification-arm64.json"]]
+    # Version identity was checked above; a retry may replace identical release evidence.
+    command("gh", "release", "upload", meta["tag"], "--repo", os.environ["GITHUB_REPOSITORY"], "--clobber", *map(str, assets))
+    print(meta["image"] + "@" + digest)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/distribution/test_release.py
+++ b/scripts/distribution/test_release.py
@@ -1,0 +1,78 @@
+"""Publication guards for immutable versions and verified platform identities."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import release
+
+
+class PromotionTest(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.directory = Path(self.temp.name)
+        self.digest = "sha256:" + "a" * 64
+        self.meta = {"tag": "v0.3.4", "version": "0.3.4", "revision": "b" * 40, "image": "ghcr.io/jaxernst/lasso-rpc", "source": "https://github.com/jaxernst/lasso-rpc"}
+        self.saved = dict(self.meta, digest=self.digest, workflow_revision="c" * 40, workflow_run="https://github.com/jaxernst/lasso-rpc/actions/runs/1")
+        (self.directory / "container-release.json").write_text(json.dumps(self.saved))
+        for arch in ["amd64", "arm64"]:
+            result = {"result": "pass", "image": self.meta["image"] + "@" + self.digest, "revision": self.meta["revision"], "architecture": arch}
+            (self.directory / f"verification-{arch}.json").write_text(json.dumps(result))
+        self.addCleanup(patch.stopall)
+        patch.dict(os.environ, {"GITHUB_REPOSITORY": "jaxernst/lasso-rpc"}).start()
+        patch("sys.argv", ["release.py", "promote", "--tag", "v0.3.4", "--directory", str(self.directory)]).start()
+        patch.object(release, "identity", return_value=self.meta).start()
+        patch.object(release, "descriptor", return_value={"digest": self.digest}).start()
+        self.commands = patch.object(release, "command", return_value="").start()
+        self.api = patch.object(release, "api", return_value={"tag_name": "v0.3.4"}).start()
+        self.probe = patch.object(release.subprocess, "run", return_value=subprocess.CompletedProcess([], 1, "", "manifest unknown")).start()
+
+    def test_refuses_replacing_an_existing_version_with_different_content(self):
+        self.probe.return_value = subprocess.CompletedProcess([], 0, json.dumps({"digest": "sha256:" + "d" * 64}), "")
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            release.main()
+        self.commands.assert_not_called()
+
+    def test_registry_permission_failure_is_not_treated_as_an_absent_version(self):
+        self.probe.return_value = subprocess.CompletedProcess([], 1, "", "403 Forbidden")
+        with self.assertRaisesRegex(RuntimeError, "Cannot establish"):
+            release.main()
+        self.commands.assert_not_called()
+
+    def test_failed_platform_cannot_be_promoted(self):
+        file = self.directory / "verification-arm64.json"
+        data = json.loads(file.read_text())
+        data["result"] = "fail"
+        file.write_text(json.dumps(data))
+        with self.assertRaisesRegex(ValueError, "Both native"):
+            release.main()
+        self.commands.assert_not_called()
+
+    def test_verification_of_another_digest_does_not_authorize_publication(self):
+        file = self.directory / "verification-amd64.json"
+        data = json.loads(file.read_text())
+        data["image"] = self.meta["image"] + "@sha256:" + "d" * 64
+        file.write_text(json.dumps(data))
+        with self.assertRaisesRegex(ValueError, "Both native"):
+            release.main()
+        self.commands.assert_not_called()
+
+    def test_older_release_rerun_does_not_move_latest_backwards(self):
+        self.api.return_value = {"tag_name": "v0.3.5"}
+        release.main()
+        self.assertFalse(any(self.meta["image"] + ":latest" in call.args for call in self.commands.call_args_list))
+        self.assertTrue(any(self.meta["image"] + ":v0.3.4" in call.args for call in self.commands.call_args_list))
+
+    def test_same_digest_retry_preserves_the_version_tag(self):
+        self.probe.return_value = subprocess.CompletedProcess([], 0, json.dumps({"digest": self.digest}), "")
+        release.main()
+        self.assertFalse(any(self.meta["image"] + ":v0.3.4" in call.args for call in self.commands.call_args_list))
+        self.assertTrue(any(call.args[:3] == ("gh", "release", "upload") for call in self.commands.call_args_list))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/distribution/upstream.py
+++ b/scripts/distribution/upstream.py
@@ -1,0 +1,122 @@
+"""Controlled RPC upstream for container acceptance checks (Python standard library)."""
+import base64
+import hashlib
+import json
+import socket
+import select
+import struct
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+class Upstream:
+    def __init__(self, credential):
+        self.credential = credential
+        self.fail_first = False
+        self.calls = {"/first": 0, "/second": 0}
+        self.authenticated = 0
+        self.events = []
+        owner = self
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+            def log_message(self, *_args):
+                pass
+
+            def do_POST(self):
+                if self.headers.get("X-Release-Test") != owner.credential:
+                    self.send_error(401)
+                    return
+                owner.authenticated += 1
+                owner.calls[self.path] = owner.calls.get(self.path, 0) + 1
+                request = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                if owner.fail_first and self.path == "/first":
+                    self.send_error(503)
+                    return
+                body = json.dumps(owner.reply(request)).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):
+                if self.headers.get("Upgrade", "").lower() != "websocket":
+                    self.send_error(404)
+                    return
+                if self.headers.get("X-Release-Test") != owner.credential:
+                    self.send_error(401)
+                    return
+                key = self.headers["Sec-WebSocket-Key"] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+                self.send_response(101)
+                self.send_header("Upgrade", "websocket")
+                self.send_header("Connection", "Upgrade")
+                self.send_header("Sec-WebSocket-Accept", base64.b64encode(hashlib.sha1(key.encode()).digest()).decode())
+                self.end_headers()
+                self.connection.settimeout(5)
+                subscribed = False
+                for _ in range(180):
+                    try:
+                        if not select.select([self.connection], [], [], 1)[0]:
+                            if subscribed:
+                                event = {"jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xfeed", "result": owner.block()}}
+                                self.frame(json.dumps(event).encode())
+                            continue
+                        header = self.rfile.read(2)
+                        if len(header) != 2:
+                            return
+                        opcode, length = header[0] & 15, header[1] & 127
+                        owner.events.append((self.path, "frame", opcode, length, bool(header[1] & 128)))
+                        if length == 126:
+                            length = struct.unpack("!H", self.rfile.read(2))[0]
+                        elif length == 127:
+                            length = struct.unpack("!Q", self.rfile.read(8))[0]
+                        if length > 1_048_576:
+                            return
+                        mask = self.rfile.read(4) if header[1] & 128 else None
+                        payload = self.rfile.read(length)
+                        if mask:
+                            payload = bytes(v ^ mask[i % 4] for i, v in enumerate(payload))
+                        if opcode == 8:
+                            return
+                        if opcode == 9:
+                            self.frame(payload, 10)
+                        elif opcode == 1:
+                            request = json.loads(payload)
+                            owner.events.append((self.path, request.get("method")))
+                            self.frame(json.dumps(owner.reply(request)).encode())
+                            if request.get("method") == "eth_subscribe":
+                                subscribed = True
+                    except (socket.timeout, OSError):
+                        if not subscribed:
+                            return
+                    if subscribed:
+                        event = {"jsonrpc": "2.0", "method": "eth_subscription", "params": {"subscription": "0xfeed", "result": owner.block()}}
+                        try:
+                            self.frame(json.dumps(event).encode())
+                        except OSError:
+                            return
+
+            def frame(self, payload, opcode=1):
+                prefix = bytes([128 | opcode])
+                prefix += bytes([len(payload)]) if len(payload) < 126 else bytes([126]) + struct.pack("!H", len(payload))
+                self.connection.sendall(prefix + payload)
+
+        self.server = ThreadingHTTPServer(("0.0.0.0", 0), Handler)
+        self.server.daemon_threads = True
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.port = self.server.server_port
+
+    @staticmethod
+    def block():
+        return {"number": "0x1000", "hash": "0x" + "a" * 64, "parentHash": "0x" + "b" * 64, "timestamp": "0x65000000", "transactions": []}
+
+    def reply(self, request):
+        method = request.get("method")
+        values = {"eth_chainId": "0x1", "eth_blockNumber": "0x1000", "net_version": "1", "eth_syncing": False, "eth_getLogs": [], "eth_getBalance": "0x0", "eth_call": "0x", "eth_subscribe": "0xfeed", "eth_unsubscribe": True}
+        result = self.block() if method in ["eth_getBlockByNumber", "eth_getBlockByHash"] else values.get(method, "0x0")
+        return {"jsonrpc": "2.0", "id": request.get("id"), "result": result}
+
+    def close(self):
+        self.server.shutdown()
+        self.server.server_close()

--- a/scripts/distribution/verify.py
+++ b/scripts/distribution/verify.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Verify a container through the downloadable Compose recipe; never build the app."""
+import argparse
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import socket
+import subprocess
+import tempfile
+import traceback
+import time
+import urllib.error
+import urllib.request
+
+from upstream import Upstream
+
+
+def run(args, **kwargs):
+    result = subprocess.run(args, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+    if result.returncode:
+        # Container environment and command arguments can contain generated test secrets.
+        raise RuntimeError(f"{args[0]} command failed (exit {result.returncode}): {result.stderr[-2000:]}")
+    return result.stdout.strip()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--report", required=True)
+    parser.add_argument("--compose", default=str(Path(__file__).resolve().parents[2] / "deployment/compose.release.yml"))
+    args = parser.parse_args()
+    credential = secrets.token_hex(24)
+    upstream = Upstream(credential)
+    project = "lasso-dist-" + secrets.token_hex(4)
+    checks = []
+    started = time.time()
+    cid = None
+    report = {"image": args.image, "version": args.version, "revision": args.revision, "checks": checks}
+    with tempfile.TemporaryDirectory(prefix="lasso-distribution-") as directory:
+        root = Path(directory)
+        shutil.copyfile(args.compose, root / "compose.yml")
+        with socket.socket() as sock:
+            sock.bind(("127.0.0.1", 0))
+            port = sock.getsockname()[1]
+        env = dict(os.environ)
+        # Isolate this installation from the caller's Compose configuration and secrets.
+        for key in ["SECRET_KEY_BASE", "RELEASE_COOKIE", "LASSO_NODE_ID", "LASSO_IMAGE", "LASSO_PORT", "COMPOSE_FILE", "COMPOSE_PROJECT_NAME", "LASSO_TEST_CREDENTIAL"]:
+            env.pop(key, None)
+        secret = secrets.token_hex(64)
+        cookie = secrets.token_hex(32)
+        (root / ".env").write_text(f"SECRET_KEY_BASE={secret}\nRELEASE_COOKIE={cookie}\nLASSO_TEST_CREDENTIAL={credential}\nLASSO_IMAGE={args.image}\nLASSO_PORT={port}\n")
+        (root / ".env").chmod(0o600)
+        # This host entry connects the disposable controlled upstream to the container.
+        (root / "test.override.json").write_text(json.dumps({"services": {"lasso": {"extra_hosts": ["host.docker.internal:host-gateway"]}}}))
+        compose = ["docker", "compose", "--project-name", project, "--project-directory", directory, "--env-file", str(root / ".env"), "-f", str(root / "compose.yml"), "-f", str(root / "test.override.json")]
+
+        def dc(*parts):
+            return run(compose + list(parts), env=env)
+
+        def record(name):
+            checks.append(name)
+            print("PASS " + name, flush=True)
+
+        def request(path, payload=None):
+            data = json.dumps(payload).encode() if payload is not None else None
+            req = urllib.request.Request(f"http://127.0.0.1:{port}" + path, data=data, headers={"Content-Type": "application/json"})
+            try:
+                with urllib.request.urlopen(req, timeout=20) as response:
+                    return response.status, response.read().decode()
+            except urllib.error.HTTPError as error:
+                return error.code, error.read().decode()
+
+        def healthy():
+            for _ in range(60):
+                try:
+                    status, body = request("/api/health")
+                    if status == 200 and json.loads(body).get("version") == args.version:
+                        return
+                except (OSError, ValueError):
+                    pass
+                time.sleep(1)
+            raise AssertionError("Container failed versioned health check")
+
+        def execute(*parts, **kwargs):
+            return run(["docker", "exec", cid] + list(parts), **kwargs)
+
+        def rpc(expression):
+            return execute("/app/bin/lasso", "rpc", expression)
+
+        def write_profile(slug, content):
+            run(["docker", "exec", "-i", cid, "sh", "-c", 'cat > "$1"', "sh", f"/data/config/profiles/{slug}.yml"], input=content)
+
+        def profile(slug):
+            return f'''---
+name: Distribution {slug}
+slug: {slug}
+rps_limit: 2
+---
+chains:
+  ethereum:
+    chain_id: 1
+    monitoring:
+      probe_interval_ms: 60000
+    websocket:
+      subscribe_new_heads: true
+    providers:
+      - id: first
+        url: http://host.docker.internal:{upstream.port}/first
+        ws_url: ws://host.docker.internal:{upstream.port}/first
+        priority: 1
+        headers:
+          X-Release-Test: ${{LASSO_TEST_CREDENTIAL}}
+      - id: second
+        url: http://host.docker.internal:{upstream.port}/second
+        ws_url: ws://host.docker.internal:{upstream.port}/second
+        priority: 2
+        headers:
+          X-Release-Test: ${{LASSO_TEST_CREDENTIAL}}
+'''
+
+        try:
+            dc("config", "--quiet")
+            dc("up", "--detach", "--no-build", "--wait", "--wait-timeout", "90")
+            cid = dc("ps", "--quiet", "lasso")
+            healthy()
+            record("Compose install from image without source or application build tools")
+            info = json.loads(run(["docker", "inspect", cid]))[0]
+            assert info["Config"]["User"] == "10001:10001"
+            assert info["HostConfig"]["ReadonlyRootfs"]
+            assert info["HostConfig"]["CapDrop"] == ["ALL"]
+            assert "no-new-privileges:true" in info["HostConfig"]["SecurityOpt"]
+            labels = info["Config"].get("Labels", {})
+            assert labels["org.opencontainers.image.revision"] == args.revision
+            assert labels["org.opencontainers.image.version"] == "v" + args.version
+            report["architecture"] = json.loads(run(["docker", "image", "inspect", info["Image"]]))[0]["Architecture"]
+            record("Version/revision identity, nonroot user, read-only root, restricted capabilities")
+            status, body = request("/api/chains")
+            assert status == 200 and len(json.loads(body)["chains"]) >= 1
+            assert request("/dashboard")[0] == 200
+            assert request("/favicon.svg")[0] == 200
+            record("Bundled profiles, dashboard HTML, and favicon")
+            write_profile("public", profile("public"))
+            write_profile("custom", profile("custom"))
+            execute("rm", "-f", "/data/config/profiles/testnet.yml")
+            assert rpc("IO.inspect(Lasso.Config.ConfigStore.reload())") == ":ok"
+            payload = {"jsonrpc": "2.0", "method": "eth_getBalance", "params": ["0x0000000000000000000000000000000000000001", "latest"], "id": 34}
+            for path in ["/rpc/ethereum", "/rpc/profile/custom/ethereum", "/rpc/profile/custom/provider/first/ethereum"]:
+                status, body = request(path, payload)
+                assert status == 200 and json.loads(body).get("result") == "0x0", (path, status, body)
+            assert upstream.authenticated > 0
+            record("Custom YAML activation, namespaced routing, provider override, credential substitution")
+            before = upstream.calls["/second"]
+            upstream.fail_first = True
+            for _ in range(4):
+                status, body = request("/rpc/profile/custom/fastest/ethereum", payload)
+                assert status == 200 and json.loads(body).get("result") == "0x0", (status, body)
+            assert upstream.calls["/second"] > before
+            upstream.fail_first = False
+            record("HTTP routing remains available with one upstream returning 503")
+            # Node's built-in WebSocket client requires no installed npm dependencies.
+            ws = r'''
+const assert = require('node:assert/strict');
+const ws = new WebSocket(process.argv[1]);
+const timer = setTimeout(() => { console.error('WebSocket RPC/subscription timed out'); process.exit(1); }, 20000);
+let ordinary = false, subscription = false;
+ws.onopen = () => ws.send(JSON.stringify({jsonrpc:'2.0',id:1,method:'eth_chainId',params:[]}));
+ws.onmessage = event => {
+  const data = JSON.parse(event.data);
+  if(data.id === 1) { assert.equal(data.result, '0x1'); ordinary = true; ws.send(JSON.stringify({jsonrpc:'2.0',id:2,method:'eth_subscribe',params:['newHeads']})); }
+  if(data.id === 2) { assert.equal(typeof data.result, 'string', JSON.stringify(data)); subscription = true; }
+  if(data.method === 'eth_subscription') { assert.ok(ordinary && subscription); assert.equal(data.params.result.number, '0x1000'); clearTimeout(timer); ws.close(); }
+};
+ws.onerror = () => { console.error('WebSocket error'); process.exit(1); };
+'''
+            run(["node", "-e", ws, f"ws://127.0.0.1:{port}/ws/rpc/profile/custom/provider/second/ethereum"], timeout=25)
+            record("WebSocket RPC, subscription acknowledgment, and newHeads delivery")
+            for path, expected in [("/rpc/profile/missing/ethereum", 404), ("/rpc/provider/missing/ethereum", 400)]:
+                status, body = request(path, payload)
+                assert status == expected and "error" in json.loads(body)
+            record("Invalid profile/provider client errors")
+            write_profile("custom", profile("custom") + "\nunsupported_setting: true\n")
+            answer = rpc('before = Lasso.Config.ConfigStore.route_generation(); result = Lasso.Config.ConfigStore.reload(); unless match?({:error, _}, result) and before == Lasso.Config.ConfigStore.route_generation(), do: raise("Invalid reload changed active config"); IO.puts("retained")')
+            assert answer == "retained"
+            assert json.loads(request("/rpc/profile/custom/ethereum", payload)[1])["result"] == "0x0"
+            write_profile("custom", profile("custom"))
+            assert rpc("IO.inspect(Lasso.Config.ConfigStore.reload())") == ":ok"
+            record("Invalid reload preserves active generation and working RPC")
+            assert rpc('Lasso.Benchmarking.Persistence.save_snapshot("custom", "ethereum", %{release_probe: true}); entries = Lasso.Benchmarking.Persistence.load_snapshots("custom", "ethereum", 1); unless Enum.any?(entries, &(&1["data"]["release_probe"] == true)), do: raise("Snapshot missing"); IO.puts("saved")') == "saved"
+            previous = cid
+            dc("up", "--detach", "--no-build", "--force-recreate", "--wait", "--wait-timeout", "90")
+            cid = dc("ps", "--quiet", "lasso")
+            assert cid != previous
+            healthy()
+            assert json.loads(request("/rpc/profile/custom/ethereum", payload)[1])["result"] == "0x0"
+            assert rpc('entries = Lasso.Benchmarking.Persistence.load_snapshots("custom", "ethereum", 1); IO.puts(Enum.any?(entries, &(&1["data"]["release_probe"] == true)))') == "true"
+            record("Container replacement preserves custom profiles and actual saved benchmark history")
+            profiles = root / "profiles"
+            profiles.mkdir()
+            for slug in ["public", "custom"]:
+                (profiles / (slug + ".yml")).write_text(profile(slug))
+                (profiles / (slug + ".yml")).chmod(0o644)
+            profiles.chmod(0o755)
+            override = {"services": {"lasso": {"extra_hosts": ["host.docker.internal:host-gateway"], "environment": {"LASSO_PROFILES_DIR": "/profiles"}, "volumes": [{"type": "bind", "source": str(profiles), "target": "/profiles", "read_only": True}]}}}
+            (root / "test.override.json").write_text(json.dumps(override))
+            dc("up", "--detach", "--no-build", "--force-recreate", "--wait", "--wait-timeout", "90")
+            cid = dc("ps", "--quiet", "lasso")
+            healthy()
+            assert rpc("IO.inspect(Lasso.Config.ConfigStore.reload())") == ":ok"
+            assert json.loads(request("/rpc/profile/custom/ethereum", payload)[1])["result"] == "0x0"
+            record("Read-only host-managed profiles boot, reload, and route successfully")
+            logs = subprocess.run(["docker", "logs", cid], text=True, capture_output=True, check=True)
+            surfaces = request("/dashboard/custom")[1] + logs.stdout + logs.stderr
+            assert all(value not in surfaces for value in [credential, secret, cookie])
+            record("Generated credentials absent from inspected dashboard HTML and runtime logs")
+            report["result"] = "pass"
+        except Exception as error:
+            message = str(error) or traceback.format_exc()
+            for value in [credential, secret, cookie]:
+                message = message.replace(value, "[redacted]")
+            report.update(result="fail", error=message, upstream_events=upstream.events)
+            if cid:
+                logs = subprocess.run(["docker", "logs", "--tail", "100", cid], text=True, capture_output=True)
+                diagnostic = logs.stdout + logs.stderr
+                for value in [credential, secret, cookie]:
+                    diagnostic = diagnostic.replace(value, "[redacted]")
+                Path(args.report + ".log").write_text(diagnostic)
+            raise RuntimeError(message) from None
+        finally:
+            report["duration_seconds"] = round(time.time() - started, 2)
+            Path(args.report).write_text(json.dumps(report, indent=2) + "\n")
+            try:
+                dc("down", "--volumes", "--timeout", "15")
+            finally:
+                upstream.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Lasso RPC releases currently require users to build the application locally. Add a container publication workflow that builds the exact published source release on native AMD64/ARM64 runners, records immutable digests and build provenance/SBOMs, and promotes version tags only after anonymous pulls and distribution acceptance checks pass on both platforms.

The standalone Compose attachment requires no source checkout, keeps secrets in a local `.env`, and preserves profiles/history in a restricted nonroot container. Acceptance checks exercise upstream-backed HTTP, a failed upstream, WebSocket RPC/newHeads, invalid reload preservation, real snapshot persistence across replacement, and read-only configuration mounts. `eth_chainId` alone is explicitly excluded as proof of upstream connectivity because it can be served locally.

Publication checks reuse exact-commit CI, reject replacement of an existing version with another digest, and do not move `latest` backward on an older release rerun. The refreshed release runbook documents first-publication package visibility, retries, evidence, and the distinction between source and publication-tooling revisions. README/deployment installation guidance will switch to the public artifact after publication is verified.

Validation: `actionlint`, six publication-guard unit tests, and the native ARM64 local distribution acceptance run pass. First registry publication targets the already-released v0.3.4 source commit; this PR does not change runtime code or its version.
