### PR TITLE
docs: align API reference with released Core behavior

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -237,7 +237,7 @@ curl -X POST http://localhost:4000/rpc/ethereum \
 
 Response preserves request order as a JSON array.
 
-**Provider pinning**: a single provider is selected before routing any batch items, so all items in the batch read from the same upstream. Individual items can still failover to a different provider if the pinned provider returns an error for that specific request.
+Each item is validated and routed independently with bounded concurrency and its own execution deadline. A batch does not imply one provider or an atomic state snapshot. Valid notifications produce no response item; an all-notification batch returns HTTP 204.
 
 ---
 
@@ -273,7 +273,7 @@ Response preserves request order as a JSON array.
 
 ### Unsupported Methods
 
-Write methods (`eth_sendRawTransaction`, `eth_sendTransaction`) are not currently supported. Subscription methods (`eth_subscribe`) are rejected over HTTP with a WebSocket URL hint.
+`eth_sendRawTransaction` is routable with one upstream dispatch under one deadline. A lost response can mean the transaction was accepted; clients reconcile its hash. `eth_sendTransaction`, `eth_accounts`, `eth_sign`, `eth_signTransaction`, and `personal_sign` are globally disallowed. Provider capability policy can impose additional restrictions. Subscription methods are rejected over HTTP with a WebSocket URL hint. See [Method support](RPC_STANDARDS.md) for the released Core contract.
 
 ---
 
@@ -305,23 +305,14 @@ The `websocket_url` mirrors the HTTP request path — for example, a request to
 | `-32601` | Method not found or not supported on this transport |
 | `-32602` | Invalid params (unsupported chain, missing chain_id) |
 | `-32603` | Internal error |
-| `-32000` | Server error (rate limit, strategy access denied, quota exceeded) |
+| `-32000` | Server error (for example, upstream rate limiting or exhausted routing) |
 
-### Rate Limiting
+### Upstream rate limits
 
