### PR TITLE
Fix cross-scope publication cutovers and prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-10
+
+### Fixed
+
+- Acknowledge closed publication gates concurrently across scopes, with at most four acknowledgment tasks independent of provider probes. Cross-region database latency no longer accumulates serially across all closing scopes. Gates still require durable acknowledgment before a newer publication can open; request deadlines and selectors are unchanged.
+
+### Compatibility
+
+- No configuration or journal migration changes. Upgrade from v0.4.0 using the existing graceful replacement procedure and retain acknowledged history. Binaries predating global publication remain unsafe after enrollment.
+
 ## [0.4.0] - 2026-09-10
 
 ### Added
@@ -214,7 +224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.6...v0.4.0
 [0.3.6]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.4...v0.3.5

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-26A5E4?style=flat-square&labelColor=19202E&logo=telegram&logoColor=white)](https://t.me/+79pFERTlZPIzZTZh)
 [![X](https://img.shields.io/badge/follow-%40lassoRPC-19202E?style=flat-square&labelColor=19202E&logo=x&logoColor=white)](https://x.com/lassoRPC)
 [![License](https://img.shields.io/badge/license-Apache--2.0-19202E?style=flat-square&labelColor=19202E)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.4.0-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.4.1-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
 [![Elixir](https://img.shields.io/badge/built%20with-Elixir%2FOTP-19202E?style=flat-square&labelColor=19202E&logo=elixir&logoColor=white)](https://elixir-lang.org)
 
 Lasso is a multi-chain Ethereum JSON-RPC proxy with health checks, retries,
@@ -41,7 +41,7 @@ You need Docker with the Compose plugin, curl, and OpenSSL. Start in an empty di
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.0/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.1/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health

--- a/deployment/compose.release.yml
+++ b/deployment/compose.release.yml
@@ -1,6 +1,6 @@
 services:
   lasso:
-    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.4.0}
+    image: ${LASSO_IMAGE:-ghcr.io/jaxernst/lasso-rpc:v0.4.1}
     ports:
       - "127.0.0.1:${LASSO_PORT:-4000}:4000"
     env_file:

--- a/docs/BLOCK_CONTINUITY_OPERATIONS.md
+++ b/docs/BLOCK_CONTINUITY_OPERATIONS.md
@@ -98,6 +98,9 @@ The initial operating limit is four active profile/chain scopes per journal,
 1,024 retained scopes and 32 MiB of reserved state. A rejected enrollment does
 not change an existing floor or reservation. These conservative limits bound
 background work; they are not a high-throughput or broad-fleet certification.
+Each runtime permits at most four provider-probe tasks and four independent
+closure-acknowledgment tasks, with at most one closure task per scope. Gates
+close locally before those acknowledgment writes start.
 Measure your provider costs, publication age and request error rate before
 expanding rollout. Do not remove the capacity constraints as a rollout shortcut.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,7 +41,7 @@ requires Docker Compose and OpenSSL for generating local secrets:
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.0/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.1/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health

--- a/docs/RPC_STANDARDS.md
+++ b/docs/RPC_STANDARDS.md
@@ -1,6 +1,6 @@
 # RPC Core method support
 
-This page describes the self-hosted **v0.4.0** runtime. Lasso Cloud has a separate
+This page describes the self-hosted **v0.4.1** runtime. Lasso Cloud has a separate
 [compatibility contract](https://docs.lasso.sh/cloud/json-rpc-compatibility).
 Do not infer parity from a shared method name or product version.
 
@@ -33,7 +33,7 @@ Do not treat a profile as an authentication or authorization boundary.
 
 ## Stateful filters and extensions
 
-RPC Core v0.4.0 can forward provider-local filter methods when capability policy
+RPC Core v0.4.1 can forward provider-local filter methods when capability policy
 permits them. They receive one dispatch per request and have **no cross-request
 affinity guarantee**. A filter ID created on one upstream may be invalid on a
 later selected upstream. Prefer `eth_getLogs` or supported WebSocket subscriptions;
@@ -65,7 +65,7 @@ replay and a replacement live stream. Recovery beyond its time, replay, attempt,
 or buffer limits terminates the affected downstream connection explicitly; it
 does not promise unbounded or lossless delivery through arbitrary outages.
 
-In Core v0.4.0, `subscribe_new_heads` controls automatic block monitoring **and**
+In Core v0.4.1, `subscribe_new_heads` controls automatic block monitoring **and**
 client `newHeads` eligibility. Set it to `true` on intended providers. New profiles
 can reuse an already-connected upstream after a successful configuration reload.
 See [Configuration](CONFIGURATION.md) and [Deployment](DEPLOYMENT.md).

--- a/lib/lasso/core/block_publication/runtime.ex
+++ b/lib/lasso/core/block_publication/runtime.ex
@@ -37,6 +37,7 @@ defmodule Lasso.BlockPublication.Runtime do
       probe: Keyword.get(config, :probe, Probe),
       interval: Keyword.get(config, :interval_ms, 1_000),
       tasks: %{},
+      closure_tasks: %{},
       snapshots: %{},
       timer: nil,
       next_probe: %{},
@@ -60,7 +61,11 @@ defmodule Lasso.BlockPublication.Runtime do
   @impl true
   def handle_call({:quiesce, deadline}, _from, state) when is_integer(deadline) do
     Gate.retire()
-    Enum.each(state.tasks, fn {ref, _} -> Process.demonitor(ref, [:flush]) end)
+
+    Enum.each(Map.merge(state.tasks, state.closure_tasks), fn {ref, _} ->
+      Process.demonitor(ref, [:flush])
+    end)
+
     state = %{state | retired: true}
 
     result = fence_before_deadline(state, deadline)
@@ -141,12 +146,19 @@ defmodule Lasso.BlockPublication.Runtime do
 
   def handle_info({ref, {key, result}}, state) when is_reference(ref) do
     Process.demonitor(ref, [:flush])
-    state = %{state | tasks: Map.delete(state.tasks, ref)}
+    state = finish_task(state, ref)
 
     state =
       case result do
-        {:ok, publication} -> install(state, key, publication)
-        _ -> state
+        {:ok, publication} ->
+          install(state, key, publication)
+
+        {:error, :stale_revision} ->
+          send(self(), :publication_changed)
+          state
+
+        _ ->
+          state
       end
 
     {:noreply, state}
@@ -156,7 +168,7 @@ defmodule Lasso.BlockPublication.Runtime do
     if reason != :normal,
       do: Logger.warning("Block publication background task failed: #{inspect(reason)}")
 
-    {:noreply, %{state | tasks: Map.delete(state.tasks, ref)}}
+    {:noreply, finish_task(state, ref)}
   end
 
   defp reconcile(state) do
@@ -246,7 +258,7 @@ defmodule Lasso.BlockPublication.Runtime do
 
       publication["phase"] in ["closing", "disabling"] and publication["closed"][member] != boot ->
         # install/3 has synchronously closed the gate before this durable ACK.
-        command(state, key, {:closed, publication["epoch"], member, boot})
+        acknowledge_closure(state, key, {:closed, publication["epoch"], member, boot})
 
       map_size(state.tasks) >= 4 or key in Map.values(state.tasks) ->
         state
@@ -305,15 +317,34 @@ defmodule Lasso.BlockPublication.Runtime do
     end
   end
 
-  defp command(state, key, cmd) do
-    result =
-      if function_exported?(state.journal, :compare_and_apply, 3),
-        do: state.journal.compare_and_apply(key, Map.fetch!(state.snapshots, key), cmd),
-        else: state.journal.command(key, cmd)
+  # Closure writes have independent slots so provider probes cannot delay the barrier.
+  defp acknowledge_closure(state, key, command) do
+    if map_size(state.closure_tasks) >= 4 or key in Map.values(state.closure_tasks) do
+      state
+    else
+      journal = state.journal
+      snapshot = Map.fetch!(state.snapshots, key)
 
-    case result do
+      task =
+        Task.Supervisor.async_nolink(Lasso.TaskSupervisor, fn ->
+          {key, apply_command(journal, key, snapshot, command)}
+        end)
+
+      %{state | closure_tasks: Map.put(state.closure_tasks, task.ref, key)}
+    end
+  end
+
+  defp finish_task(state, ref) do
+    %{
+      state
+      | tasks: Map.delete(state.tasks, ref),
+        closure_tasks: Map.delete(state.closure_tasks, ref)
+    }
+  end
+
+  defp command(state, key, cmd) do
+    case apply_command(state.journal, key, Map.fetch!(state.snapshots, key), cmd) do
       {:ok, publication} ->
-        Phoenix.PubSub.broadcast(Lasso.PubSub, @topic, :publication_changed)
         install(state, key, publication)
 
       {:error, :stale_revision} ->
@@ -323,6 +354,18 @@ defmodule Lasso.BlockPublication.Runtime do
       _ ->
         state
     end
+  end
+
+  defp apply_command(journal, key, snapshot, command) do
+    result =
+      if function_exported?(journal, :compare_and_apply, 3),
+        do: journal.compare_and_apply(key, snapshot, command),
+        else: journal.command(key, command)
+
+    if match?({:ok, _}, result),
+      do: Phoenix.PubSub.broadcast(Lasso.PubSub, @topic, :publication_changed)
+
+    result
   end
 
   defp publish_command(state, key, cmd) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],

--- a/test/integration/block_publication_cluster_test.exs
+++ b/test/integration/block_publication_cluster_test.exs
@@ -267,6 +267,86 @@ defmodule Lasso.BlockPublication.ClusterTest do
     eventually(fn -> :erpc.call(a, Peer, :read, [key]) == :unmanaged end)
   end
 
+  test "four scopes close concurrently without blocking the runtime or opening before durable acknowledgments" do
+    {_output, 0} = System.cmd("epmd", ["-daemon"])
+    :ok = LocalCluster.start()
+
+    endpoint =
+      Application.get_env(:lasso, LassoWeb.Endpoint)
+      |> Keyword.put(:server, false)
+      |> Keyword.put(:http, ip: {127, 0, 0, 1}, port: 0)
+
+    {:ok, cluster} =
+      LocalCluster.start_link(2,
+        prefix: "closure#{System.unique_integer([:positive])}",
+        applications: [:lasso],
+        environment: [
+          lasso: [
+            {LassoWeb.Endpoint, endpoint},
+            {Repo,
+             Keyword.put(Application.get_env(:lasso, Repo), :pool, DBConnection.ConnectionPool)},
+            {:block_publication, [journal: Lasso.BlockPublication.Postgres]}
+          ]
+        ]
+      )
+
+    on_exit(fn -> if Process.alive?(cluster), do: GenServer.stop(cluster, :normal, 30_000) end)
+    {:ok, nodes} = LocalCluster.nodes(cluster)
+    keys = for _ <- 1..4, do: {"cluster-" <> Ecto.UUID.generate(), 1}
+    profiles = Enum.map(keys, &elem(&1, 0))
+    members = ["a", "b"]
+
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      for key <- keys, do: assert({:ok, _} = BlockPublicationJournal.ensure(key, members, 60_000))
+    end)
+
+    on_exit(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        Repo.delete_all(from(p in BlockPublicationJournal, where: p.profile in ^profiles))
+      end)
+    end)
+
+    for {node, member} <- Enum.zip(nodes, members) do
+      for key <- keys, do: :erpc.call(node, Peer, :set_height, [key, 100])
+      assert :ok == :erpc.call(node, Peer, :configure, [member, members, hd(keys)])
+    end
+
+    eventually(fn -> Enum.all?(keys, &(reads(nodes, &1) == [ok: 100, ok: 100])) end)
+    for node <- nodes, do: :erpc.call(node, Peer, :block_closures, [self()])
+
+    try do
+      for node <- nodes, key <- keys, do: :erpc.call(node, Peer, :set_height, [key, 101])
+
+      workers =
+        for _ <- 1..8 do
+          assert_receive {:closure_waiting, node, pid, key}, 2_000
+          {node, pid, key}
+        end
+
+      assert MapSet.new(Enum.map(workers, fn {node, _, key} -> {node, key} end)) ==
+               MapSet.new(for node <- nodes, key <- keys, do: {node, key})
+
+      for node <- nodes do
+        state = :erpc.call(node, :sys, :get_state, [Lasso.BlockPublication.Runtime, 1_000])
+        assert map_size(state.closure_tasks) == 4
+        send({Lasso.BlockPublication.Runtime, node}, :publication_changed)
+      end
+
+      for key <- keys,
+          do:
+            assert(
+              reads(nodes, key) == [error: :publication_changing, error: :publication_changing]
+            )
+
+      refute_receive {:closure_waiting, _, _, _}, 150
+      for node <- nodes, do: :erpc.call(node, Peer, :block_closures, [nil])
+      for {_, pid, _} <- workers, do: send(pid, :continue)
+      eventually(fn -> Enum.all?(keys, &(reads(nodes, &1) == [ok: 101, ok: 101])) end)
+    after
+      for node <- nodes, do: :erpc.call(node, Peer, :block_closures, [nil])
+    end
+  end
+
   defp reads(nodes, key), do: Enum.map(nodes, &:erpc.call(&1, Peer, :read, [key]))
   defp eventually(fun, attempts \\ 150)
   defp eventually(fun, 0), do: assert(fun.())

--- a/test/support/block_publication_peer.ex
+++ b/test/support/block_publication_peer.ex
@@ -34,8 +34,21 @@ defmodule Lasso.Test.BlockPublicationPeer do
       available(fn -> Durable.command(key, command) end)
     end
 
-    def compare_and_apply(key, snapshot, command),
-      do: available(fn -> Durable.compare_and_apply(key, snapshot, command) end)
+    def compare_and_apply(key, snapshot, command) do
+      case {command, :persistent_term.get({__MODULE__, :blocked_closures}, nil)} do
+        {{:closed, _, _, _}, owner} when is_pid(owner) ->
+          send(owner, {:closure_waiting, node(), self(), key})
+
+          receive do
+            :continue -> available(fn -> Durable.compare_and_apply(key, snapshot, command) end)
+          after
+            5_000 -> {:error, :journal_unavailable}
+          end
+
+        _ ->
+          available(fn -> Durable.compare_and_apply(key, snapshot, command) end)
+      end
+    end
 
     defp available(fun) do
       if :persistent_term.get({__MODULE__, :available}, true),
@@ -43,6 +56,8 @@ defmodule Lasso.Test.BlockPublicationPeer do
         else: {:error, :journal_unavailable}
     end
   end
+
+  def block_closures(owner), do: :persistent_term.put({Journal, :blocked_closures}, owner)
 
   def journal_available(value), do: :persistent_term.put({Journal, :available}, value)
 


### PR DESCRIPTION
Cross-region database round trips can accumulate when several block-continuity scopes close together, causing otherwise healthy block choices to exceed the handoff deadline. Acknowledge closures in at most four independent tasks, one per scope, separate from provider probes. Gates still close before writes and remain closed until the durable barrier completes; RPC work, selectors and the one-second wait limit are unchanged.

Prepare v0.4.1 with the existing journal/configuration format. v0.4.0 remains upgrade-compatible; pre-publication binaries remain unsafe after enrollment. Installation links and the Compose default move with the version.

Validation: the real PostgreSQL two-node/four-scope regression and existing three-node lifecycle test pass; strict Credo and formatting pass. The runtime is byte-identical to the Cloud correction. Full CI [34532193184](https://github.com/jaxernst/lasso-rpc/actions/runs/34532193184) passes, including hermetic integration and Linux container boot. The byte-identical runtime passed a five-minute, four-scope, two-region Cloud staging screen: 1,737/1,737 choices and 175/175 hash-pinned code reads, no regressions, p95 successful choice time 0.904 ms. This is a bounded staging comparison, not a Core production throughput benchmark; this PR does not claim production availability certification. The separate Claude action completed but published no accessible review verdict and recorded permission denials; #142 tracks that process gap, so its green status is not counted as independent approval.
