### PR TITLE
Fix container promotion artifact selection

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -197,8 +197,15 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - name: Download the assembled image identity
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
+          name: container-release
+          path: ${{ runner.temp }}/distribution
+      - name: Download native verification evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: verification-*
           merge-multiple: true
           path: ${{ runner.temp }}/distribution
       - name: Publish verified version, current latest, Compose recipe, and evidence

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -60,10 +60,12 @@ end users need Docker Compose and the downloaded configuration.
 
 ### First publication and package access
 
-GHCR packages initially default to private. After the first candidate is built,
-open the repository-linked `lasso-rpc` package settings and make that specific OSS
-package public. Do not change visibility of other packages. Then rerun failed
-verification jobs. An authenticated push is not evidence that a user can pull.
+GHCR packages initially default to private. If the anonymous pull fails because
+the package is private, open the repository-linked `lasso-rpc` package settings
+and make that specific OSS package public. Do not change visibility of other
+packages. Then rerun failed verification jobs. A package that already permits
+anonymous pulls needs no visibility change. An authenticated push alone does not
+establish public access.
 
 If package access or runner capacity blocks a stage, retain the run and report the
 actual blocker. Do not bypass anonymous verification or publish version tags to


### PR DESCRIPTION
Container builds, signed index assembly, anonymous pulls, and native AMD64/ARM64 acceptance checks passed in [the first publication run](https://github.com/jaxernst/lasso-rpc/actions/runs/34168609996). Promotion then failed because its unfiltered artifact download also tried to extract Docker build-record artifacts, which are not ZIP release evidence.

Download the named `container-release` artifact and `verification-*` artifacts explicitly. Keep Docker build records available in the run without passing them to the release-asset extraction step. Clarify that package visibility only needs changing when anonymous access actually fails.

Validation: actionlint, six publication-guard tests, and `git diff --check` pass. A complete publication run will verify the corrected artifact selection after merge; version tags were not created by the failed run.