-When rate limited, the error includes retry information:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "error": {
-    "code": -32000,
-    "message": "Rate limit exceeded. Limit: 100 requests per second.",
-    "data": {"retry_after_ms": 150, "rate_limit": 100}
-  }
-}
-```
+RPC Core has no built-in client authentication or incoming per-client quotas.
+Provider rate limits can cause cooldowns, failover, or an RPC error. Configure
+incoming admission at your reverse proxy. Profile `rps_limit` controls the
+dashboard tester maximum; `burst_limit` is metadata, not ingress enforcement.
 
 ---
 
@@ -374,5 +365,6 @@ All origins are allowed (`*`). Allowed headers:
 - `X-Requested-With`
 - `X-Lasso-Provider`
 - `X-Lasso-Transport`
+- `X-Lasso-Include-Meta`
 
 Preflight responses are cached for 24 hours.

--- a/docs/RPC_STANDARDS.md
+++ b/docs/RPC_STANDARDS.md
@@ -1,461 +1,89 @@
-# Lasso RPC: JSON-RPC Standards & Method Support
+# RPC Core method support
 
-## Overview
+This page describes the self-hosted **v0.3.5** runtime. Lasso Cloud has a separate
+[compatibility contract](https://docs.lasso.sh/cloud/json-rpc-compatibility).
+Do not infer parity from a shared method name or product version.
 
-Lasso provides production-grade routing for stateless Ethereum JSON-RPC reads and subscriptions with intelligent failover, performance-based selection, and comprehensive observability.
+## Reads and execution safety
 
-**In Scope:**
+Common Ethereum reads such as `eth_blockNumber`, `eth_getBalance`, `eth_call`,
+`eth_getTransactionReceipt`, and `eth_getLogs` are routable, subject to provider
+capability, transport availability, history, and request parameters. A routable
+method is not a guarantee that every provider supports it.
 
-- Stateless read methods with strategy-based routing
-- WebSocket subscriptions with multiplexing and gap-filling
-- Transport-agnostic routing (HTTP ↔ WebSocket failover)
-- Circuit breakers, rate limit handling, benchmarking
+Methods classified as replay-safe by the released `ExecutionEnvelope` can use
+bounded further attempts within the original deadline. Unknown methods receive
+one upstream dispatch. Provider error classification does not override execution
+safety. The registry classifies methods; it does not certify upstream semantics
+or full compliance with every Ethereum specification.
 
-**Out of Scope (Current):**
+## Signed transaction submission
 
-- Transaction writes without guarantees (nonce management, deduplication)
-- Wallet/signing methods (client-side per EIP-1193)
-- Stateful filters (require sticky sessions)
+`eth_sendRawTransaction` receives one upstream dispatch. Lasso does not retry or
+fan out after dispatch. A lost response may mean the upstream accepted the
+transaction. Clients remain responsible for signing, nonce management,
+replacement, transaction-hash reconciliation, receipts, and finality.
 
----
+## Node-local methods
 
-## Supported Methods by Protocol
+The transport policy globally disallows `eth_sendTransaction`, `eth_accounts`,
+`eth_sign`, `eth_signTransaction`, and `personal_sign`. Provider capability
+policy can reject additional methods, including the `local_only` category.
+Do not treat a profile as an authentication or authorization boundary.
 
-### HTTP: Stateless Reads
+## Stateful filters and extensions
 
-All standard Ethereum read methods are supported with failover, circuit breakers, and performance-based routing.
+RPC Core v0.3.5 can forward provider-local filter methods when capability policy
+permits them. They receive one dispatch per request and have **no cross-request
+affinity guarantee**. A filter ID created on one upstream may be invalid on a
+later selected upstream. Prefer `eth_getLogs` or supported WebSocket subscriptions;
+Core does not advertise a reliable multi-provider filter lifecycle.
 
-**Blocks & Transactions:**
+Debug, trace, transaction-pool, bundler, and chain-specific methods depend on
+upstream support and configured restrictions. Their presence in a registry does
+not provide sticky sessions, common history, or a universal parameter contract.
 
-- `eth_blockNumber`, `eth_getBlockByNumber`, `eth_getBlockByHash`
-- `eth_getTransactionByHash`, `eth_getTransactionReceipt`, `eth_getBlockTransactionCountByNumber`
+## WebSocket subscriptions
 
-**Account State:**
-
-- `eth_getBalance`, `eth_getTransactionCount`, `eth_getCode`, `eth_getStorageAt`
-
-**Execution & Gas:**
-
-- `eth_call`, `eth_estimateGas`, `eth_gasPrice`, `eth_maxPriorityFeePerGas`, `eth_feeHistory`
-
-**Logs & Events:**
-
-- `eth_getLogs` (note: large ranges subject to upstream limits; see best practices below)
-
-**Network Info:**
-
-- `eth_chainId`, `net_version`, `net_listening`, `web3_clientVersion`
-
-**Advanced:**
-
-- `eth_getProof` (EIP-1186 state proofs)
-- EIP-1898 block parameter objects (`{blockNumber, blockHash, requireCanonical}`)
-- `finalized` and `safe` block tags
-
-**Non-Standard Methods:**
-
-- Debug/tracing: `debug_*`, `trace_*`, `parity_*`, `erigon_*`, `arbtrace_*`
-- Chain-specific: `eth_getBlockReceipts` (Alchemy/Erigon), `optimism_*`, etc.
-- **Policy:** Forwarded when upstream supports them; no guarantees; may be expensive
-
-### WebSocket: Subscriptions & Reads
-
-**Subscriptions (WS only):**
-
-- `eth_subscribe(["newHeads"])` - Block headers with gap-filling on failover
-- `eth_subscribe(["logs", {...filter}])` - Transaction logs with gap-filling on failover
-- `eth_subscribe(["newPendingTransactions"])` - Pending tx hashes (no gap-filling)
-- `eth_unsubscribe([subscriptionId])`
-
-**WebSocket Reads:**
-
-- All stateless read methods listed above
-- **Transport-agnostic routing:** Can route to either HTTP or WS providers based on performance
-- Automatic failover across transports (WS → HTTP or HTTP → WS)
-
----
-
-## Blocked Methods
-
-### Subscriptions Over HTTP ❌
-
-- `eth_subscribe`, `eth_unsubscribe` - Use WebSocket
-
-### Wallet/Signing ❌
-
-- `eth_sign`, `eth_signTransaction`, `eth_signTypedData*`
-- `personal_sign`, `personal_*` namespace
-- `wallet_*` namespace (EIP-1193 client APIs)
-- `eth_accounts` (server-side enumeration insecure)
-
-**Why:** Server-side key management is out of scope
-
-### Transaction Writes ❌
-
-- `eth_sendTransaction`, `eth_sendRawTransaction`
-
-**Why:** Multi-provider routing requires nonce management, tx deduplication, and sticky routing. Enabling writes without these guarantees causes nonce gaps and duplicate transactions.
-
-**Roadmap:** May support writes with proper nonce queue, sticky sessions, and idempotency tracking.
-
-### Stateful Filters ❌
-
-- `eth_newFilter`, `eth_newBlockFilter`, `eth_newPendingTransactionFilter`
-- `eth_getFilterChanges`, `eth_getFilterLogs`, `eth_uninstallFilter`
-
-**Why:** Filters are stateful per-provider. Failover breaks filter state.
-
-**Alternative:** Use WebSocket subscriptions (`eth_subscribe`) for real-time events.
-
-### Transaction Pool ❌
-
-- `txpool_content`, `txpool_inspect`, `txpool_status`
-
-**Why:** Provider-specific internal state; no standardization.
-
----
-
-## Advanced Features
-
-### Batching (HTTP)
-
-Lasso supports JSON-RPC batch requests:
+The supported stream kinds are `newHeads` and `logs`. Use:
 
 ```json
