### PR TITLE
Fix shared WebSocket subscriptions after reload; release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-09-07
+
+### Fixed
+
+- New profiles can subscribe through shared WebSocket upstreams after configuration reload without restarting the node. Routing eligibility reads the physical connection state instead of requiring a pre-existing profile channel cache entry.
+- Exclude disconnected WebSocket upstreams even when profile channel caches still contain their wrappers; publish connected state before notifying consumers.
+- Container acceptance checks cover subscription acknowledgment, block delivery, and unsubscribe for newly reloaded profiles sharing existing connections.
+
+### Compatibility
+
+- No YAML schema or storage migration. Distribute and reload profile files on each node; environment and mount changes still require recreation. Existing v0.3.4 installations should retain the restart workaround until upgraded.
+
 ### Distribution
 
 - Publish versioned AMD64/ARM64 container images with anonymous installation checks, build provenance, SBOMs, and signed publication attestations.
@@ -180,7 +192,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.4...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.5...HEAD
+[0.3.5]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.1...v0.3.2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-26A5E4?style=flat-square&labelColor=19202E&logo=telegram&logoColor=white)](https://t.me/+79pFERTlZPIzZTZh)
 [![X](https://img.shields.io/badge/follow-%40lassoRPC-19202E?style=flat-square&labelColor=19202E&logo=x&logoColor=white)](https://x.com/lassoRPC)
 [![License](https://img.shields.io/badge/license-Apache--2.0-19202E?style=flat-square&labelColor=19202E)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.3.4-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.3.5-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
 [![Elixir](https://img.shields.io/badge/built%20with-Elixir%2FOTP-19202E?style=flat-square&labelColor=19202E&logo=elixir&logoColor=white)](https://elixir-lang.org)
 
 Lasso is a multi-chain Ethereum JSON-RPC proxy with health checks, retries,
@@ -38,7 +38,7 @@ You need Docker with the Compose plugin, curl, and OpenSSL. Start in an empty di
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.4/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.5/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health
@@ -137,10 +137,10 @@ docker compose up -d --force-recreate --wait
 
 Then use `http://localhost:4000/rpc/profile/my-app/ethereum` or
 `ws://localhost:4000/ws/rpc/profile/my-app/ethereum`.
-For YAML edits to existing profiles, use
+For new profiles and YAML edits, use
 [configuration reload](docs/DEPLOYMENT.md#custom-profiles-and-credentials).
-A failed reload preserves the active configuration. New profiles and environment
-changes require container recreation.
+A failed reload preserves the active configuration. Environment or mount changes
+require container recreation.
 
 Profiles are configuration boundaries, not access controls. The dashboard reads
 them from YAML; edit the files to create or change profiles. Profile `rps_limit`

--- a/deployment/compose.release.yml
+++ b/deployment/compose.release.yml
@@ -1,6 +1,6 @@
 services:
   lasso:
-    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.3.4}
+    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.3.5}
     ports:
       - "127.0.0.1:${LASSO_PORT:-4000}:4000"
     env_file:

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -276,9 +276,9 @@ config/profiles/
 └── staging.yml      # Subset for testing
 ```
 
-The dashboard lists configured profiles and links to this guide. To add a profile, create its YAML file in the profiles directory on each node and restart Lasso. For containers, follow the [deployment instructions](DEPLOYMENT.md#custom-profiles-and-credentials). In v0.3.4, reload alone can leave a newly added profile's WebSocket subscriptions unavailable.
+The dashboard lists configured profiles and links to this guide. To add a profile, create its YAML file in the profiles directory on each node and reload Lasso. For containers, follow the [deployment instructions](DEPLOYMENT.md#custom-profiles-and-credentials). v0.3.5 supports new profiles reusing connected WebSocket upstreams after reload. On v0.3.4, restart after adding a profile to avoid unavailable subscriptions.
 
-For YAML edits to existing profiles, reload the running release:
+For new profiles and YAML edits, reload the running release:
 
 ```bash
 _build/prod/rel/lasso/bin/lasso rpc 'Lasso.Config.ConfigStore.reload()'

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,7 +41,7 @@ requires Docker Compose and OpenSSL for generating local secrets:
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.4/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.5/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health
@@ -122,15 +122,16 @@ traversable by that UID; host directories used for writable history must also be
 writable by UID 10001. Keep credential values in `.env` and reference them as
 `${VARIABLE_NAME}` in provider URLs or headers.
 
-Apply new profiles, mount changes, or environment changes:
+Apply mount changes or environment changes:
 
 ```bash
 docker compose up -d --force-recreate --wait
 ```
 
-In v0.3.4, adding a profile through reload alone can leave its WebSocket
-subscriptions unavailable. Recreate the container after adding profiles.
-For YAML-only edits to existing profiles, reload the running node:
+In v0.3.5, new profiles can reuse connected WebSocket upstreams after reload.
+If you remain on v0.3.4, recreate the container after adding profiles to avoid
+unavailable subscriptions. For new profiles and YAML-only edits in v0.3.5, reload
+the running node:
 
 ```bash
 docker compose exec -T lasso /app/bin/lasso rpc 'IO.inspect(Lasso.Config.ConfigStore.reload())'
@@ -277,8 +278,7 @@ For each release/container instance, set:
 Replace the example IP and DNS name with your network's values. For a second
 node at `10.0.0.12`, use `RELEASE_NODE=lasso@10.0.0.12` and a different
 `LASSO_NODE_ID`; keep the cookie, DNS query, and basename the same. Supply matching
-profile YAML to every node. Recreate nodes after adding profiles; reload each
-node for edits to existing profiles.
+profile YAML to every node. Reload each node after adding or editing profiles.
 
 In Compose, put these values in each instance's `.env` and recreate its container
 with `docker compose up -d --force-recreate --wait`. Nodes poll DNS every five

--- a/lib/lasso/core/transport/websocket/connection.ex
+++ b/lib/lasso/core/transport/websocket/connection.ex
@@ -1043,11 +1043,11 @@ defmodule Lasso.RPC.Transport.WebSocket.Connection do
         schedule_stability_check(state)
       end
 
+    write_ws_status(state.instance_id, :connected, state.reconnect_attempts)
+
     broadcast_conn_event(state, fn provider_id ->
       {:ws_connected, provider_id, connection_id}
     end)
-
-    write_ws_status(state.instance_id, :connected, state.reconnect_attempts)
 
     state = schedule_heartbeat(state)
     {:noreply, state}

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -4,7 +4,7 @@ defmodule Lasso.Providers.CandidateListing do
 
   Implements a 9-stage filter pipeline using shared ETS state:
   1. Transport availability (provider config has url/ws_url)
-  2. WS liveness (channel cache for WS presence)
+  2. WS liveness (shared upstream connection state)
   3. Circuit breaker state
   4. Rate limit state
   5. Lag filtering (BlockSync.Registry + ChainState)
@@ -357,7 +357,7 @@ defmodule Lasso.Providers.CandidateListing do
   defp build_candidate(provider, learned_scope, plan, protocol, workload_key, mode) do
     instance_id = provider.instance_id
     routing_instance_id = provider.routing_instance_id
-    transports = live_transports(provider, protocol, plan.profile, plan.chain_id)
+    transports = live_transports(provider, protocol)
 
     include_learned? = not learned_scope.degraded?
 
@@ -436,11 +436,11 @@ defmodule Lasso.Providers.CandidateListing do
     end
   end
 
-  defp live_transports(provider, protocol, profile, chain_id) do
+  defp live_transports(provider, protocol) do
     provider.transports
     |> Enum.filter(fn
       :http -> protocol in [:http, :both, nil]
-      :ws -> protocol in [:ws, :both, nil] and ws_channel_live?(profile, chain_id, provider.id)
+      :ws -> protocol in [:ws, :both, nil] and ws_instance_connected?(provider.instance_id)
     end)
   end
 
@@ -496,11 +496,8 @@ defmodule Lasso.Providers.CandidateListing do
       rate_limit_ok?(candidate, protocol, filters)
   end
 
-  defp ws_channel_live?(profile, chain_id, provider_id) do
-    case :ets.lookup(:transport_channel_cache, {profile, chain_id, provider_id, :ws}) do
-      [{_, _channel}] -> true
-      [] -> false
-    end
+  defp ws_instance_connected?(instance_id) do
+    InstanceState.read_ws_status(instance_id).status == :connected
   end
 
   defp circuit_breaker_ready?(candidate, protocol, include_half_open) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.3.4",
+      version: "0.3.5",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],

--- a/scripts/distribution/verify.py
+++ b/scripts/distribution/verify.py
@@ -172,12 +172,19 @@ ws.onmessage = event => {
   const data = JSON.parse(event.data);
   if(data.id === 1) { assert.equal(data.result, '0x1'); ordinary = true; ws.send(JSON.stringify({jsonrpc:'2.0',id:2,method:'eth_subscribe',params:['newHeads']})); }
   if(data.id === 2) { assert.equal(typeof data.result, 'string', JSON.stringify(data)); subscription = true; }
-  if(data.method === 'eth_subscription') { assert.ok(ordinary && subscription); assert.equal(data.params.result.number, '0x1000'); clearTimeout(timer); ws.close(); }
+  if(data.id === 3) { assert.equal(data.result, true); clearTimeout(timer); ws.close(); }
+  if(data.method === 'eth_subscription') { assert.ok(ordinary && subscription); assert.equal(data.params.result.number, '0x1000'); ws.send(JSON.stringify({jsonrpc:'2.0',id:3,method:'eth_unsubscribe',params:[data.params.subscription]})); }
 };
 ws.onerror = () => { console.error('WebSocket error'); process.exit(1); };
 '''
             run(["node", "-e", ws, f"ws://127.0.0.1:{port}/ws/rpc/profile/custom/provider/second/ethereum"], timeout=25)
-            record("WebSocket RPC, subscription acknowledgment, and newHeads delivery")
+            record("WebSocket RPC, subscription acknowledgment, newHeads delivery, and unsubscribe")
+            write_profile("shared", profile("shared"))
+            assert rpc("IO.inspect(Lasso.Config.ConfigStore.reload())") == ":ok"
+            for slug in ["shared", "public", "custom"]:
+                assert json.loads(request(f"/rpc/profile/{slug}/ethereum", payload)[1])["result"] == "0x0"
+                run(["node", "-e", ws, f"ws://127.0.0.1:{port}/ws/rpc/profile/{slug}/ethereum"], timeout=25)
+            record("New profile reload reuses connected upstreams for HTTP and subscriptions; existing profiles remain available")
             for path, expected in [("/rpc/profile/missing/ethereum", 404), ("/rpc/provider/missing/ethereum", 400)]:
                 status, body = request(path, payload)
                 assert status == expected and "error" in json.loads(body)

--- a/test/lasso/providers/candidate_listing_test.exs
+++ b/test/lasso/providers/candidate_listing_test.exs
@@ -763,6 +763,29 @@ defmodule Lasso.Providers.CandidateListingTest do
     end
   end
 
+  describe "WebSocket instance liveness" do
+    test "a connected shared upstream is eligible before a profile channel is cached" do
+      provider =
+        Catalog.get_profile_providers(@profile, @chain) |> Enum.find(&(&1.provider_id == "p2"))
+
+      assert :ets.lookup(:transport_channel_cache, {@profile, @chain, "p2", :ws}) == []
+      :ets.insert(@instance_table, {{:ws_status, provider.instance_id}, %{status: :connected}})
+      {:ok, plan} = Catalog.get_routing_plan(Catalog.snapshot(), @profile, @chain)
+
+      assert [%{id: "p2", transports: [:ws]}] =
+               CandidateListing.list_routing_candidates_from_plan(plan, %{protocol: :ws})
+    end
+
+    test "a cached profile channel does not make a disconnected upstream eligible" do
+      key = {@profile, @chain, "p2", :ws}
+      :ets.insert(:transport_channel_cache, {key, :stale_channel})
+      on_exit(fn -> :ets.delete(:transport_channel_cache, key) end)
+      {:ok, plan} = Catalog.get_routing_plan(Catalog.snapshot(), @profile, @chain)
+
+      assert CandidateListing.list_routing_candidates_from_plan(plan, %{protocol: :ws}) == []
+    end
+  end
+
   # Helpers
 
   defp register_chain(profile, chain, providers) do
@@ -820,6 +843,7 @@ defmodule Lasso.Providers.CandidateListingTest do
       :ets.delete(Storage.snapshot_table(), {pp.instance_id, :ws})
       :ets.delete(@instance_table, {:rate_limit, pp.instance_id, :http})
       :ets.delete(@instance_table, {:rate_limit, pp.instance_id, :ws})
+      :ets.delete(@instance_table, {:ws_status, pp.instance_id})
       :ets.delete(@instance_table, {:health_probe, pp.instance_id})
       :ets.delete(@instance_table, {:health_block_sync, pp.instance_id})
       :ets.delete(@instance_table, {:health_routing, pp.instance_id})

--- a/test/lasso/rpc/upstream_subscription_pool_test.exs
+++ b/test/lasso/rpc/upstream_subscription_pool_test.exs
@@ -204,6 +204,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       Process.sleep(25)
       assert get_pool_state(chain_id).keys[{:newHeads}].status == :establishing
 
+      set_ws_status(profile, chain_id, provider, :connected)
+
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
         Lasso.Topics.ws_connection(profile, chain_id),
@@ -242,6 +244,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       :ok = wait_until_key_active(chain_id, {:newHeads})
       [{manager_pid, _}] = Registry.lookup(Lasso.Registry, {:instance_sub_manager, instance_id})
       send(manager_pid, {:ws_disconnected, instance_id, %{reason: :recovery_test}})
+      set_ws_status(profile, chain_id, provider, :disconnected)
       :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
 
       Phoenix.PubSub.broadcast(
@@ -257,6 +260,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
       assert_receive {:subscription_terminated, ^subscription_id, :continuity_exhausted}, 1_000
       assert TestHelper.eventually(fn -> get_pool_state(chain_id).keys == %{} end)
+
+      set_ws_status(profile, chain_id, provider, :connected)
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
@@ -295,6 +300,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       provider: provider,
       profile: profile
     } do
+      set_ws_status(profile, chain_id, provider, :disconnected)
       :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
 
       client_pid = self()
@@ -324,6 +330,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       bounded_entry = get_pool_state(chain_id).keys[{:newHeads}]
       assert bounded_entry.readiness_retries <= 4
 
+      set_ws_status(profile, chain_id, provider, :connected)
+
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
         Lasso.Topics.ws_connection(profile, chain_id),
@@ -340,6 +348,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       provider: provider,
       profile: profile
     } do
+      set_ws_status(profile, chain_id, provider, :disconnected)
       :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
 
       client_pid = self()
@@ -359,6 +368,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
       Process.sleep(25)
       assert get_pool_state(chain_id).keys[pool_key].status == :establishing
+
+      set_ws_status(profile, chain_id, provider, :connected)
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
@@ -480,6 +491,7 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
       provider: provider,
       profile: profile
     } do
+      set_ws_status(profile, chain_id, provider, :disconnected)
       :ets.delete(:transport_channel_cache, {profile, chain_id, provider, :ws})
 
       deadline_us = System.monotonic_time(:microsecond) + 100_000
@@ -496,6 +508,8 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
                )
 
       assert get_pool_state(chain_id).keys == %{}
+
+      set_ws_status(profile, chain_id, provider, :connected)
 
       Phoenix.PubSub.broadcast(
         Lasso.PubSub,
@@ -856,6 +870,11 @@ defmodule Lasso.Core.Streaming.UpstreamSubscriptionPoolTest do
 
     assert_receive {:subscription_terminated, ^subscription_id, :continuity_exhausted}, 1_000
     assert TestHelper.eventually(fn -> get_pool_state(chain_id).keys == %{} end)
+  end
+
+  defp set_ws_status(profile, chain_id, provider, status) do
+    instance_id = Lasso.Providers.Catalog.lookup_instance_id(profile, chain_id, provider)
+    :ets.insert(:lasso_instance_state, {{:ws_status, instance_id}, %{status: status}})
   end
 
   defp get_pool_state(chain_id, profile \\ @default_profile) do

--- a/test/support/lasso/testing/mock_ws_provider.ex
+++ b/test/support/lasso/testing/mock_ws_provider.ex
@@ -109,6 +109,8 @@ defmodule Lasso.Testing.MockWSProvider do
         }
       })
 
+      :ets.insert(:lasso_instance_state, {{:ws_status, instance_id}, %{status: :connected}})
+
       start_instance_subscription_manager(chain_id, instance_id)
 
       connection_id =
@@ -607,6 +609,7 @@ defmodule Lasso.Testing.MockWSProvider do
           end
         end
 
+        :ets.delete(:lasso_instance_state, {:ws_status, instance_id})
         :ets.delete(:lasso_instance_state, {:health_probe, instance_id})
         :ets.delete(:lasso_instance_state, {:health_block_sync, instance_id})
         :ets.delete(:lasso_instance_state, {:health_routing, instance_id})


### PR DESCRIPTION
Adding a YAML profile that reuses an already-connected upstream could leave `eth_subscribe` timing out until restart. Selection required a profile-local channel cache entry, but the new profile had missed the upstream’s original connection event.

Read WebSocket eligibility from the shared instance connection state and publish that state before notifying consumers. Cached wrappers no longer make a disconnected upstream eligible. Prepare v0.3.5 with matching installation references and retain the v0.3.4 restart caveat for existing installations.

Validation:
- Reproduced on the published v0.3.4 container: shared endpoint fails; separate endpoint and original profile pass.
- Fixed container passes HTTP, subscription acknowledgment, newHeads delivery, and unsubscribe after reload, including original-profile controls.
- Full hermetic integration suite: 1,672 tests pass. Final focused selection/subscription checks: 61 pass; WebSocket transport checks: 48 pass.
- Full local container distribution acceptance passes, including the new shared-profile reload regression, invalid reload retention, replacement, and read-only mounts. Native AMD64/ARM64 acceptance remains required before image promotion.
- Two connected local nodes pass ten boot/reload/shared/separate-endpoint checks with advancing block headers; each check proves HTTP, ACK, notification, and unsubscribe. A constant-head fixture was unsuitable for post-subscription delivery because repeated heights are deduplicated.
- Credo and six publication guard tests pass. All five CI jobs pass on 694e6eef870e8ef29faa3efee61868c88e362a32.
- Source self-review traced the connection-state producer, event ordering, lazy channel creation, disconnect gating, and unchanged circuit/rate-limit/lag filters. The automated review action completed but published no substantive review; it is not counted as independent approval.

No YAML schema or storage migration. Each node still needs its own profile files and reload. Environment and mount changes still require recreation. This does not claim uninterrupted delivery across node replacement.

Fixes #135.
