### PR TITLE
Recover catalog after owner restart; prepare v0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2026-09-08
+
+### Fixed
+
+- Restore the routing catalog automatically after its owner restarts. Failed recovery publications discard their unfinished tables and retry without requiring a configuration reload.
+
 ## [0.3.5] - 2026-09-07
 
 ### Fixed
@@ -192,7 +198,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.5...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.6...HEAD
+[0.3.6]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.3...v0.3.4
 [0.3.3]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.2...v0.3.3

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-26A5E4?style=flat-square&labelColor=19202E&logo=telegram&logoColor=white)](https://t.me/+79pFERTlZPIzZTZh)
 [![X](https://img.shields.io/badge/follow-%40lassoRPC-19202E?style=flat-square&labelColor=19202E&logo=x&logoColor=white)](https://x.com/lassoRPC)
 [![License](https://img.shields.io/badge/license-Apache--2.0-19202E?style=flat-square&labelColor=19202E)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.3.5-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.3.6-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
 [![Elixir](https://img.shields.io/badge/built%20with-Elixir%2FOTP-19202E?style=flat-square&labelColor=19202E&logo=elixir&logoColor=white)](https://elixir-lang.org)
 
 Lasso is a multi-chain Ethereum JSON-RPC proxy with health checks, retries,
@@ -38,7 +38,7 @@ You need Docker with the Compose plugin, curl, and OpenSSL. Start in an empty di
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.5/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.6/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health

--- a/deployment/compose.release.yml
+++ b/deployment/compose.release.yml
@@ -1,6 +1,6 @@
 services:
   lasso:
-    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.3.5}
+    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.3.6}
     ports:
       - "127.0.0.1:${LASSO_PORT:-4000}:4000"
     env_file:

--- a/docs/DECIMAL_ADVISORY.md
+++ b/docs/DECIMAL_ADVISORY.md
@@ -1,0 +1,7 @@
+# Decimal advisory range discrepancy
+
+The locked Decimal 3.1.1 release is newer than the fixed 3.0.0 release identified in the [maintainer advisory](https://github.com/ericmj/decimal/security/advisories/GHSA-rhv4-8758-jx7v). On September 8, 2026, the [EEF record imported by OSV](https://osv.dev/vulnerability/EEF-CVE-2026-32686) states the same affected range in prose but omits the fixed boundary from its machine-readable range, causing `mix hex.audit` to flag 3.1.1.
+
+The exception for CVE-2026-32686 is guarded by `DecimalSecurityTest`: the package must remain at the reviewed 3.1.1 version, parsing and casting extreme positive/negative exponents must reject them, and directly constructed extreme exponents must not expand into unbounded normal-format output. This does not permit the vulnerable behavior or change the locked dependency.
+
+Remove the exception when the feed is corrected. Re-review it whenever Decimal changes.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,7 +41,7 @@ requires Docker Compose and OpenSSL for generating local secrets:
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.5/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.3.6/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health

--- a/docs/RPC_STANDARDS.md
+++ b/docs/RPC_STANDARDS.md
@@ -1,6 +1,6 @@
 # RPC Core method support
 
-This page describes the self-hosted **v0.3.5** runtime. Lasso Cloud has a separate
+This page describes the self-hosted **v0.3.6** runtime. Lasso Cloud has a separate
 [compatibility contract](https://docs.lasso.sh/cloud/json-rpc-compatibility).
 Do not infer parity from a shared method name or product version.
 
@@ -33,7 +33,7 @@ Do not treat a profile as an authentication or authorization boundary.
 
 ## Stateful filters and extensions
 
-RPC Core v0.3.5 can forward provider-local filter methods when capability policy
+RPC Core v0.3.6 can forward provider-local filter methods when capability policy
 permits them. They receive one dispatch per request and have **no cross-request
 affinity guarantee**. A filter ID created on one upstream may be invalid on a
 later selected upstream. Prefer `eth_getLogs` or supported WebSocket subscriptions;
@@ -65,7 +65,7 @@ replay and a replacement live stream. Recovery beyond its time, replay, attempt,
 or buffer limits terminates the affected downstream connection explicitly; it
 does not promise unbounded or lossless delivery through arbitrary outages.
 
-In Core v0.3.5, `subscribe_new_heads` controls automatic block monitoring **and**
+In Core v0.3.6, `subscribe_new_heads` controls automatic block monitoring **and**
 client `newHeads` eligibility. Set it to `true` on intended providers. New profiles
 can reuse an already-connected upstream after a successful configuration reload.
 See [Configuration](CONFIGURATION.md) and [Deployment](DEPLOYMENT.md).

--- a/lib/lasso/providers/catalog/owner.ex
+++ b/lib/lasso/providers/catalog/owner.ex
@@ -52,9 +52,7 @@ defmodule Lasso.Providers.Catalog.Owner do
   # which can be hours of degraded routing in the worst case. On a
   # fresh boot (no persistent_term entry) `InfrastructureStarter`
   # handles the initial population, so this self-heal is a no-op.
-  # Rebuild attempts are tolerated to fail (ConfigStore may not be up
-  # yet on a co-restart) — the InfrastructureStarter path still runs
-  # afterwards on first boot.
+  # Failed crash-recovery rebuilds retry while the published table is dead.
   @impl true
   def handle_continue(:self_heal_catalog, state) do
     case Catalog.snapshot() do
@@ -62,21 +60,15 @@ defmodule Lasso.Providers.Catalog.Owner do
         :ok
 
       %{table: tid} ->
-        try do
-          _ = :ets.info(tid, :size)
-          :ok
-        rescue
-          ArgumentError ->
-            try do
-              do_rebuild()
-              Logger.info("Catalog.Owner self-healed catalog after a crash restart")
-            rescue
-              e ->
-                Logger.warning(
-                  "Catalog.Owner self-heal deferred to InfrastructureStarter: " <>
-                    Exception.message(e)
-                )
-            end
+        if :ets.info(tid, :size) == :undefined do
+          try do
+            do_rebuild()
+            Logger.info("Catalog.Owner self-healed catalog after a crash restart")
+          rescue
+            e ->
+              Logger.warning("Catalog.Owner self-heal failed: " <> Exception.message(e))
+              Process.send_after(self(), :retry_self_heal_catalog, 1_000)
+          end
         end
     end
 
@@ -87,6 +79,11 @@ defmodule Lasso.Providers.Catalog.Owner do
   def handle_call(:rebuild, _from, state) do
     do_rebuild()
     {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_info(:retry_self_heal_catalog, state) do
+    handle_continue(:self_heal_catalog, state)
   end
 
   @impl true
@@ -104,20 +101,17 @@ defmodule Lasso.Providers.Catalog.Owner do
 
   defp do_rebuild do
     new_table = :ets.new(:lasso_provider_catalog, [:public, :set, read_concurrency: true])
-    generation = ConfigStore.route_generation()
 
     try do
+      generation = ConfigStore.route_generation()
       Catalog.populate(new_table, generation)
       publication_barrier(:after_catalog_populate, generation)
-    rescue
-      e ->
-        # Drop the half-built table so it doesn't leak; `:persistent_term`
-        # still points at the previous good table, so readers are unaffected.
-        :ets.delete(new_table)
-        reraise e, __STACKTRACE__
+      continue_rebuild(new_table, generation)
+    catch
+      kind, reason ->
+        if :ets.info(new_table, :owner) == self(), do: :ets.delete(new_table)
+        :erlang.raise(kind, reason, __STACKTRACE__)
     end
-
-    continue_rebuild(new_table, generation)
   end
 
   defp continue_rebuild(new_table, generation) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.3.5",
+      version: "0.3.6",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],
@@ -17,7 +17,15 @@ defmodule Lasso.MixProject do
         # Cowlib has no patched release for these encoder-only advisories. Lasso and its
         # Cowboy/Plug stack do not call cow_cookie:cookie/1, cow_link:link/1, or Cowlib's
         # structured-header encoders.
-        ignore_advisories: ["CVE-2026-43966", "CVE-2026-43969", "CVE-2026-43971"]
+        # Decimal's advisory feed omits its fixed 3.0.0 boundary. DecimalSecurityTest
+        # guards this exception against the reviewed 3.1.1 version and input/output bounds.
+        # See docs/DECIMAL_ADVISORY.md for sources and the removal condition.
+        ignore_advisories: [
+          "CVE-2026-43966",
+          "CVE-2026-43969",
+          "CVE-2026-43971",
+          "CVE-2026-32686"
+        ]
       ]
     ]
   end

--- a/test/lasso/decimal_security_test.exs
+++ b/test/lasso/decimal_security_test.exs
@@ -1,0 +1,21 @@
+defmodule Lasso.DecimalSecurityTest do
+  use ExUnit.Case, async: true
+
+  test "the Decimal advisory exception applies only to the reviewed release" do
+    assert to_string(Application.spec(:decimal, :vsn)) == "3.1.1",
+           "Re-review CVE-2026-32686 and remove or revise its audit exception when Decimal changes"
+  end
+
+  test "untrusted large exponents are rejected before decimal arithmetic" do
+    for input <- ["1e1000000000", "1e-1000000000"] do
+      assert Decimal.parse(input) == :error
+      assert Decimal.cast(input) == :error
+    end
+  end
+
+  test "expanded output is bounded even for directly constructed decimals" do
+    assert_raise ArgumentError, fn ->
+      Decimal.to_string(%Decimal{sign: 1, coef: 1, exp: 1_000_000_000}, :normal)
+    end
+  end
+end

--- a/test/lasso/providers/catalog_test.exs
+++ b/test/lasso/providers/catalog_test.exs
@@ -1,6 +1,8 @@
 defmodule Lasso.Providers.CatalogTest do
   use ExUnit.Case, async: false
 
+  @moduletag capture_log: true
+
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.Catalog
   alias Lasso.RPC.BoundedIdentifier
@@ -25,6 +27,89 @@ defmodule Lasso.Providers.CatalogTest do
       display_name: "Test Chain #{chain_id}",
       providers: providers
     })
+  end
+
+  test "owner restart rebuilds a dead catalog without a configuration mutation" do
+    register_chain(@profile_a, @chain_id, [
+      %{
+        id: "recovery-provider",
+        name: "Recovery",
+        url: "https://recovery.example.invalid",
+        priority: 1
+      }
+    ])
+
+    :ok = Catalog.build_from_config()
+    before = Catalog.snapshot()
+    instance_id = Catalog.lookup_instance_id(@profile_a, @chain_id, "recovery-provider")
+    assert is_binary(instance_id)
+    owner = Process.whereis(Catalog.Owner)
+    :ok = Supervisor.terminate_child(Lasso.Supervisor, Catalog.Owner)
+    {:ok, _restarted} = Supervisor.restart_child(Lasso.Supervisor, Catalog.Owner)
+
+    recovered =
+      Enum.reduce_while(1..100, false, fn _, _ ->
+        snapshot = Catalog.snapshot()
+
+        if snapshot.table != before.table and
+             Catalog.lookup_instance_id(@profile_a, @chain_id, "recovery-provider") == instance_id do
+          {:halt, true}
+        else
+          Process.sleep(10)
+          {:cont, false}
+        end
+      end)
+
+    assert recovered
+    assert Process.whereis(Catalog.Owner) != owner
+  end
+
+  test "failed crash recovery discards the unpublished table and retries" do
+    register_chain(@profile_a, @chain_id, [
+      %{id: "retry-provider", name: "Retry", url: "https://retry.example.invalid", priority: 1}
+    ])
+
+    :ok = Catalog.build_from_config()
+    snapshot = Catalog.snapshot()
+    original_barrier = Application.get_env(:lasso, :catalog_publication_barrier)
+    ref = make_ref()
+    :ok = Supervisor.terminate_child(Lasso.Supervisor, Catalog.Owner)
+    Application.put_env(:lasso, :catalog_publication_barrier, {self(), ref})
+
+    try do
+      {:ok, owner} = Supervisor.restart_child(Lasso.Supervisor, Catalog.Owner)
+      assert_receive {:catalog_publication_phase, ^owner, ^ref, :after_catalog_populate, _}, 1_000
+
+      [unpublished] =
+        Enum.filter(:ets.all(), fn table ->
+          :ets.info(table, :owner) == owner and :ets.info(table, :name) == :lasso_provider_catalog
+        end)
+
+      :ets.insert(unpublished, {{:routing_plan, "invalid-test-plan", @chain_id}, :invalid})
+      Application.put_env(:lasso, :catalog_publication_barrier, original_barrier)
+      send(owner, {:catalog_publication_continue, ref, :after_catalog_populate})
+      :sys.get_state(owner)
+      assert :ets.info(unpublished, :size) == :undefined
+      assert Catalog.snapshot().table == snapshot.table
+
+      recovered =
+        Enum.reduce_while(1..200, false, fn _, _ ->
+          if is_binary(Catalog.lookup_instance_id(@profile_a, @chain_id, "retry-provider")) do
+            {:halt, true}
+          else
+            Process.sleep(10)
+            {:cont, false}
+          end
+        end)
+
+      assert recovered
+      assert Process.whereis(Catalog.Owner) == owner
+    after
+      Application.put_env(:lasso, :catalog_publication_barrier, original_barrier)
+
+      if owner = Process.whereis(Catalog.Owner),
+        do: send(owner, {:catalog_publication_continue, ref, :after_catalog_populate})
+    end
   end
 
   describe "build_from_config/0" do


### PR DESCRIPTION
When Catalog.Owner restarts, its ETS table disappears but the published snapshot still references it. `:ets.info(table, :size)` returns `:undefined`; the previous rescue-only check never rebuilt the catalog. Restore it automatically, retry a temporarily failed recovery, and delete unpublished tables if publication fails.

Prepare patch 0.3.6 with matching download/container references. Also document the Decimal advisory feed range discrepancy already reviewed in Cloud: the locked 3.1.1 release is beyond the maintainer's fixed 3.0.0 boundary. The narrow exception has exact-version and bounded-input/output regression guards; no dependency changes.

Validation: all 1,674 existing tests including integration pass, plus three Decimal security guards; 20 catalog tests pass, strict Credo is clean, formatting and dependency audit pass, and all six distribution guard tests pass. Cloud staging independently recovered its catalog in 101 ms after killing the owner. These checks establish recovery behavior, not the cause of the separate historical application shutdown.
