### PR TITLE
Bind publication tasks to coordinator lifetime before v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Acknowledge closed publication gates concurrently across scopes, with at most four acknowledgment tasks independent of provider probes. Cross-region database latency no longer accumulates serially across all closing scopes. Gates still require durable acknowledgment before a newer publication can open; request deadlines and selectors are unchanged.
 
+- Supervise the coordinator and its background tasks together, so a coordinator crash stops blocked tasks before replacement work starts.
+
 ### Compatibility
 
 - No configuration or journal migration changes. Upgrade from v0.4.0 using the existing graceful replacement procedure and retain acknowledged history. Binaries predating global publication remain unsafe after enrollment.

--- a/docs/BLOCK_CONTINUITY_OPERATIONS.md
+++ b/docs/BLOCK_CONTINUITY_OPERATIONS.md
@@ -100,7 +100,8 @@ not change an existing floor or reservation. These conservative limits bound
 background work; they are not a high-throughput or broad-fleet certification.
 Each runtime permits at most four provider-probe tasks and four independent
 closure-acknowledgment tasks, with at most one closure task per scope. Gates
-close locally before those acknowledgment writes start.
+close locally before those acknowledgment writes start. The coordinator and its
+task supervisor restart together, stopping old tasks before replacement work.
 Measure your provider costs, publication age and request error rate before
 expanding rollout. Do not remove the capacity constraints as a rollout shortcut.
 

--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -150,7 +150,7 @@ defmodule Lasso.Application do
 
         # Supervised bootstrap loads profiles and starts shared infrastructure.
         Lasso.Boot.InfrastructureStarter,
-        Lasso.BlockPublication.Runtime,
+        Lasso.BlockPublication.Supervisor,
 
         # Start Phoenix endpoint
         LassoWeb.Endpoint,

--- a/lib/lasso/core/block_publication/runtime.ex
+++ b/lib/lasso/core/block_publication/runtime.ex
@@ -85,7 +85,9 @@ defmodule Lasso.BlockPublication.Runtime do
       {:error, :shutdown_timeout}
     else
       task =
-        Task.Supervisor.async_nolink(Lasso.TaskSupervisor, fn -> fence_serving_boots(state) end)
+        Task.Supervisor.async_nolink(Lasso.BlockPublication.TaskSupervisor, fn ->
+          fence_serving_boots(state)
+        end)
 
       remaining = max(deadline - System.monotonic_time(:millisecond), 0)
 
@@ -326,7 +328,7 @@ defmodule Lasso.BlockPublication.Runtime do
       snapshot = Map.fetch!(state.snapshots, key)
 
       task =
-        Task.Supervisor.async_nolink(Lasso.TaskSupervisor, fn ->
+        Task.Supervisor.async_nolink(Lasso.BlockPublication.TaskSupervisor, fn ->
           {key, apply_command(journal, key, snapshot, command)}
         end)
 
@@ -378,7 +380,8 @@ defmodule Lasso.BlockPublication.Runtime do
   end
 
   defp task(state, key, fun) do
-    task = Task.Supervisor.async_nolink(Lasso.TaskSupervisor, fn -> {key, fun.()} end)
+    task =
+      Task.Supervisor.async_nolink(Lasso.BlockPublication.TaskSupervisor, fn -> {key, fun.()} end)
 
     %{
       state

--- a/lib/lasso/core/block_publication/supervisor.ex
+++ b/lib/lasso/core/block_publication/supervisor.ex
@@ -1,0 +1,17 @@
+defmodule Lasso.BlockPublication.Supervisor do
+  @moduledoc "Restarts the publication coordinator and its owned background tasks together."
+  use Supervisor
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts), do: Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+
+  @impl true
+  def init(_opts) do
+    children = [
+      {Task.Supervisor, name: Lasso.BlockPublication.TaskSupervisor},
+      Lasso.BlockPublication.Runtime
+    ]
+
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+end

--- a/test/integration/block_publication_cluster_test.exs
+++ b/test/integration/block_publication_cluster_test.exs
@@ -339,6 +339,33 @@ defmodule Lasso.BlockPublication.ClusterTest do
             )
 
       refute_receive {:closure_waiting, _, _, _}, 150
