### PR TITLE
Advance committed publications without blocking on journal inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Propagate committed publication snapshots between runtimes and retry stale closure acknowledgments from already received revisions, avoiding extra journal reads at cutover. Preserve periodic recovery, boot checks, durable closure, and the invalidation topic used by older runtimes; no schema or configuration changes are required.
+
 - Avoid serialized journal transactions for locally ineligible block proposals and unchanged readiness evidence. Provider checks continue so anchor, provider, floor and freshness changes can still drive publication; observation timestamps alone no longer repeat readiness writes. No configuration or journal migration is required.
 
 ## [0.4.1] - 2026-09-10

--- a/docs/BLOCK_CONTINUITY_OPERATIONS.md
+++ b/docs/BLOCK_CONTINUITY_OPERATIONS.md
@@ -2,8 +2,23 @@
 
 `global` mode stores the monotonic floor, selected block and admitted instance
 boots in PostgreSQL. Serving requests read local ETS grants. PubSub accelerates
-updates; background reconciliation recovers missed messages. PostgreSQL is an
-optional dependency for this policy, not for ordinary Core routing.
+committed journal snapshots; background reconciliation recovers missed messages.
+PostgreSQL is required when enabling global continuity. Ordinary Core routing
+requires no database.
+
+Peers apply revision and boot checks before installing committed snapshots, then
+progress the cutover locally. Every serving boot still closes before its durable
+acknowledgment; a rejected acknowledgment retries from a newer received revision
+or waits for reconciliation. Cached work can progress through a failed inventory
+read, but writes still require PostgreSQL and only successful reconciliation
+completes cold bootstrap.
+
+Committed snapshots and invalidations use separate topics. Older runtimes receive
+invalidations, while current runtimes recover older peers' writes through periodic
+reconciliation during rolling replacement. Snapshot transport uses the existing
+journal state and scope bounds. This changes neither the public continuity contract
+nor the one-second request wait; geographic availability still needs qualification
+on the intended serving fleet.
 
 Read the [builder contract](BLOCK_CONTINUITY.md) before enabling it. Global mode
 can return an availability error to preserve continuity. It does not choose one
@@ -175,3 +190,10 @@ These tests do not certify your database provider's infrastructure failover.
 For rollback, coordinate disable and verify it before deploying a binary that
 cannot read this journal or honor its gates. Preserve journal tables and rows.
 An ordinary routing health check does not prove the continuity policy is active.
+
+Journal reconciliation runs in at most one supervised background task per runtime.
+A slow inventory read therefore cannot block committed notifications or closure
+ACKs. The first successful inventory still gates cold bootstrap. Inventory results
+use the same revision check as notifications, so an older reply cannot reopen a
+closed gate or replace a newer published block. Failed reads keep cached work
+progressing; they never create a grant.

--- a/lib/lasso/core/block_publication/runtime.ex
+++ b/lib/lasso/core/block_publication/runtime.ex
@@ -1,7 +1,8 @@
 defmodule Lasso.BlockPublication.Runtime do
   @moduledoc """
   Background journal reconciliation and regional preparation. PubSub carries
-  invalidations; only the durable journal can authorize a serving grant.
+  committed journal results; only the durable journal authorizes serving grants.
+  Reconciliation recovers missed notifications.
   """
   use GenServer
   require Logger
@@ -9,7 +10,8 @@ defmodule Lasso.BlockPublication.Runtime do
   alias Lasso.Config.ConfigStore
   alias Lasso.RPC.HeadPolicy
 
-  @topic "block_publications"
+  @commit_topic "block_publication_commits"
+  @invalidation_topic "block_publications"
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []), do: GenServer.start_link(__MODULE__, opts, name: __MODULE__)
@@ -38,6 +40,7 @@ defmodule Lasso.BlockPublication.Runtime do
       interval: Keyword.get(config, :interval_ms, 1_000),
       tasks: %{},
       closure_tasks: %{},