-POST /rpc/ethereum
-[
-  {"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]},
-  {"jsonrpc":"2.0","id":2,"method":"eth_gasPrice","params":[]}
-]
+{"jsonrpc":"2.0","method":"eth_subscribe","params":["newHeads"],"id":1}
 ```
-
-**Behavior:**
-
-- Responses preserve request order
-- Each item returns individual `result` or `error`
-- Default limit: 50 requests per batch (configurable)
-- ID echoing: Exact `id` type and value preserved
-
-### Provider Override
-
-Pin a request to specific provider:
-
-```bash
-POST /rpc/ethereum?provider=alchemy_eth
-# or
-POST /rpc/ethereum
-X-Lasso-Provider: alchemy_eth
-```
-
-**Failover on override:**
-
-- Default: Return provider's error if it fails
-- `?allow_failover=true`: Fall back to strategy-based selection on failure
-
-### Region Biasing
-
-Prefer providers in a specific region:
-
-```bash
-POST /rpc/ethereum
-X-Lasso-Region: us-east
-```
-
-**Behavior:** Filters candidates to specified region before strategy selection (when providers have region tags configured).
-
----
-
-## Error Handling
-
-Lasso normalizes all responses to JSON-RPC 2.0 format:
 
 ```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "error": {
-    "code": -32601,
-    "message": "Method not found or blocked in this context",
-    "data": { "hint": "Use WebSocket for eth_subscribe" }
-  }
-}
+{"jsonrpc":"2.0","method":"eth_subscribe","params":["logs",{}],"id":2}
 ```
 
-**Standard Error Codes:**
-
-- `-32700` Parse error
-- `-32600` Invalid Request
-- `-32601` Method not found (or blocked)
-- `-32602` Invalid params
-- `-32603` Internal error (upstream failure)
-- `-32000` Server error (proxy/failover errors)
-
-**Context Hints:** Blocked methods include suggestions (e.g., "Use WebSocket for subscriptions").
-
----
-
-## WebSocket Subscriptions: Reliability
-
-### Gap-Filling on Failover
-
-When a provider fails mid-stream, Lasso automatically:
-
-1. **Establishes replacement:** Subscribes to the replacement and buffers its events
-2. **Detects gap:** Reads the current head after replacement confirmation
-3. **HTTP backfill:** Replays the checkpoint block through the bounded current head
-4. **Merges events:** Orders and suppresses overlap between replay and the live buffer
-5. **Resumes stream:** Continues from the replacement provider
-
-Subscription IDs are returned only after usable upstream establishment.
-Recovery that exceeds the replay, buffer, attempt, or time bounds closes the
-affected downstream socket with code 1011 so the client receives a terminal
-signal and can reconnect.
-
-**Supported Subscription Types:**
-
-- ✅ `newHeads` - Full gap-filling with `eth_getBlockByNumber` backfill
-- ✅ `logs` - Full gap-filling with `eth_getLogs` backfill
-- ⚠️ `newPendingTransactions` - No gap-filling (pending txs are ephemeral)
-
-**Configuration:**
-
-```elixir
-config :lasso, :subscriptions,
-  max_backfill_blocks: 32,       # Max blocks to backfill
-  backfill_timeout_ms: 30_000,   # Timeout per backfill request
-  enable_gap_filling: true       # Enable/disable gap-filling
-```
-
-### Multiplexing
-
-Lasso multiplexes client subscriptions to minimize upstream connections:
-
-**Example:** 100 clients subscribe to `newHeads`
-
-- Without multiplexing: 100 upstream WS connections
-- With Lasso: 1 upstream connection, fanned out to 100 clients
-
-**Benefits:** Reduced bandwidth, lower rate limit consumption, better scalability.
-
----
-
-## Best Practices
-
-### Large `eth_getLogs` Queries
-
-**Challenge:** Providers cap log results by block range (typically 2,000-10,000 blocks).
-
-**Recommendations:**
-
-- Page by block range: Query 2,000 blocks at a time
-- Filter aggressively: Use `address` and `topics` to narrow results
-- Monitor provider signals: Back off on rate limit errors
-- Use `:priority` strategy for consistency across paginated queries
-
-**Roadmap:** Automatic pagination/splitting helper.
-
-### Gas Estimation Consistency
-
-`eth_estimateGas` and `eth_call` can vary across providers due to:
-
-- Different node implementations (Geth, Erigon, etc.)
-- Timing of state (block lag)
-- Gas limit buffers
-
-**Recommendations:**
-
-- Pin estimates to single provider using `?provider=<id>`
-- Use `:priority` strategy for consistency
-- Add buffer (10-20%) on client side
-
-### Non-Standard Methods
-
-**Policy:** Forward on best-effort basis; no guarantees.
-
-**Examples:**
-
-- `eth_getBlockReceipts` (Alchemy/Erigon) - May not be available on all providers
-- `trace_*` methods - Expensive; provider may reject or rate-limit
-- Chain-specific methods (`arbtrace_*`, `optimism_*`) - Chain-dependent
-
-**Check Availability:** Use provider override to test specific provider support.
-
----
-
-## EIP Compatibility
-
-### Supported EIPs
-
-**EIP-1474** (JSON-RPC) - Full baseline method set
-**EIP-1898** (Block Params) - Object block identifiers with `blockHash`, `blockNumber`, `requireCanonical`
-**EIP-1186** (`eth_getProof`) - State proofs for account/storage
-**EIP-1193** (Provider API) - Recognized (wallet methods blocked server-side)
-**EIP-4844** (Blobs) - Pass-through support; blob extras provider-specific
-
-### Account Abstraction (EIP-4337)
-
-**Bundler RPC Methods:**
-
-- `eth_sendUserOperation`, `eth_estimateUserOperationGas`
-- `eth_getUserOperationByHash`, `eth_getUserOperationReceipt`
-- `eth_supportedEntryPoints`
-
-**Policy:** Maintain separate bundler provider pools; do not mix with node pools. Bundler methods require different routing policies and SLAs.
-
-**Status:** Not yet implemented; roadmap item.
-
----
-
-## Implementation Details
-
-### MethodRegistry
-
-**Location:** `lib/lasso/rpc/method_registry.ex`
-
-The MethodRegistry provides a canonical categorization of 100+ Ethereum JSON-RPC methods based on real-world provider support patterns:
-
-```elixir
-Lasso.RPC.MethodRegistry.category_methods(:core)
-# => ["eth_blockNumber", "eth_chainId", "eth_getBalance", ...]
-
-Lasso.RPC.MethodRegistry.method_category("eth_getLogs")
-# => :filters
-
-Lasso.RPC.MethodRegistry.default_support_assumption("debug_traceTransaction")
-# => false (conservative for debug methods)
-```
-
-**Categories:**
-
-- `:core` - Universal support (99%+ providers): `eth_blockNumber`, `eth_getBalance`, etc.
-- `:state` - Common support (90%+ providers): `eth_call`, `eth_estimateGas`, etc.
-- `:filters` - Restricted support (~60% providers): `eth_getLogs`, `eth_newFilter`, etc.
-- `:debug/:trace` - Rare support (<10% providers): `debug_traceTransaction`, `trace_block`, etc.
-- `:local_only` - Never supported on hosted providers: `eth_accounts`, `eth_sign`, etc.
-- `:subscriptions` - WebSocket-only: `eth_subscribe`, `eth_unsubscribe`
-- `:eip1559`, `:eip4844`, `:batch`, `:mempool`, `:network`, `:txpool` - Specialized categories
-
-**Usage in capabilities system:**
-
-The capabilities engine uses MethodRegistry to map methods to categories for filtering. When a provider declares `unsupported_categories: [debug, trace]`, the engine checks each method against MethodRegistry to determine if it should be blocked.
-
----
-
-## Roadmap
-
-### Near-Term (P0)
-
-**Enhanced Subscription Policies**
-
-- Formalize WS provider stickiness and failover rules
-- Per-subscription-type SLO tracking
-- Better handling of subscription conflicts on failover
-
-### Mid-Term (P1)
-
-**Stateful Filter Support (Optional)**
-
-- Sticky session routing with TTLs
-- Explicit opt-in required
-- Recommend WS subscriptions as primary path
-
-**Provider Capability Registry**
-
-- Static capabilities: `supports_trace`, `supports_eip_1186`, etc.
-- Active probing for feature detection
-- Selection/failover aware of capabilities
-
-**Enhanced Error Normalization**
-
-- Map provider-specific error codes to standard taxonomy
-- Consistent error messages across providers
-
-### Long-Term (P2)
-
-**Transaction Write Support**
-
-- Per-account sticky routing
-- Nonce manager with queuing
-- Transaction deduplication store
-- Controlled rebroadcast logic
-- Receipt binding to same provider
-
-**`eth_getLogs` Pagination**
-
-- Automatic range splitting for large queries
-- Provider-aware batching
-- Parallel fetching with ordering guarantees
-
-**OpenRPC/JSON Schema**
-
-- Auto-generate API docs from MethodRegistry
-- Interactive API explorer
-- Client SDK generation
-
----
-
-## Implementation Alignment
-
-### Current Blocklist Enforcement
-
-Located in `lib/lasso_web/controllers/rpc_controller.ex`:
-
-**Recommended additions to HTTP blocklist:**
-
-- `eth_signTypedData`, `eth_signTypedData_v3`, `eth_signTypedData_v4`
-- All `wallet_*` methods
-- All `personal_*` methods
-- Filter methods: `eth_newFilter`, `eth_newBlockFilter`, `eth_getFilterChanges`, `eth_uninstallFilter`
-
-### Configuration
-
-```elixir
-# config/config.exs
-config :lasso,
-  max_batch_requests: 50,
-  provider_selection_strategy: :fastest
-
-config :lasso, :circuit_breaker,
-  failure_threshold: 5,
-  recovery_timeout: 60_000,
-  success_threshold: 2
-
-config :lasso, :subscriptions,
-  max_backfill_blocks: 32,
-  backfill_timeout_ms: 30_000,
-  enable_gap_filling: true
-```
-
----
-
-## Summary: What Lasso Allows
-
-**✅ Allow with Failover:**
-
-- All stateless read methods over HTTP or WebSocket
-- Non-standard methods (best-effort)
-- Batch requests (HTTP)
-
-**✅ Allow with Special Handling:**
-
-- Subscriptions over WebSocket (multiplexing + gap-filling)
-- Provider override with optional failover
-- Region-biased routing
-
-**❌ Block:**
-
-- Subscriptions over HTTP
-- Wallet/signing/account methods
-- Transaction writes (until write-path implementation)
-- Stateful filters (until sticky routing implementation)
-- Transaction pool introspection
-
-**⚠️ Forward But No Guarantees:**
-
-- Debug/trace methods (expensive, non-standard)
-- Chain-specific extensions
-- Bundler RPCs (requires separate pool)
-
----
-
-**Last Updated:** February 2026
+Use `eth_unsubscribe` with the returned subscription ID to stop the stream.
+Pending-transaction subscriptions are not part of this released subset.
+HTTP subscription requests return a method error with a WebSocket URL hint.
+
+Matching client streams can share upstream subscriptions. Establishment requires
+a usable upstream before returning a subscription ID. Recovery uses bounded HTTP
+replay and a replacement live stream. Recovery beyond its time, replay, attempt,
+or buffer limits terminates the affected downstream connection explicitly; it
+does not promise unbounded or lossless delivery through arbitrary outages.
+
+In Core v0.3.5, `subscribe_new_heads` controls automatic block monitoring **and**
+client `newHeads` eligibility. Set it to `true` on intended providers. New profiles
+can reuse an already-connected upstream after a successful configuration reload.
+See [Configuration](CONFIGURATION.md) and [Deployment](DEPLOYMENT.md).
+
+## HTTP batches
+
+HTTP endpoints accept arrays with up to 50 items by default (`max_batch_requests`).
+Items are validated and routed independently with bounded concurrency. A batch
+is not an atomic state snapshot and does not pin every item to one provider.
+Response items retain request order. Valid notifications produce no response;
+an all-notification batch returns HTTP 204. Use unique IDs for correlation.
+
+## Deployment boundary
+
+Core does not authenticate clients or enforce incoming customer quotas. Protect
+RPC, metrics, and dashboard endpoints through your network or reverse proxy.
+Profile tester settings do not create API quotas or upstream quota isolation.
+
+The authoritative implementation is `TransportPolicy`, `ExecutionEnvelope`,
+`Capabilities`, `RPCController`, and `RPCSocket.ItemOwner` at the selected release.
+See [API reference](API_REFERENCE.md) for routes and metadata.


### PR DESCRIPTION
The released API guides still said signed transaction submission was unsupported and batches shared one provider, and described incoming client quotas that RPC Core does not enforce. Reconcile those claims with v0.3.5 source and distinguish its provider-local filter behavior from the separate Cloud contract.

Document one-dispatch transaction and unknown-method safety, bounded subscriptions, shared-profile quota limits, and actual globally disallowed node-local methods. Remove speculative roadmap and universal compatibility claims from the method reference.

Validation: source review of TransportPolicy, ExecutionEnvelope, Capabilities, RPCController/BatchExecutor, RPCSocket.ItemOwner, and Endpoint CORS configuration; git diff --check passes. Documentation only: the published v0.3.5 source tag and container digest remain immutable.