+
+      [restarting | _] = nodes
+      retired_workers = for {^restarting, pid, _} <- workers, do: pid
+      monitors = Enum.map(retired_workers, &Process.monitor/1)
+      :erpc.call(restarting, Peer, :crash_worker, [])
+
+      for monitor <- monitors do
+        assert_receive {:DOWN, ^monitor, :process, _, _}, 2_000
+      end
+
+      replacements =
+        for _ <- 1..4 do
+          assert_receive {:closure_waiting, ^restarting, pid, key}, 2_000
+          refute pid in retired_workers
+          {restarting, pid, key}
+        end
+
+      assert MapSet.new(Enum.map(replacements, &elem(&1, 2))) == MapSet.new(keys)
+
+      for key <- keys,
+          do:
+            assert(
+              reads(nodes, key) == [error: :publication_changing, error: :publication_changing]
+            )
+
+      refute_receive {:closure_waiting, _, _, _}, 150
+      workers = Enum.reject(workers, fn {node, _, _} -> node == restarting end) ++ replacements
       for node <- nodes, do: :erpc.call(node, Peer, :block_closures, [nil])
       for {_, pid, _} <- workers, do: send(pid, :continue)
       eventually(fn -> Enum.all?(keys, &(reads(nodes, &1) == [ok: 101, ok: 101])) end)

--- a/test/support/block_publication_peer.ex
+++ b/test/support/block_publication_peer.ex
@@ -42,7 +42,7 @@ defmodule Lasso.Test.BlockPublicationPeer do
           receive do
             :continue -> available(fn -> Durable.compare_and_apply(key, snapshot, command) end)
           after
-            5_000 -> {:error, :journal_unavailable}
+            30_000 -> {:error, :journal_unavailable}
           end
 
         _ ->
@@ -68,7 +68,7 @@ defmodule Lasso.Test.BlockPublicationPeer do
     Application.put_env(:lasso, :node_id, member)
     :persistent_term.put({Lasso.Cluster.Topology, :self_node_id}, member)
     set_height(key, 100)
-    :ok = Supervisor.terminate_child(Lasso.Supervisor, Runtime)
+    :ok = Supervisor.terminate_child(Lasso.Supervisor, Lasso.BlockPublication.Supervisor)
 
     Application.put_env(:lasso, :block_publication,
       members: members,
@@ -77,7 +77,7 @@ defmodule Lasso.Test.BlockPublicationPeer do
       interval_ms: 100
     )
 
-    {:ok, _} = Supervisor.restart_child(Lasso.Supervisor, Runtime)
+    {:ok, _} = Supervisor.restart_child(Lasso.Supervisor, Lasso.BlockPublication.Supervisor)
     :ok
   end
 
@@ -106,9 +106,15 @@ defmodule Lasso.Test.BlockPublicationPeer do
 
   def restart_worker do
     old_boot = Gate.boot()
-    :ok = Supervisor.terminate_child(Lasso.Supervisor, Runtime)
-    {:ok, _} = Supervisor.restart_child(Lasso.Supervisor, Runtime)
+    :ok = Supervisor.terminate_child(Lasso.Supervisor, Lasso.BlockPublication.Supervisor)
+    {:ok, _} = Supervisor.restart_child(Lasso.Supervisor, Lasso.BlockPublication.Supervisor)
     old_boot == Gate.boot()
+  end
+
+  def crash_worker do
+    pid = Process.whereis(Runtime)
+    Process.exit(pid, :kill)
+    pid
   end
 
   def suspend, do: :sys.suspend(Runtime)


### PR DESCRIPTION
Blocked publication tasks can outlive a coordinator crash when they run under the shared TaskSupervisor. A replacement coordinator then admits duplicate work beyond the documented per-scope/four-task bound.

Put the coordinator and its dedicated TaskSupervisor under `one_for_all` supervision. Old acknowledgment and probe tasks stop before replacement work starts. The RPC path, journal format, selectors and gate-before-ACK ordering stay unchanged. This completes the task-ownership correction before the prepared v0.4.1 release is tagged.

Validation: the real PostgreSQL two-node/four-scope test kills the coordinator with blocked acknowledgments, observes all old workers terminate, and verifies exactly four replacements while gates stay closed. It and the existing three-node recovery test pass. Strict Credo and formatting pass. The identical Cloud code also passes 61 focused checks; a one-for-one negative control fails. Final CI and final-source staging verification are pending.

The prior green Claude review action did not publish an accessible verdict and is not counted as approval; #142 tracks that process gap. No release tag or new container has been published yet.