+      reconciliation: nil,
       snapshots: %{},
       timer: nil,
       next_probe: %{},
@@ -52,7 +55,7 @@ defmodule Lasso.BlockPublication.Runtime do
       unless is_atom(state.journal) and not is_nil(state.journal),
         do: raise(ArgumentError, "block publication requires a durable journal adapter")
 
-      Phoenix.PubSub.subscribe(Lasso.PubSub, @topic)
+      Phoenix.PubSub.subscribe(Lasso.PubSub, @commit_topic)
       send(self(), :reconcile)
       {:ok, state}
     end
@@ -66,6 +69,7 @@ defmodule Lasso.BlockPublication.Runtime do
       Process.demonitor(ref, [:flush])
     end)
 
+    if state.reconciliation, do: Process.demonitor(state.reconciliation, [:flush])
     state = %{state | retired: true}
 
     result = fence_before_deadline(state, deadline)
@@ -130,7 +134,7 @@ defmodule Lasso.BlockPublication.Runtime do
   @impl true
   def handle_info(:reconcile, state) do
     if state.timer, do: Process.cancel_timer(state.timer)
-    state = reconcile(state)
+    state = state |> reconcile() |> progress_snapshots()
 
     {:noreply,
      %{state | timer: Process.send_after(self(), :reconcile, state.interval), urgent: false}}
@@ -146,6 +150,33 @@ defmodule Lasso.BlockPublication.Runtime do
     end
   end
 
+  def handle_info({:publication_committed, key, publication}, state) do
+    {:noreply, state |> install(key, publication) |> advance(key)}
+  end
+
+  def handle_info({ref, {:inventory, result}}, %{reconciliation: ref} = state)
+      when is_reference(ref) do
+    Process.demonitor(ref, [:flush])
+    state = %{state | reconciliation: nil}
+
+    state =
+      case result do
+        {:ok, publications} ->
+          state =
+            Enum.reduce(publications, state, fn {key, publication}, acc ->
+              install(acc, key, publication)
+            end)
+
+          Gate.bootstrapped()
+          state
+
+        {:error, _} ->
+          state
+      end
+
+    {:noreply, progress_snapshots(state)}
+  end
+
   def handle_info({ref, {key, result}}, state) when is_reference(ref) do
     Process.demonitor(ref, [:flush])
     state = finish_task(state, ref)
@@ -153,7 +184,17 @@ defmodule Lasso.BlockPublication.Runtime do
     state =
       case result do
         {:ok, publication} ->
-          install(state, key, publication)
+          state |> install(key, publication) |> advance(key)
+
+        {:error, {:stale_revision, attempted_revision}} ->
+          case Map.get(state.snapshots, key) do
+            %{"revision" => current} when current > attempted_revision ->
+              advance(state, key)
+
+            _ ->
+              send(self(), :publication_changed)
+              state
+          end
 
         {:error, :stale_revision} ->
           send(self(), :publication_changed)
@@ -173,37 +214,33 @@ defmodule Lasso.BlockPublication.Runtime do
     {:noreply, finish_task(state, ref)}
   end
 
-  defp reconcile(state) do
-    ensure_configured_scopes(state)
+  defp reconcile(%{retired: true} = state), do: state
+  defp reconcile(%{reconciliation: ref} = state) when is_reference(ref), do: state
 
+  defp reconcile(state) do
     revisions =
       Map.new(state.snapshots, fn {key, publication} -> {key, publication["revision"]} end)
 
-    case state.journal.changes(revisions) do
-      {:ok, publications} ->
-        state =
-          Enum.reduce(publications, state, fn {key, publication}, acc ->
-            install(acc, key, publication)
-          end)
+    task =
+      Task.Supervisor.async_nolink(Lasso.BlockPublication.TaskSupervisor, fn ->
+        ensure_configured_scopes(state)
+        {:inventory, state.journal.changes(revisions)}
+      end)
 
