### PR TITLE
Keep logical query deadlines expired after timer cancellation

### DIFF
--- a/examples/logical-read/evidence-rpc.mjs
+++ b/examples/logical-read/evidence-rpc.mjs
@@ -13,17 +13,19 @@ export function evidenceRpc({ url, apiKey, profile, profileId, chainId, deadline
   const entries = [];
   const slots = concurrencySlots(maxConcurrency);
   const lifetime = new AbortController();
+  let deadlineSignal;
   let started = 0, completed = 0, missing = 0, omitted = 0, bytes = 0;
 
   async function request({ method, params = [], signal: parentSignal }) {
     const remaining = deadline - Date.now();
-    if (remaining <= 0) throw new Error("Logical query deadline exceeded");
+    if (remaining <= 0 || deadlineSignal?.aborted) throw new Error("Logical query deadline exceeded");
+    deadlineSignal ??= AbortSignal.timeout(remaining);
     lifetime.signal.throwIfAborted();
     if (started >= maxRequests) throw new Error("Logical query RPC limit exceeded");
     const id = ++started;
     const entry = { sequence: id, method, outcome: "transport_error", metadataStatus: "missing" };
     const controller = new AbortController();
-    const signal = AbortSignal.any([lifetime.signal, controller.signal, AbortSignal.timeout(remaining), ...(parentSignal ? [parentSignal] : [])]);
+    const signal = AbortSignal.any([lifetime.signal, controller.signal, deadlineSignal, ...(parentSignal ? [parentSignal] : [])]);
     const supplied = stateBlockSelector({ method, params });
     if (supplied?.blockHash) entry.blockHash = supplied.blockHash;
     let release, response, reader, pending;

--- a/examples/logical-read/evidence-rpc.test.mjs
+++ b/examples/logical-read/evidence-rpc.test.mjs
@@ -183,6 +183,25 @@ test("deadline cancels in-flight fetch and prohibits subsequent RPCs", async () 
   assert.equal(rpc.evidence().completed, 1);
 });
 
+test("an expired query cannot dispatch again when the wall clock still precedes its deadline", async t => {
+  const now = Date.now();
+  t.mock.method(Date, "now", () => now);
+  const timeout = new AbortController();
+  t.mock.method(AbortSignal, "timeout", () => timeout.signal);
+  let dispatched = 0;
+  const rpc = evidenceRpc({ ...scope, deadline: now + 30, fetch: (_url, { signal }) => {
+    dispatched++;
+    return new Promise((_resolve, reject) => {
+      signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      timeout.abort(new DOMException("Query timeout", "TimeoutError"));
+    });
+  } });
+  await assert.rejects(publishedBlockQuery(rpc), /timeout/i);
+  await assert.rejects(publishedBlockQuery(rpc), /deadline exceeded/);
+  assert.equal(dispatched, 1);
+  assert.equal(rpc.evidence().completed, 1);
+});
+
 test("worker handoff preserves hash and deadline; cache identity separates forks and scopes", async () => {
   const rpc = evidenceRpc({ ...scope, fetch: transport().fetch });
   const query = await publishedBlockQuery(rpc);

--- a/examples/logical-read/evidence-rpc.test.mjs
+++ b/examples/logical-read/evidence-rpc.test.mjs
@@ -186,8 +186,11 @@ test("deadline cancels in-flight fetch and prohibits subsequent RPCs", async () 
 test("an expired query cannot dispatch again when the wall clock still precedes its deadline", async t => {
   const now = Date.now();
   t.mock.method(Date, "now", () => now);
-  const timeout = new AbortController();
-  t.mock.method(AbortSignal, "timeout", () => timeout.signal);
+  let timeout;
+  t.mock.method(AbortSignal, "timeout", () => {
+    timeout = new AbortController();
+    return timeout.signal;
+  });
   let dispatched = 0;
   const rpc = evidenceRpc({ ...scope, deadline: now + 30, fetch: (_url, { signal }) => {
     dispatched++;
@@ -197,8 +200,10 @@ test("an expired query cannot dispatch again when the wall clock still precedes 
     });
   } });
   await assert.rejects(publishedBlockQuery(rpc), /timeout/i);
-  await assert.rejects(publishedBlockQuery(rpc), /deadline exceeded/);
+  const next = publishedBlockQuery(rpc);
+  await assert.rejects(next);
   assert.equal(dispatched, 1);
+  await assert.rejects(next, /deadline exceeded/);
   assert.equal(rpc.evidence().completed, 1);
 });
 


### PR DESCRIPTION
Once a logical query times out, later requests must remain rejected even if the wall clock still falls just before its absolute deadline. Reuse one deadline abort signal across the query so an early timer firing cannot create a fresh request window.

The failing Core #143 integration job exposed this boundary. A deterministic regression holds the wall clock before the deadline and fires the timeout; it fails on the old implementation. All 24 evidence-client tests pass with the fix in both Cloud and Core. Matching files are identical across products.

Complements #143 for the v0.4.1 candidate. The publication ownership fix remains independently reviewed there.
