### PR TITLE
Suppress redundant publication journal transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid serialized journal transactions for locally ineligible block proposals and unchanged readiness evidence. Provider checks continue so anchor, provider, floor and freshness changes can still drive publication; observation timestamps alone no longer repeat readiness writes. No configuration or journal migration is required.
+
 ## [0.4.1] - 2026-09-10
 
 ### Fixed

--- a/lib/lasso/core/block_publication/runtime.ex
+++ b/lib/lasso/core/block_publication/runtime.ex
@@ -5,7 +5,7 @@ defmodule Lasso.BlockPublication.Runtime do
   """
   use GenServer
   require Logger
-  alias Lasso.BlockPublication.{Block, Gate, Probe}
+  alias Lasso.BlockPublication.{Block, Gate, Probe, Publication}
   alias Lasso.Config.ConfigStore
   alias Lasso.RPC.HeadPolicy
 
@@ -272,28 +272,7 @@ defmodule Lasso.BlockPublication.Runtime do
       publication["phase"] == "preparing" ->
         floor = HeadPolicy.fence_local(key)
 
-        task(state, key, fn ->
-          candidate = publication["candidate"]
-
-          if Block.fresh?(
-               candidate["timestamp_ms"],
-               System.system_time(:millisecond),
-               publication["max_age_ms"]
-             ) == :ok do
-            with {:ok, evidence} <-
-                   worker.probe.prepare(
-                     key,
-                     candidate,
-                     publication["published"],
-                     publication["max_age_ms"]
-                   ) do
-              evidence = Map.put(evidence, "minimum_height", floor || 0)
-              publish_command(worker, key, {:ready, publication["epoch"], member, boot, evidence})
-            end
-          else
-            publish_command(worker, key, {:abort, publication["epoch"]})
-          end
-        end)
+        task(state, key, fn -> prepare(worker, key, publication, member, boot, floor) end)
 
       publication["phase"] == "active" ->
         task(state, key, fn ->
@@ -309,13 +288,47 @@ defmodule Lasso.BlockPublication.Runtime do
                do: {:ok, publication["published"], nil},
                else: worker.probe.latest(key, publication["max_age_ms"])
 
-          with {:ok, block, _} <- candidate do
-            publish_command(worker, key, {:propose, member, boot, block})
+          with {:ok, block, _} <- candidate,
+               proposal = {:propose, member, boot, block},
+               {:ok, _} <- Publication.apply(publication, proposal) do
+            publish_command(worker, key, proposal)
           end
         end)
 
       true ->
         state
+    end
+  end
+
+  defp prepare(worker, key, publication, member, boot, floor) do
+    candidate = publication["candidate"]
+
+    if Block.fresh?(
+         candidate["timestamp_ms"],
+         System.system_time(:millisecond),
+         publication["max_age_ms"]
+       ) == :ok do
+      with {:ok, evidence} <-
+             worker.probe.prepare(
+               key,
+               candidate,
+               publication["published"],
+               publication["max_age_ms"]
+             ) do
+        evidence = Map.put(evidence, "minimum_height", floor || 0)
+
+        previous = Map.get(publication["ready"], member, %{})
+
+        if Map.delete(evidence, "observed_at_ms") != Map.delete(previous, "observed_at_ms") do
+          publish_command(
+            worker,
+            key,
+            {:ready, publication["epoch"], member, boot, evidence}
+          )
+        end
+      end
+    else
+      publish_command(worker, key, {:abort, publication["epoch"]})
     end
   end
 

--- a/test/integration/block_publication_cluster_test.exs
+++ b/test/integration/block_publication_cluster_test.exs
@@ -374,6 +374,92 @@ defmodule Lasso.BlockPublication.ClusterTest do
     end
   end
 
+  test "unchanged heads and completed preparation do not contend on the durable row" do
+    {_output, 0} = System.cmd("epmd", ["-daemon"])
+    :ok = LocalCluster.start()
+
+    endpoint =
+      Application.get_env(:lasso, LassoWeb.Endpoint)
+      |> Keyword.put(:server, false)
+      |> Keyword.put(:http, ip: {127, 0, 0, 1}, port: 0)
+
+    {:ok, cluster} =
+      LocalCluster.start_link(2,
+        prefix: "idle#{System.unique_integer([:positive])}",
+        applications: [:lasso],
+        environment: [
+          lasso: [
+            {LassoWeb.Endpoint, endpoint},
+            {Repo,
+             Keyword.merge(Application.get_env(:lasso, Repo),
+               pool: DBConnection.ConnectionPool,
+               pool_size: 4
+             )},
+            {:block_publication, [journal: Lasso.BlockPublication.Postgres]}
+          ]
+        ]
+      )
+
+    on_exit(fn -> if Process.alive?(cluster), do: GenServer.stop(cluster, :normal, 30_000) end)
+    {:ok, [a, b] = nodes} = LocalCluster.nodes(cluster)
+    key = {"idle-" <> Ecto.UUID.generate(), 1}
+    {profile, _} = key
+
+    Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+      assert {:ok, _} = BlockPublicationJournal.ensure(key, ["a", "b"], 60_000)
+    end)
+
+    on_exit(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        Repo.delete_all(from(p in BlockPublicationJournal, where: p.profile == ^profile))
+      end)
+    end)
+
+    for {node, member} <- Enum.zip(nodes, ["a", "b"]),
+        do: assert(:ok == :erpc.call(node, Peer, :configure, [member, ["a", "b"], key]))
+
+    eventually(fn -> reads(nodes, key) == [ok: 100, ok: 100] end)
+    for node <- nodes, do: :erpc.call(node, Peer, :observe_commands, [self()])
+
+    for _ <- 1..4 do
+      assert_receive {:provider_probe, ^a, ^key, :latest}, 1_000
+      assert_receive {:provider_probe, ^b, ^key, :latest}, 1_000
+    end
+
+    refute_receive {:journal_command, _, ^key, {:propose, _, _, _}}, 100
+
+    :erpc.call(a, Peer, :set_height, [key, 101])
+
+    eventually(fn ->
+      Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
+        state = BlockPublicationJournal.get(key)
+        state["phase"] == "preparing" and Map.has_key?(state["ready"], "a")
+      end)
+    end)
+
+    :erpc.call(a, Peer, :observe_commands, [nil])
+    # Flush the single successful preparation recorded before observation resumes.
+    flush_commands(key)
+    :erpc.call(a, Peer, :observe_commands, [self()])
+    for _ <- 1..4, do: assert_receive({:provider_probe, ^b, ^key, :prepare}, 1_000)
+    refute_receive {:journal_command, ^a, ^key, {:ready, _, _, _, _}}, 100
+    assert_receive {:provider_probe, ^a, ^key, :prepare}, 1_000
+    assert reads(nodes, key) == [ok: 100, ok: 100]
+    anchor = "0x" <> String.duplicate("1", 64)
+    for node <- nodes, do: :erpc.call(node, Peer, :set_anchor, [key, anchor])
+    :erpc.call(b, Peer, :set_height, [key, 101])
+    eventually(fn -> reads(nodes, key) == [ok: 101, ok: 101] end)
+  end
+
+  defp flush_commands(key) do
+    receive do
+      {:journal_command, _, ^key, _} -> flush_commands(key)
+      {:provider_probe, _, ^key, _} -> flush_commands(key)
+    after
+      0 -> :ok
+    end
+  end
+
   defp reads(nodes, key), do: Enum.map(nodes, &:erpc.call(&1, Peer, :read, [key]))
   defp eventually(fun, attempts \\ 150)
   defp eventually(fun, 0), do: assert(fun.())

--- a/test/support/block_publication_peer.ex
+++ b/test/support/block_publication_peer.ex
@@ -19,6 +19,8 @@ defmodule Lasso.Test.BlockPublicationPeer do
     def ensure(key, members, age), do: available(fn -> Durable.ensure(key, members, age) end)
 
     def command(key, command) do
+      Lasso.Test.BlockPublicationPeer.observe({:journal_command, node(), key, command})
+
       case {command, :persistent_term.get({__MODULE__, :blocked_history}, nil)} do
         {{:fence, _, _, _}, {keys, owner}} when is_map_key(keys, key) ->
           send(owner, {:fencing_history, self(), key})
@@ -57,6 +59,15 @@ defmodule Lasso.Test.BlockPublicationPeer do
     end
   end
 
+  def observe_commands(owner), do: :persistent_term.put({__MODULE__, :observer}, owner)
+
+  def observe(event) do
+    case :persistent_term.get({__MODULE__, :observer}, nil) do
+      owner when is_pid(owner) -> send(owner, event)
+      _ -> :ok
+    end
+  end
+
   def block_closures(owner), do: :persistent_term.put({Journal, :blocked_closures}, owner)
 
   def journal_available(value), do: :persistent_term.put({Journal, :available}, value)
@@ -82,15 +93,25 @@ defmodule Lasso.Test.BlockPublicationPeer do
   end
 
   def set_height(key, height), do: :persistent_term.put({__MODULE__, key}, height)
-  def latest(key, _), do: {:ok, block(:persistent_term.get({__MODULE__, key})), nil}
+
+  def set_anchor(key, hash), do: :persistent_term.put({__MODULE__, key, :anchor}, hash)
+
+  def latest(key, _) do
+    observe({:provider_probe, node(), key, :latest})
+    {:ok, block(:persistent_term.get({__MODULE__, key})), nil}
+  end
 
   def prepare(key, candidate, published, _) do
+    observe({:provider_probe, node(), key, :prepare})
+
     if :persistent_term.get({__MODULE__, key}) >= candidate["height"] do
       {:ok,
        %{
          "block_hash" => candidate["hash"],
-         "anchor_hash" => published && published["hash"],
-         "provider_id" => "regional-fixture"
+         "anchor_hash" =>
+           :persistent_term.get({__MODULE__, key, :anchor}, published && published["hash"]),
+         "provider_id" => "regional-fixture",
+         "observed_at_ms" => System.system_time(:millisecond)
        }}
     else
       {:error, :provider_behind}


### PR DESCRIPTION
Regions repeat serialized journal transactions when the published head has not advanced and when their readiness evidence is unchanged. Port Cloud #1036: precheck proposals with the existing state machine and suppress duplicate readiness writes, ignoring only observation timestamps. Provider checks, changed evidence, expiry, durable closure and retained-floor recovery remain intact; no schema or configuration changes.

The two-node/PostgreSQL regression verifies continued probes without duplicate writes and recovery when the anchor changes. The shared runtime is byte-for-byte identical to the Cloud correction. Validation: `mix format`, 24 focused publication and real PostgreSQL cluster tests pass. Exact-head repository CI is required before merge.

Cloud's prior four-region production canary failed availability; this correction is not yet geographically qualified. Leave the next immutable release tag pending that qualification and any further required correction. Existing v0.4.1 remains unchanged.