-        state =
-          state.snapshots
-          |> Enum.sort_by(fn {key, _} ->
-            case Map.fetch(state.next_probe, key) do
-              :error -> {0, 0, key}
-              {:ok, next_probe} -> {1, next_probe, key}
-            end
-          end)
-          |> Enum.reduce(state, fn {key, publication}, acc ->
-            progress(acc, key, publication)
-          end)
+    %{state | reconciliation: task.ref}
+  end
 
-        Gate.bootstrapped()
-        state
-
-      {:error, _} ->
-        state
-    end
+  defp progress_snapshots(state) do
+    state.snapshots
+    |> Enum.sort_by(fn {key, _} ->
+      case Map.fetch(state.next_probe, key) do
+        :error -> {0, 0, key}
+        {:ok, next_probe} -> {1, next_probe, key}
+      end
+    end)
+    |> Enum.reduce(state, fn {key, publication}, acc ->
+      progress(acc, key, publication)
+    end)
   end
 
   defp ensure_configured_scopes(state) do
@@ -233,6 +270,13 @@ defmodule Lasso.BlockPublication.Runtime do
       else
         %{state | snapshots: Map.put(state.snapshots, key, publication)}
       end
+    end
+  end
+
+  defp advance(state, key) do
+    case Map.fetch(state.snapshots, key) do
+      {:ok, publication} -> progress(state, key, publication)
+      :error -> state
     end
   end
 
@@ -342,7 +386,13 @@ defmodule Lasso.BlockPublication.Runtime do
 
       task =
         Task.Supervisor.async_nolink(Lasso.BlockPublication.TaskSupervisor, fn ->
-          {key, apply_command(journal, key, snapshot, command)}
+          result =
+            case apply_command(journal, key, snapshot, command) do
+              {:error, :stale_revision} -> {:error, {:stale_revision, snapshot["revision"]}}
+              result -> result
+            end
+
+          {key, result}
         end)
 
       %{state | closure_tasks: Map.put(state.closure_tasks, task.ref, key)}
@@ -353,7 +403,8 @@ defmodule Lasso.BlockPublication.Runtime do
     %{
       state
       | tasks: Map.delete(state.tasks, ref),
-        closure_tasks: Map.delete(state.closure_tasks, ref)
+        closure_tasks: Map.delete(state.closure_tasks, ref),
+        reconciliation: if(state.reconciliation == ref, do: nil, else: state.reconciliation)
     }
   end
 
@@ -377,20 +428,27 @@ defmodule Lasso.BlockPublication.Runtime do
         do: journal.compare_and_apply(key, snapshot, command),
         else: journal.command(key, command)
 
-    if match?({:ok, _}, result),
-      do: Phoenix.PubSub.broadcast(Lasso.PubSub, @topic, :publication_changed)
-
-    result
+    notify_commit(key, result)
   end
 
   defp publish_command(state, key, cmd) do
     result = state.journal.command(key, cmd)
 
-    if match?({:ok, _}, result),
-      do: Phoenix.PubSub.broadcast(Lasso.PubSub, @topic, :publication_changed)
+    notify_commit(key, result)
+  end
 
+  defp notify_commit(key, {:ok, publication} = result) do
+    Phoenix.PubSub.broadcast(
+      Lasso.PubSub,
+      @commit_topic,
+      {:publication_committed, key, publication}
+    )
+
+    Phoenix.PubSub.broadcast(Lasso.PubSub, @invalidation_topic, :publication_changed)
     result
   end
+
+  defp notify_commit(_key, result), do: result
 
   defp task(state, key, fun) do
     task =

--- a/test/integration/block_publication_cluster_test.exs
+++ b/test/integration/block_publication_cluster_test.exs
@@ -234,6 +234,7 @@ defmodule Lasso.BlockPublication.ClusterTest do
     end)
 
     :erpc.call(c, Peer, :journal_available, [false])
