### PR TITLE
Prepare v0.4.2 local continuity and peer recovery release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-09-11
+
 ### Fixed
 
 - Avoid serialized journal transactions for locally ineligible block proposals and unchanged readiness evidence. Provider checks continue so anchor, provider, floor and freshness changes can still drive publication; observation timestamps alone no longer repeat readiness writes. No configuration or journal migration is required.
@@ -230,7 +232,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Credo and Dialyzer static analysis
 - Comprehensive test suite (unit + integration)
 
-[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/jaxernst/lasso-rpc/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.6...v0.4.0
 [0.3.6]: https://github.com/jaxernst/lasso-rpc/compare/v0.3.5...v0.3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Propagate committed publication snapshots between runtimes and retry stale closure acknowledgments from already received revisions, avoiding extra journal reads at cutover. Preserve periodic recovery, boot checks, durable closure, and the invalidation topic used by older runtimes; no schema or configuration changes are required.
 
+- Reconcile journal inventory in one supervised background task, allowing committed updates to proceed while a read is slow. Stale inventory results cannot regress a newer publication; cold bootstrap still requires a successful inventory.
+
 - Avoid serialized journal transactions for locally ineligible block proposals and unchanged readiness evidence. Provider checks continue so anchor, provider, floor and freshness changes can still drive publication; observation timestamps alone no longer repeat readiness writes. No configuration or journal migration is required.
 
 ## [0.4.1] - 2026-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.2] - 2026-09-11
 
+### Changed
+
+- Local block continuity captures the mandatory floor once per request and atomically retains the greatest accepted height. Sequential nonoverlapping requests within one application generation remain nondecreasing; overlapping responses can complete out of height order.
+- Connected BEAM instances exchange accepted-height hints through bounded background work. Hints prefer suitable providers without raising the local admission floor or removing valid fallbacks. Local mode requires no publication database or peer acknowledgment. Recovery after an application restart or node switch is best effort, with no promised time or block-gap bound.
+- Provider preference uses transport observations with the captured route's freshness settings. Existing health, capability, explicit override and fallback-group rules retain precedence; a stalled preferred provider leaves time for a valid fallback within the existing request deadline.
+
 ### Fixed
 
 - Propagate committed publication snapshots between runtimes and retry stale closure acknowledgments from already received revisions, avoiding extra journal reads at cutover. Preserve periodic recovery, boot checks, durable closure, and the invalidation topic used by older runtimes; no schema or configuration changes are required.
@@ -16,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reconcile journal inventory in one supervised background task, allowing committed updates to proceed while a read is slow. Stale inventory results cannot regress a newer publication; cold bootstrap still requires a successful inventory.
 
 - Avoid serialized journal transactions for locally ineligible block proposals and unchanged readiness evidence. Provider checks continue so anchor, provider, floor and freshness changes can still drive publication; observation timestamps alone no longer repeat readiness writes. No configuration or journal migration is required.
+
+### Compatibility
+
+- Existing `off`, `local` and `global` configuration values remain valid. Global retains its durable coordinated contract and journal/membership requirements. Explicit number/hash state reads retain their targets. Local floors and hints are volatile application state; losing all copies loses that history.
+- Local choices still require an eligible provider response and can fail when a provider regresses and every fallback is unavailable or quota-limited. This release does not add a retained-response cache or certify any customer's provider capacity.
 
 ## [0.4.1] - 2026-09-10
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ providers let you try it without API keys.
 For query-wide state consistency, see [Read at one block](docs/READ_AT_ONE_BLOCK.md)
 and the opt-in [Block continuity policy](docs/BLOCK_CONTINUITY.md).
 
+Use `head_policy: local` for monotonic choices on each running instance, with
+best-effort recovery from connected BEAM peers and no publication database.
+The separate `global` mode retains a durable coordinated fleet-wide contract.
+Both require providers capable of serving the selected block and state; see the
+policy guide for restart, freshness and availability limits.
+
 ## Features
 
 - **Routing control:** `fastest`, `load-balanced`, `latency-weighted`, and direct provider routes.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Telegram](https://img.shields.io/badge/telegram-join%20chat-26A5E4?style=flat-square&labelColor=19202E&logo=telegram&logoColor=white)](https://t.me/+79pFERTlZPIzZTZh)
 [![X](https://img.shields.io/badge/follow-%40lassoRPC-19202E?style=flat-square&labelColor=19202E&logo=x&logoColor=white)](https://x.com/lassoRPC)
 [![License](https://img.shields.io/badge/license-Apache--2.0-19202E?style=flat-square&labelColor=19202E)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Version](https://img.shields.io/badge/version-0.4.1-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
+[![Version](https://img.shields.io/badge/version-0.4.2-19202E?style=flat-square&labelColor=19202E)](https://github.com/jaxernst/lasso-rpc/releases)
 [![Elixir](https://img.shields.io/badge/built%20with-Elixir%2FOTP-19202E?style=flat-square&labelColor=19202E&logo=elixir&logoColor=white)](https://elixir-lang.org)
 
 Lasso is a multi-chain Ethereum JSON-RPC proxy with health checks, retries,
@@ -41,7 +41,7 @@ You need Docker with the Compose plugin, curl, and OpenSSL. Start in an empty di
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.1/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.2/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,7 +41,7 @@ requires Docker Compose and OpenSSL for generating local secrets:
 
 ```bash
 mkdir lasso && cd lasso
-curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.1/compose.yml --output compose.yml
+curl --fail --location https://github.com/jaxernst/lasso-rpc/releases/download/v0.4.2/compose.yml --output compose.yml
 (umask 077; printf 'SECRET_KEY_BASE=%s\nRELEASE_COOKIE=%s\n' "$(openssl rand -hex 64)" "$(openssl rand -hex 32)" > .env)
 docker compose up -d --wait
 curl --fail http://localhost:4000/api/health

--- a/docs/RPC_STANDARDS.md
+++ b/docs/RPC_STANDARDS.md
@@ -1,6 +1,6 @@
 # RPC Core method support
 
-This page describes the self-hosted **v0.4.1** runtime. Lasso Cloud has a separate
+This page describes the self-hosted **v0.4.2** runtime. Lasso Cloud has a separate
 [compatibility contract](https://docs.lasso.sh/cloud/json-rpc-compatibility).
 Do not infer parity from a shared method name or product version.
 
@@ -33,7 +33,7 @@ Do not treat a profile as an authentication or authorization boundary.
 
 ## Stateful filters and extensions
 
-RPC Core v0.4.1 can forward provider-local filter methods when capability policy
+RPC Core v0.4.2 can forward provider-local filter methods when capability policy
 permits them. They receive one dispatch per request and have **no cross-request
 affinity guarantee**. A filter ID created on one upstream may be invalid on a
 later selected upstream. Prefer `eth_getLogs` or supported WebSocket subscriptions;
@@ -65,7 +65,7 @@ replay and a replacement live stream. Recovery beyond its time, replay, attempt,
 or buffer limits terminates the affected downstream connection explicitly; it
 does not promise unbounded or lossless delivery through arbitrary outages.
 
-In Core v0.4.1, `subscribe_new_heads` controls automatic block monitoring **and**
+In Core v0.4.2, `subscribe_new_heads` controls automatic block monitoring **and**
 client `newHeads` eligibility. Set it to `true` on intended providers. New profiles
 can reuse an already-connected upstream after a successful configuration reload.
 See [Configuration](CONFIGURATION.md) and [Deployment](DEPLOYMENT.md).

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lasso.MixProject do
   def project do
     [
       app: :lasso,
-      version: "0.4.1",
+      version: "0.4.2",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
       listeners: [Phoenix.CodeReloader],

--- a/test/lasso/core/request/request_owner_test.exs
+++ b/test/lasso/core/request/request_owner_test.exs
@@ -392,16 +392,17 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
 
   test "a negative proof after D cannot erase D-1 ambiguity" do
     test_pid = self()
-    deadline_us = deadline_after(50)
 
     owner =
       spawn(fn ->
+        deadline_us = deadline_after(1_000)
+
         outcome =
           RequestOwner.execute(identity(:unknown), deadline_us, fn ->
             context = AttemptProtocol.context()
             assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 1)
-            send(test_pid, {:negative_transport_ready, self()})
-            assert_receive :report_late_negative
+            send(test_pid, {:negative_transport_ready, self(), deadline_us})
+            assert_receive :report_late_negative, 2_000
 
             assert :ok =
                      AttemptProtocol.observe_at(
@@ -417,7 +418,9 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
         send(test_pid, {:negative_owner_outcome, outcome})
       end)
 
-    assert_receive {:negative_transport_ready, task}
+    on_exit(fn -> if Process.alive?(owner), do: Process.exit(owner, :kill) end)
+
+    assert_receive {:negative_transport_ready, task, deadline_us}, 1_500
     assert :erlang.suspend_process(owner)
     wait_past(deadline_us)
 

--- a/test/lasso/core/request/request_owner_test.exs
+++ b/test/lasso/core/request/request_owner_test.exs
@@ -429,6 +429,21 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
     end)
 
     send(task, :report_late_negative)
+    late_proof_us = deadline_us + 1
+
+    await_mailbox(owner, fn messages ->
+      Enum.any?(messages, fn
+        {_ref,
+         %RequestOwner.AttemptCompletion{
+           terminal_candidate: {:ok, %{kind: :predispatch_failure, event_us: ^late_proof_us}}
+         }} ->
+          true
+
+        _ ->
+          false
+      end)
+    end)
+
     assert :erlang.resume_process(owner)
 
     assert_receive {:negative_owner_outcome, outcome}, 1_000


### PR DESCRIPTION
Release v0.4.2 with local monotonic block choices and best-effort BEAM peer recovery, plus the merged global-publication contention fixes. The release updates versioned installation metadata, the changelog and the README. Local hints influence provider preference without raising the hard floor or requiring a database/peer acknowledgment on advancement. Existing Global, explicit selectors and request deadlines retain their contracts.

Exact head `ca0dd226` passes unit tests, all 1,749 hermetic integration tests, static checks and Docker build/boot. The runtime, deadline regression, deterministic cutoff fixture and mode-aware example are merged in Core #149–#152. Cloud staging qualification and the provider-capacity limits are recorded in Cloud #1042/#997.

After merging, require the exact merged-main CI before creating the new v0.4.2 tag. Publish through the existing native AMD64/ARM64 installation/recovery verification pipeline. Existing v0.4.1 remains immutable. Coordinated production qualification and documentation publication are tracked in Cloud #997.