+    :erpc.call(c, Peer, :notifications_available, [false])
 
     Ecto.Adapters.SQL.Sandbox.unboxed_run(Repo, fn ->
       assert {:ok, _} = BlockPublicationJournal.command(key, :disable)
@@ -374,7 +375,7 @@ defmodule Lasso.BlockPublication.ClusterTest do
     end
   end
 
-  test "unchanged heads and completed preparation do not contend on the durable row" do
+  test "unchanged evidence avoids writes and committed publications survive journal read failure" do
     {_output, 0} = System.cmd("epmd", ["-daemon"])
     :ok = LocalCluster.start()
 
@@ -449,12 +450,61 @@ defmodule Lasso.BlockPublication.ClusterTest do
     for node <- nodes, do: :erpc.call(node, Peer, :set_anchor, [key, anchor])
     :erpc.call(b, Peer, :set_height, [key, 101])
     eventually(fn -> reads(nodes, key) == [ok: 101, ok: 101] end)
+
+    :ok = Phoenix.PubSub.subscribe(Lasso.PubSub, "block_publications")
+    :erpc.call(b, Peer, :changes_available, [false])
+    for node <- nodes, do: :erpc.call(node, Peer, :block_closures, [self()])
+    for node <- nodes, do: :erpc.call(node, Peer, :set_height, [key, 102])
+
+    assert_receive {:closure_waiting, ^a, a_worker, ^key}, 2_000
+    assert_receive {:closure_waiting, ^b, b_worker, ^key}, 2_000
+    :ok = :erpc.call(b, Peer, :delay_reconciliation, [30_000])
+    assert_receive {:reconciliation_delayed, ^b}, 1_000
+    flush_commands(key)
+    send(a_worker, :continue)
+
+    eventually(fn ->
+      state = :erpc.call(b, :sys, :get_state, [Lasso.BlockPublication.Runtime])
+      is_binary(state.snapshots[key]["closed"]["a"])
+    end)
+
+    send(b_worker, :continue)
+    assert_receive {:closure_waiting, ^b, retry_worker, ^key}, 2_000
+    refute retry_worker == b_worker
+    assert reads(nodes, key) == [error: :publication_changing, error: :publication_changing]
+    send(retry_worker, :continue)
+    eventually(fn -> reads(nodes, key) == [ok: 102, ok: 102] end)
+    refute_received {:journal_changes, ^b, [^key]}
+    assert_receive :publication_changed, 1_000
+    refute_received {:publication_committed, ^key, _}
+
+    for node <- nodes, do: :erpc.call(node, Peer, :block_closures, [nil])
+    :erpc.call(b, Peer, :changes_available, [true])
+    :erpc.call(b, Peer, :block_changes, [self()])
+    :erpc.call(b, :erlang, :send, [Lasso.BlockPublication.Runtime, :reconcile])
+    assert_receive {:journal_changes_waiting, ^b, read_worker, {:ok, stale_publications}}, 2_000
+
+    try do
+      assert Map.new(stale_publications)[key]["published"]["height"] == 102
+      for node <- nodes, do: :erpc.call(node, Peer, :set_height, [key, 103])
+      eventually(fn -> reads(nodes, key) == [ok: 103, ok: 103] end, 20)
+      refute_received {:journal_changes_waiting, ^b, _, _}
+    after
+      :erpc.call(b, Peer, :block_changes, [nil])
+      send(read_worker, :continue)
+    end
+
+    eventually(fn ->
+      state = :erpc.call(b, :sys, :get_state, [Lasso.BlockPublication.Runtime])
+      is_nil(state.reconciliation) and state.snapshots[key]["published"]["height"] == 103
+    end)
   end
 
   defp flush_commands(key) do
     receive do
       {:journal_command, _, ^key, _} -> flush_commands(key)
       {:provider_probe, _, ^key, _} -> flush_commands(key)
+      {:journal_changes, _, [^key]} -> flush_commands(key)
     after
       0 -> :ok
     end

--- a/test/support/block_publication_peer.ex
+++ b/test/support/block_publication_peer.ex
@@ -15,7 +15,34 @@ defmodule Lasso.Test.BlockPublicationPeer do
       end)
     end
 
-    def changes(revisions), do: available(fn -> Durable.changes(revisions) end)
+    def changes(revisions) do
+      Lasso.Test.BlockPublicationPeer.observe({:journal_changes, node(), Map.keys(revisions)})
+
+      blocked = :persistent_term.get({__MODULE__, :blocked_changes}, nil)
+
+      revisions =
+        if is_pid(blocked), do: Map.new(revisions, fn {key, _} -> {key, -1} end), else: revisions
+
+      result =
+        if :persistent_term.get({__MODULE__, :changes_available}, true),
+          do: available(fn -> Durable.changes(revisions) end),
+          else: {:error, :journal_unavailable}
+
+      case blocked do
+        owner when is_pid(owner) ->
+          send(owner, {:journal_changes_waiting, node(), self(), result})
+
+          receive do
+            :continue -> result
+          after
+            30_000 -> {:error, :journal_unavailable}
+          end
+
+        _ ->
+          result
+      end
+    end
+
     def ensure(key, members, age), do: available(fn -> Durable.ensure(key, members, age) end)
 
     def command(key, command) do
@@ -68,7 +95,40 @@ defmodule Lasso.Test.BlockPublicationPeer do
     end
   end
 
+  def block_changes(owner), do: :persistent_term.put({Journal, :blocked_changes}, owner)
+
   def block_closures(owner), do: :persistent_term.put({Journal, :blocked_closures}, owner)
+
+  def delay_reconciliation(delay_ms) do
+    :sys.replace_state(Runtime, fn state ->
+      if state.timer, do: Process.cancel_timer(state.timer)
+
+      receive do
+        :reconcile -> :ok
+      after
+        0 -> :ok
+      end
+
+      observe({:reconciliation_delayed, node()})
+      %{state | timer: Process.send_after(self(), :reconcile, delay_ms)}
+    end)
+
+    :ok
+  end
+
+  def notifications_available(value) do
+    :sys.replace_state(Runtime, fn state ->
+      if value,
+        do: Phoenix.PubSub.subscribe(Lasso.PubSub, "block_publication_commits"),
+        else: Phoenix.PubSub.unsubscribe(Lasso.PubSub, "block_publication_commits")
+
+      state
+    end)
+
+    :ok
+  end
+
+  def changes_available(value), do: :persistent_term.put({Journal, :changes_available}, value)
 
   def journal_available(value), do: :persistent_term.put({Journal, :available}, value)
 


### PR DESCRIPTION
Publication closure currently waits for serialized cross-region journal rereads and stale-revision retries. The four-region production screen at `3c9c602b` returned 106/120 successful choices, below the unchanged 99% availability requirement; customer policies remain off.

Successful journal writes now transport committed snapshots on a separate PubSub topic, allowing peers to close their local gate and acknowledge the barrier immediately. A rejected closure retries only when a newer committed revision has already arrived. Inventory reconciliation runs in one supervised task, so a slow read cannot block committed updates. The durable journal, revision/boot checks, cold-bootstrap requirement, worker limits, freshness rules and request deadline retain their contracts. Legacy invalidations remain on their original topic for rolling compatibility.

Validation covers unchanged-evidence suppression, simultaneous closure revision contention with failed reads, a deliberately stalled stale inventory response, loss of both journal and notifications, restart/retirement and retained-floor lifecycle behavior. Negative controls reproduced failures without the committed transport, immediate revision retry and asynchronous inventory read. Local Cloud validation: 44 focused tests, zero failures; strict Credo passes across 436 source files. Core: 24 focused tests, zero failures. Full exact-head CI is pending. The runtime is byte-identical to Cloud PR #1038; Core uses its standalone PostgreSQL adapter in the same distributed regression.

This PR does not claim production availability qualification. Staging and a new four-region screen must pass the existing thresholds before the v0.4.2 release tag, public docs or customer activation.
