### PR TITLE
Recover local block choices through asynchronous peer hints

### DIFF
--- a/docs/BLOCK_CONTINUITY.md
+++ b/docs/BLOCK_CONTINUITY.md
@@ -12,7 +12,28 @@ This works for queries that combine proxy resolution, storage and code reads,
 Multicall, and dependent `eth_call` rounds. Follow the
 [read at one block guide](READ_AT_ONE_BLOCK.md) to integrate it.
 
-## What the setting guarantees
+## Local choices with peer recovery hints
+
+Set `head_policy: local` to preserve sequential nondecreasing block choices
+within each application generation. This mode needs no publication journal.
+Overlapping choices may complete out of order; each must meet the local floor
+captured when it starts. A lower provider response triggers bounded retry or an
+explicit error, and same-height hash conflicts remain errors.
+
+A background worker shares accepted heights with connected peers. A recovered
+height prefers providers with fresh observations at that height or higher while
+retaining valid lower fallbacks. Opt-in metadata reports `minimum_height`,
+`recovery_height` and `recovery_gap_blocks`. Remote hints never raise the mandatory
+local minimum or add a database hop to a request.
+
+Worker restart retains learned hints. Application or machine replacement starts
+a new generation and recovers asynchronously from surviving peers. Cross-instance
+regressions remain possible during cold startup, partitions, message loss or total
+memory loss. This is a soft recovery aid, not the global contract below. Hash-pinned
+queries retain their ordinary behavior in either mode. See the
+[design and qualification boundary](adr/0006-local-head-recovery.md).
+
+## What the global setting guarantees
 
 After a successful block choice returns height **N**, a later block choice
 returns **N or higher**, or an error. Returning the same height is allowed.

--- a/docs/adr/0006-local-head-recovery.md
+++ b/docs/adr/0006-local-head-recovery.md
@@ -1,0 +1,86 @@
+# Local monotonic choices with asynchronous recovery hints
+
+Status: candidate for staging comparison. This supplements the existing global
+publication policy; it does not weaken or remove that policy's contract.
+
+## Contract
+
+The `local` policy captures the profile/chain floor when a protected block choice
+initializes. Its successful height must meet that captured floor. Acceptance
+atomically raises the aggregate maximum. Therefore, if A completes before B
+begins on the same application generation, B cannot successfully return below A.
+Overlapping requests may finish out of height order without retrying solely
+because another overlapping request raised the aggregate maximum.
+
+A per-scope epoch changes when global enrollment fences local admission. An old
+local snapshot cannot become usable again after the global policy is disabled.
+Disabling or canceling enrollment restores the greater of the remembered and
+published heights, retaining the remembered hash at equal height.
+Same-height hash conflicts against the captured floor or the current equal-height
+floor remain errors. Height ordering does not prove ancestry, canonicality or
+state availability. Explicit selectors and one-hash logical reads retain their
+existing behavior.
+
+## Recovery and selection
+
+`HeadRecovery` reads at most 64 raw floor rows and 64 raw hint rows per 100 ms
+scan. It coalesces accepted heights and broadcasts changed hints through PubSub.
+Unchanged hints are eligible for retransmission after two seconds. A startup
+repair request clears peers' send caches at most once per two seconds without
+restarting their in-progress scans. Traversals tolerate stale continuations.
+Full-scan and delivery time determine recovery lag; the tick is not a per-key
+delivery deadline.
+
+The application owns the hint table, so worker restart retains it. Peers
+retransmit learned maxima as well as their own accepted heights; a survivor can
+therefore restore knowledge from a failed source. Messages accept only bounded
+batches for currently configured `local` scopes. Same-height conflicting hashes
+produce a hint with an unknown hash until a higher height arrives.
+
+RPCs only read local ETS. A recovered height above the captured local floor
+prefers providers with fresh observations at or above that height. Static and
+ranked candidate groups are stably partitioned, including lazily resolved
+groups. Core currently retains one observation per upstream instance; preference
+requires that stored observation to match the candidate transport. Missing or
+overwritten transport evidence leaves normal fallback ordering available. Existing health/rate-limit tiers, capability checks and explicit provider
+overrides retain precedence. A cached fastest winner is reused only when its
+observation meets the recovered target. Preference does not move a later deferred
+group ahead of an earlier group and does not apply to arbitrary custom strategy
+lists; these are best-effort limitations rather than extra selection machinery.
+
+Requests still ask for `latest`. A remote hint never raises the mandatory local
+minimum, excludes fallback providers, or causes an otherwise locally valid
+response to be discarded. A known lower fallback can succeed; opt-in response
+metadata records the recovered height and the returned height's gap below it.
+Qualified provider references remain evidence and are no longer an additional
+mandatory minimum for local monotonicity.
+
+## Failure and production boundary
+
+Cold instances serve without a new peer-recovery gate. Missing hints are explicit
+as null recovery metadata. Worker restarts preserve the application tables;
+application/VM replacement loses them and starts a new generation. Lost messages,
+partitions or total in-memory loss can cause cross-instance regressions of
+unbounded depth. This candidate adds no database checkpoint, per-advance peer
+acknowledgment, lease or consensus protocol.
+
+Cloud still reconciles existing durable global enrollment during cold bootstrap.
+This candidate removes database work from local-policy advancement; it does not
+remove Cloud's configuration/database or global-compatibility bootstrap dependency.
+
+The protected block choice methods remain `eth_blockNumber []` and
+`eth_getBlockByNumber ["latest", boolean]`. State reads with implicit `latest`
+are not a shared logical query. Existing 60-second minimum header-age ceilings
+remain in place for controlled comparison; their fast-chain product adequacy
+must be assessed separately from typical measured freshness.
+
+## Qualification
+
+Compare policy-off routing, this local candidate and strict global publication
+using BNB Chain, Base, Polygon and Ethereum, plus a 250 ms fixture. Record
+sequential numerical regressions separately from overlapping completions and
+hash changes. Measure source/provider switches, hint gaps, latency, retries,
+availability, freshness and complete pinned queries. Inject missed replication,
+worker restart, source loss and replacement under load. Keep raw-policy baseline,
+forced handoffs and injected faults as separate populations. Staging results
+must identify their source and topology before they inform production readiness.

--- a/lib/lasso/application.ex
+++ b/lib/lasso/application.ex
@@ -40,6 +40,7 @@ defmodule Lasso.Application do
 
     CircuitBreakerStorage.create_tables!()
     Lasso.RPC.HeadPolicy.create_table!()
+    Lasso.RPC.HeadRecovery.create_table!()
     Lasso.BlockPublication.Gate.create_table!()
 
     :ets.new(:block_sync_registry, [
@@ -151,6 +152,7 @@ defmodule Lasso.Application do
         # Supervised bootstrap loads profiles and starts shared infrastructure.
         Lasso.Boot.InfrastructureStarter,
         Lasso.BlockPublication.Supervisor,
+        Lasso.RPC.HeadRecovery,
 
         # Start Phoenix endpoint
         LassoWeb.Endpoint,

--- a/lib/lasso/core/block_sync/observation.ex
+++ b/lib/lasso/core/block_sync/observation.ex
@@ -47,6 +47,39 @@ defmodule Lasso.BlockSync.Observation do
     end
   end
 
+  @doc "Reads a matching stored transport using the captured route freshness window."
+  @spec read_transport(pos_integer(), String.t(), :http | :ws, integer(), pos_integer()) ::
+          {:ok, t()} | {:error, :not_found | {:stale, t()}}
+  def read_transport(chain_id, instance_id, transport, now_ms, compiled_freshness_ms)
+      when transport in [:http, :ws] and is_integer(compiled_freshness_ms) and
+             compiled_freshness_ms > 0 do
+    case Registry.get_height(chain_id, instance_id) do
+      {:ok, {height, observed_at_ms, ^transport, metadata}} ->
+        stale_after_ms =
+          Enum.max([
+            compiled_freshness_ms,
+            positive(Map.get(metadata, :stale_after_ms), 0),
+            3 * positive(Map.get(metadata, :sample_interval_ms), 0)
+          ])
+
+        observation = %{
+          height: height,
+          observed_at_ms: observed_at_ms,
+          source: transport,
+          metadata: metadata,
+          stale_after_ms: stale_after_ms,
+          age_ms: max(0, now_ms - observed_at_ms)
+        }
+
+        if fresh?(observation, now_ms),
+          do: {:ok, observation},
+          else: {:error, {:stale, observation}}
+
+      _missing_transport ->
+        {:error, :not_found}
+    end
+  end
+
   @spec fresh?(map(), integer()) :: boolean()
   def fresh?(observation, now_ms \\ System.system_time(:millisecond))
       when is_map(observation) and is_integer(now_ms) do

--- a/lib/lasso/core/request/head_policy.ex
+++ b/lib/lasso/core/request/head_policy.ex
@@ -13,7 +13,7 @@ defmodule Lasso.RPC.HeadPolicy do
   alias Lasso.Config.ConfigStore
   alias Lasso.JSONRPC.{Error, Quantity}
   alias Lasso.Providers.Catalog
-  alias Lasso.RPC.{PreparedRequest, RequestContext}
+  alias Lasso.RPC.{HeadRecovery, PreparedRequest, RequestContext}
   alias Lasso.RPC.Response.Success
 
   @table :lasso_accepted_heads
@@ -51,6 +51,10 @@ defmodule Lasso.RPC.HeadPolicy do
     if ctx.opts.request_origin == :client and acquisition?(ctx.method, ctx.params) do
       case ConfigStore.get_chain(ctx.opts.profile, ctx.chain_id) do
         {:ok, %{head_policy: mode} = chain} when mode in ["local", "global"] ->
+          key = {ctx.opts.profile, ctx.chain_id}
+          floor = if mode == "local", do: snapshot_floor(key)
+          recovery = if mode == "local", do: HeadRecovery.read(key)
+
           block_time =
             if is_integer(chain.block_time_ms) and chain.block_time_ms > 0,
               do: chain.block_time_ms,
@@ -59,11 +63,14 @@ defmodule Lasso.RPC.HeadPolicy do
           %{
             ctx
             | head_policy: %{
-                key: {ctx.opts.profile, ctx.chain_id},
+                key: key,
                 mode: mode,
+                floor: floor,
+                generation: generation(),
+                recovery: recovery,
                 max_head_age_ms: max(60_000, 4 * block_time),
                 target: nil,
-                minimum_height: nil,
+                minimum_height: if(is_map(floor), do: floor.height),
                 reference_height: nil,
                 last_error: nil,
                 evidence: nil
@@ -89,6 +96,20 @@ defmodule Lasso.RPC.HeadPolicy do
     {"eth_getBlockByNumber", ["latest", full]}
   end
 
+  @doc "A recovered height affects preference, never local admission."
+  @spec selection_options(RequestContext.t()) :: keyword()
+  def selection_options(%{head_policy: %{mode: "local"} = policy}) do
+    case policy.recovery do
+      %{height: height} when is_nil(policy.minimum_height) or height > policy.minimum_height ->
+        [preferred_head_height: height]
+
+      _no_higher_recovered_floor ->
+        []
+    end
+  end
+
+  def selection_options(_ctx), do: []
+
   @spec prepare_attempt(RequestContext.t()) :: RequestContext.t()
   def prepare_attempt(%{head_policy: nil} = ctx), do: ctx
 
@@ -97,10 +118,8 @@ defmodule Lasso.RPC.HeadPolicy do
 
   def prepare_attempt(ctx) do
     policy = ctx.head_policy
-    floor = floor_height(policy.key)
     reference = reference_height(ctx.opts.profile, ctx.chain_id)
-    minimum = Enum.max(Enum.filter([floor, reference], &is_integer/1), fn -> nil end)
-    target = if is_nil(policy.last_error), do: nil, else: minimum
+    target = if is_nil(policy.last_error), do: nil, else: policy.minimum_height
     full = if ctx.method == "eth_getBlockByNumber", do: Enum.at(ctx.params, 1), else: false
 
     request = %{
@@ -117,7 +136,6 @@ defmodule Lasso.RPC.HeadPolicy do
         head_policy: %{
           policy
           | target: target,
-            minimum_height: minimum,
             reference_height: reference
         }
     }
@@ -151,8 +169,9 @@ defmodule Lasso.RPC.HeadPolicy do
          true <- valid_hash?(hash),
          :ok <- validate_target(height, policy.target),
          :ok <- validate_minimum(height, policy.minimum_height),
+         :ok <- validate_snapshot_hash(policy.floor, height, hash),
          :ok <- validate_age(timestamp * 1_000, now, policy.max_head_age_ms),
-         :ok <- advance(policy.key, height, hash, @max_cas_attempts) do
+         :ok <- advance(policy, height, hash, @max_cas_attempts) do
       evidence = %{
         policy: "local",
         scope: "profile_chain_instance",
@@ -163,6 +182,9 @@ defmodule Lasso.RPC.HeadPolicy do
         block_age_ms: max(0, now - timestamp * 1_000),
         max_head_age_ms: policy.max_head_age_ms,
         reference_height: policy.reference_height,
+        minimum_height: policy.minimum_height,
+        recovery_height: policy.recovery && policy.recovery.height,
+        recovery_gap_blocks: recovery_gap(policy.recovery, height),
         upstream_method: "eth_getBlockByNumber"
       }
 
@@ -204,7 +226,7 @@ defmodule Lasso.RPC.HeadPolicy do
           policy: "local",
           scope: "profile_chain_instance",
           reason: bounded_reason(reason),
-          minimum_height: floor_height(policy.key),
+          minimum_height: policy.minimum_height,
           target_height: policy.target,
           max_head_age_ms: policy.max_head_age_ms
         }
@@ -238,6 +260,16 @@ defmodule Lasso.RPC.HeadPolicy do
   defp validate_minimum(height, minimum) when height >= minimum, do: :ok
   defp validate_minimum(_, _), do: {:error, :head_regression}
 
+  defp validate_snapshot_hash(%{height: height, hash: hash}, height, candidate)
+       when is_binary(hash) do
+    if String.downcase(candidate) == hash, do: :ok, else: {:error, :block_hash_changed}
+  end
+
+  defp validate_snapshot_hash(_, _, _), do: :ok
+
+  defp recovery_gap(nil, _height), do: nil
+  defp recovery_gap(%{height: recovered}, height), do: max(0, recovered - height)
+
   defp validate_age(timestamp, now, max_age) do
     cond do
       timestamp > now + @future_tolerance_ms -> {:error, :head_in_future}
@@ -248,62 +280,71 @@ defmodule Lasso.RPC.HeadPolicy do
 
   defp advance(_key, _height, _hash, 0), do: {:error, :floor_contention}
 
-  defp advance(key, height, hash, attempts) do
+  defp advance(%{floor: :unavailable}, _height, _hash, _attempts),
+    do: {:error, :floor_unavailable}
+
+  defp advance(policy, height, hash, attempts) do
+    key = policy.key
+    epoch = policy.floor.epoch
     hash = String.downcase(hash)
 
-    case :ets.lookup(@table, key) do
-      [{^key, :fenced, _}] ->
+    case {generation() == policy.generation, :ets.lookup(@table, key)} do
+      {true, [{^key, :fenced, _, _}]} ->
         {:error, :floor_unavailable}
 
-      [{^key, floor, _}] when height < floor ->
-        {:error, :head_regression}
-
-      [{^key, ^height, previous_hash}] when hash != previous_hash ->
-        {:error, :block_hash_changed}
-
-      [{^key, ^height, ^hash}] ->
+      {true, [{^key, floor, _, ^epoch}]} when is_integer(floor) and height < floor ->
         :ok
 
-      [{^key, _, _} = previous] ->
-        case :ets.select_replace(@table, [{previous, [], [{:const, {key, height, hash}}]}]) do
+      {true, [{^key, ^height, previous_hash, ^epoch}]} when hash != previous_hash ->
+        {:error, :block_hash_changed}
+
+      {true, [{^key, ^height, ^hash, ^epoch}]} ->
+        :ok
+
+      {true, [{^key, _, _, ^epoch} = previous]} ->
+        case :ets.select_replace(@table, [{previous, [], [{:const, {key, height, hash, epoch}}]}]) do
           1 -> :ok
-          0 -> advance(key, height, hash, attempts - 1)
+          0 -> advance(policy, height, hash, attempts - 1)
         end
 
-      [] ->
-        if :ets.insert_new(@table, {key, height, hash}),
-          do: :ok,
-          else: advance(key, height, hash, attempts - 1)
+      _unavailable ->
+        {:error, :floor_unavailable}
     end
   rescue
     ArgumentError -> {:error, :floor_unavailable}
   end
 
-  defp floor_height(key) do
+  defp snapshot_floor(key) do
+    :ets.insert_new(@table, {key, nil, nil, make_ref()})
+
     case :ets.lookup(@table, key) do
-      [{^key, :fenced, height}] -> height
-      [{^key, height, _}] -> height
-      [] -> nil
+      [{^key, :fenced, _, _}] -> :unavailable
+      [{^key, height, hash, epoch}] -> %{height: height, hash: hash, epoch: epoch}
+      [] -> :unavailable
     end
   rescue
-    ArgumentError -> nil
+    ArgumentError -> :unavailable
   end
 
   @doc "Atomically closes the local floor and returns its last accepted height."
   @spec fence_local({String.t(), pos_integer()}) :: non_neg_integer() | nil
   def fence_local(key) do
     case :ets.lookup(@table, key) do
-      [{^key, :fenced, height}] ->
+      [{^key, :fenced, {height, _hash}, _}] ->
         height
 
-      [{^key, height, _} = old] ->
-        case :ets.select_replace(@table, [{old, [], [{:const, {key, :fenced, height}}]}]) do
+      [{^key, height, hash, _} = old] ->
+        case :ets.select_replace(@table, [
+               {old, [], [{:const, {key, :fenced, {height, hash}, make_ref()}}]}
+             ]) do
           1 -> height
           0 -> fence_local(key)
         end
 
       [] ->
-        if :ets.insert_new(@table, {key, :fenced, nil}), do: nil, else: fence_local(key)
+        if :ets.insert_new(@table, {key, :fenced, {nil, nil}, make_ref()}),
+          do: nil,
+          else: fence_local(key)
     end
   end
 
@@ -311,19 +352,20 @@ defmodule Lasso.RPC.HeadPolicy do
   @spec release_local({String.t(), pos_integer()}, map() | nil) :: :ok | true | non_neg_integer()
   def release_local(key, published) do
     case :ets.lookup(@table, key) do
-      [{^key, :fenced, _} = old] ->
-        if published do
-          :ets.select_replace(@table, [
-            {old, [], [{:const, {key, published["height"], published["hash"]}}]}
-          ])
-        else
-          :ets.delete_object(@table, old)
-        end
+      [{^key, :fenced, remembered, epoch} = old] ->
+        {height, hash} = restored_floor(remembered, published)
+        :ets.select_replace(@table, [{old, [], [{:const, {key, height, hash, epoch}}]}])
 
       _ ->
         :ok
     end
   end
+
+  defp restored_floor({height, _hash}, %{"height" => published, "hash" => hash})
+       when is_nil(height) or published > height,
+       do: {published, String.downcase(hash)}
+
+  defp restored_floor(remembered, _publication), do: remembered
 
   defp generation do
     :ets.lookup_element(@table, :generation, 2)

--- a/lib/lasso/core/request/head_recovery.ex
+++ b/lib/lasso/core/request/head_recovery.ex
@@ -1,0 +1,165 @@
+defmodule Lasso.RPC.HeadRecovery do
+  @moduledoc """
+  Best-effort replication of accepted local heights for provider preference.
+
+  RPCs only read the table. A bounded background scan coalesces advancements and
+  repairs missed broadcasts, including floors learned from departed peers.
+  Hints neither grant serving permission nor advance the hard local floor.
+  """
+  use GenServer
+
+  alias Lasso.Config.ConfigStore
+
+  @table :lasso_recovered_heads
+  @topic "local_head_recovery:v1"
+  @batch_size 64
+  @interval_ms 100
+  @repair_ms 2_000
+
+  @spec create_table!(atom()) :: :ok
+  def create_table!(table \\ @table) do
+    :ets.new(table, [:named_table, :public, :ordered_set, read_concurrency: true])
+    :ok
+  end
+
+  @spec read({String.t(), pos_integer()}, atom()) :: map() | nil
+  def read(key, table \\ @table) do
+    case :ets.lookup(table, key) do
+      [{^key, height, hash, _received_at}] -> %{height: height, hash: hash}
+      [] -> nil
+    end
+  rescue
+    ArgumentError -> nil
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts),
+    do: GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+
+  @impl true
+  def init(opts) do
+    state = %{
+      table: Keyword.get(opts, :table, @table),
+      floors: Keyword.get(opts, :floors, :lasso_accepted_heads),
+      pubsub: Keyword.get(opts, :pubsub, Lasso.PubSub),
+      local?: Keyword.get(opts, :local?, &local?/1),
+      interval: Keyword.get(opts, :interval_ms, @interval_ms),
+      floor_cursor: :start,
+      hint_cursor: :start,
+      sent: %{},
+      next_repair: System.monotonic_time(:millisecond) + @repair_ms
+    }
+
+    Phoenix.PubSub.subscribe(state.pubsub, @topic)
+    Phoenix.PubSub.broadcast_from(state.pubsub, self(), @topic, :repair_local_heads)
+    send(self(), :tick)
+    {:ok, state}
+  end
+
+  @impl true
+  def handle_info(:tick, state) do
+    now = System.monotonic_time(:millisecond)
+    {floors, floor_cursor} = page(state.floors, state.floor_cursor)
+
+    for {key, height, hash} <- floors, do: merge(state, key, height, hash, now)
+
+    {hints, hint_cursor} = page(state.table, state.hint_cursor)
+
+    {updates, sent} =
+      Enum.reduce(hints, {[], state.sent}, fn {key, height, hash} = hint, {updates, sent} ->
+        if state.local?.(key) do
+          case Map.get(sent, key) do
+            {^height, ^hash, at} when now - at < @repair_ms ->
+              {updates, sent}
+
+            _changed_or_due ->
+              {[hint | updates], Map.put(sent, key, {height, hash, now})}
+          end
+        else
+          :ets.delete(state.table, key)
+          {updates, Map.delete(sent, key)}
+        end
+      end)
+
+    if updates != [] do
+      Phoenix.PubSub.broadcast_from(state.pubsub, self(), @topic, {:local_heads, updates})
+    end
+
+    Process.send_after(self(), :tick, state.interval)
+    {:noreply, %{state | floor_cursor: floor_cursor, hint_cursor: hint_cursor, sent: sent}}
+  end
+
+  def handle_info({:local_heads, hints}, state)
+      when is_list(hints) and length(hints) <= @batch_size do
+    now = System.monotonic_time(:millisecond)
+
+    for {key, height, hash} <- hints, do: merge(state, key, height, hash, now)
+
+    {:noreply, state}
+  end
+
+  def handle_info(:repair_local_heads, state) do
+    now = System.monotonic_time(:millisecond)
+
+    if now >= state.next_repair do
+      {:noreply, %{state | sent: %{}, next_repair: now + @repair_ms}}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  defp page(table, :start) do
+    :ets.select(table, [{:_, [], [:"$_"]}], @batch_size)
+    |> page_result()
+  end
+
+  defp page(_table, cursor) do
+    cursor |> :ets.select() |> page_result()
+  rescue
+    ArgumentError -> {[], :start}
+  end
+
+  defp page_result(:"$end_of_table"), do: {[], :start}
+  defp page_result({rows, :"$end_of_table"}), do: {floor_rows(rows), :start}
+  defp page_result({rows, cursor}), do: {floor_rows(rows), cursor}
+
+  defp floor_rows(rows) do
+    for {{profile, chain} = key, height, hash, _epoch} <- rows,
+        is_binary(profile) and is_integer(chain) and is_integer(height),
+        do: {key, height, hash}
+  end
+
+  defp merge(state, {profile, chain_id} = key, height, hash, now)
+       when is_binary(profile) and is_integer(chain_id) and chain_id > 0 and
+              is_integer(height) and height >= 0 and height <= 0xFFFFFFFFFFFFFFFF do
+    if state.local?.(key) and valid_hash?(hash) do
+      hash = if is_binary(hash), do: String.downcase(hash)
+
+      case :ets.lookup(state.table, key) do
+        [{^key, previous, _, _}] when previous > height ->
+          :ok
+
+        [{^key, ^height, previous_hash, received_at}] ->
+          if previous_hash != hash,
+            do: :ets.insert(state.table, {key, height, nil, received_at})
+
+        _older_or_missing ->
+          :ets.insert(state.table, {key, height, hash, now})
+      end
+    end
+
+    :ok
+  end
+
+  defp merge(_state, _key, _height, _hash, _now), do: :ok
+
+  defp valid_hash?(nil), do: true
+  defp valid_hash?(hash) when is_binary(hash), do: Regex.match?(~r/\A0x[0-9a-fA-F]{64}\z/, hash)
+  defp valid_hash?(_hash), do: false
+
+  defp local?({profile, chain_id}) do
+    match?({:ok, %{head_policy: "local"}}, ConfigStore.get_chain(profile, chain_id))
+  end
+end

--- a/lib/lasso/core/request/request_pipeline.ex
+++ b/lib/lasso/core/request/request_pipeline.ex
@@ -298,12 +298,18 @@ defmodule Lasso.RPC.RequestPipeline do
     fn %RequestContext{chain_id: chain_id} = ctx ->
       {method, params} = HeadPolicy.selection_request(ctx)
 
-      Selection.select_channel_candidates(profile, chain_id, method,
-        strategy: opts.strategy,
-        transport: opts.transport || :both,
-        limit: @max_channel_candidates,
-        params: params,
-        request_origin: opts.request_origin
+      Selection.select_channel_candidates(
+        profile,
+        chain_id,
+        method,
+        HeadPolicy.selection_options(ctx) ++
+          [
+            strategy: opts.strategy,
+            transport: opts.transport || :both,
+            limit: @max_channel_candidates,
+            params: params,
+            request_origin: opts.request_origin
+          ]
       )
     end
   end

--- a/lib/lasso/core/selection/candidate_cursor.ex
+++ b/lib/lasso/core/selection/candidate_cursor.ex
@@ -19,6 +19,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
           }
   end
 
+  alias Lasso.BlockSync.Observation
   alias Lasso.Config.ConfigStore
   alias Lasso.Providers.{CandidateListing, Catalog, InstanceState}
 
@@ -48,6 +49,7 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
   defstruct @enforce_keys ++
               [
                 candidate_labels: [],
+                preferred_head_height: nil,
                 deferred_ranking: nil,
                 excluded_provider_ids: MapSet.new(),
                 returned: 0,
@@ -124,7 +126,9 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       filters: filters,
       consensus_height: consensus_height,
       learned_scope: deferred_scope(deferred_ranking),
-      descriptors: descriptors,
+      descriptors:
+        prefer_heads(descriptors, Keyword.get(opts, :preferred_head_height), plan.chain_id),
+      preferred_head_height: Keyword.get(opts, :preferred_head_height),
       deferred_ranking: deferred_ranking,
       limit: limit,
       candidate_labels: candidate_labels
@@ -173,7 +177,9 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       filters: filters,
       consensus_height: consensus_height,
       learned_scope: learned_scope_fun.(),
-      descriptors: descriptors,
+      descriptors:
+        prefer_heads(descriptors, Keyword.get(opts, :preferred_head_height), plan.chain_id),
+      preferred_head_height: Keyword.get(opts, :preferred_head_height),
       limit: limit,
       candidate_labels: []
     }
@@ -249,7 +255,13 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
         |> reject_deferred_providers(cursor.excluded_provider_ids)
 
       cursor = append_resolved_labels(cursor, descriptors, next_deferred)
-      scan(%{cursor | descriptors: descriptors, deferred_ranking: next_deferred})
+
+      scan(%{
+        cursor
+        | descriptors:
+            prefer_heads(descriptors, cursor.preferred_head_height, cursor.plan.chain_id),
+          deferred_ranking: next_deferred
+      })
     else
       :stale
     end
@@ -260,7 +272,13 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
        ) do
     if current?(cursor) do
       descriptors = rank_deferred(deferred)
-      scan(%{cursor | descriptors: descriptors, deferred_ranking: nil})
+
+      scan(%{
+        cursor
+        | descriptors:
+            prefer_heads(descriptors, cursor.preferred_head_height, cursor.plan.chain_id),
+          deferred_ranking: nil
+      })
     else
       :stale
     end
@@ -293,6 +311,31 @@ defmodule Lasso.RPC.Selection.CandidateCursor do
       :stale
     end
   end
+
+  defp prefer_heads(descriptors, nil, _chain_id), do: descriptors
+
+  defp prefer_heads(descriptors, height, chain_id) do
+    {preferred, remaining} =
+      Enum.split_with(descriptors, fn descriptor ->
+        {provider, transport} = head_route(descriptor)
+
+        case Observation.read_transport(
+               chain_id,
+               provider.instance_id,
+               transport,
+               System.system_time(:millisecond),
+               get_in(provider, [:head_freshness_ms, transport])
+             ) do
+          {:ok, %{height: observed}} -> observed >= height
+          _unknown -> false
+        end
+      end)
+
+    preferred ++ remaining
+  end
+
+  defp head_route({:ranked, candidate, transport}), do: {candidate, transport}
+  defp head_route({provider, transport}), do: {provider, transport}
 
   defp materialize(cursor, {provider, transport}) do
     filters = %{SelectionFilters.to_map(cursor.filters) | protocol: transport}

--- a/lib/lasso/core/selection/routing_plan.ex
+++ b/lib/lasso/core/selection/routing_plan.ex
@@ -21,7 +21,8 @@ defmodule Lasso.RPC.RoutingPlan do
           required(:capabilities) => map() | nil,
           required(:archival) => boolean(),
           required(:subscribe_new_heads) => boolean(),
-          required(:transports) => [:http | :ws]
+          required(:transports) => [:http | :ws],
+          required(:head_freshness_ms) => %{http: pos_integer(), ws: pos_integer()}
         }
 
   @type t :: %__MODULE__{

--- a/lib/lasso/core/selection/selection.ex
+++ b/lib/lasso/core/selection/selection.ex
@@ -536,7 +536,8 @@ defmodule Lasso.RPC.Selection do
           candidate_labels: if(limit > 0, do: ["#{candidate.id}:#{transport}"], else: [])
         }
 
-        if selection_snapshot_current?(snapshot, [candidate]) do
+        if selection_snapshot_current?(snapshot, [candidate]) and
+             preferred_head?(candidate, transport, plan.chain_id, opts) do
           {:ok,
            CandidateCursor.new_ranked(
              snapshot,
@@ -578,6 +579,25 @@ defmodule Lasso.RPC.Selection do
   end
 
   defp fastest_hint(:full, _plan), do: nil
+
+  defp preferred_head?(candidate, transport, chain_id, opts) do
+    case Keyword.get(opts, :preferred_head_height) do
+      nil ->
+        true
+
+      height ->
+        case Lasso.BlockSync.Observation.read_transport(
+               chain_id,
+               candidate.instance_id,
+               transport,
+               System.system_time(:millisecond),
+               get_in(candidate, [:head_freshness_ms, transport])
+             ) do
+          {:ok, %{height: observed}} -> observed >= height
+          _unknown -> false
+        end
+    end
+  end
 
   defp ranking_channel(plan, candidate, transport) do
     %Channel{

--- a/lib/lasso/providers/candidate_listing.ex
+++ b/lib/lasso/providers/candidate_listing.ex
@@ -386,6 +386,7 @@ defmodule Lasso.Providers.CandidateListing do
       instance_id: instance_id,
       route_generation: plan.generation,
       config: provider.config,
+      head_freshness_ms: Map.get(provider, :head_freshness_ms),
       transports: transports,
       routing_states: %{http: http_routing, ws: ws_routing},
       workload_key: workload_key,

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -441,12 +441,9 @@ defmodule Lasso.Providers.Catalog do
   end
 
   defp route_head_freshness_ms(chain_config) do
-    monitoring = chain_config.monitoring || %ChainConfig.Monitoring{}
-    websocket = chain_config.websocket || %ChainConfig.Websocket{}
-
     %{
-      http: max(1, monitoring.probe_interval_ms * 3),
-      ws: max(1, websocket.new_heads_timeout_ms)
+      http: max(1, chain_config.monitoring.probe_interval_ms * 3),
+      ws: max(1, chain_config.websocket.new_heads_timeout_ms)
     }
   end
 

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -417,7 +417,7 @@ defmodule Lasso.Providers.Catalog do
           capabilities: provider.capabilities,
           archival: provider.archival,
           subscribe_new_heads: provider.subscribe_new_heads,
-          head_freshness_ms: route_head_freshness_ms(chain_config, provider.provider_id),
+          head_freshness_ms: route_head_freshness_ms(chain_config),
           transports: available_transports(config)
         }
       end)
@@ -440,22 +440,12 @@ defmodule Lasso.Providers.Catalog do
     }
   end
 
-  defp route_head_freshness_ms(chain_config, provider_id) do
-    provider = Enum.find(chain_config.providers, &(&1.id == provider_id))
+  defp route_head_freshness_ms(chain_config) do
     monitoring = chain_config.monitoring || %ChainConfig.Monitoring{}
     websocket = chain_config.websocket || %ChainConfig.Websocket{}
 
-    poll_interval_ms =
-      case provider && provider.block_poll_interval_ms do
-        interval_ms when is_integer(interval_ms) and interval_ms > 0 ->
-          max(monitoring.probe_interval_ms, interval_ms)
-
-        _default ->
-          monitoring.probe_interval_ms
-      end
-
     %{
-      http: max(1, poll_interval_ms * 3),
+      http: max(1, monitoring.probe_interval_ms * 3),
       ws: max(1, websocket.new_heads_timeout_ms)
     }
   end

--- a/lib/lasso/providers/catalog.ex
+++ b/lib/lasso/providers/catalog.ex
@@ -417,6 +417,7 @@ defmodule Lasso.Providers.Catalog do
           capabilities: provider.capabilities,
           archival: provider.archival,
           subscribe_new_heads: provider.subscribe_new_heads,
+          head_freshness_ms: route_head_freshness_ms(chain_config, provider.provider_id),
           transports: available_transports(config)
         }
       end)
@@ -436,6 +437,26 @@ defmodule Lasso.Providers.Catalog do
       max_lag_blocks: max_lag_blocks,
       archival_threshold:
         selection.archival_threshold || ChainConfig.Selection.default_archival_threshold()
+    }
+  end
+
+  defp route_head_freshness_ms(chain_config, provider_id) do
+    provider = Enum.find(chain_config.providers, &(&1.id == provider_id))
+    monitoring = chain_config.monitoring || %ChainConfig.Monitoring{}
+    websocket = chain_config.websocket || %ChainConfig.Websocket{}
+
+    poll_interval_ms =
+      case provider && provider.block_poll_interval_ms do
+        interval_ms when is_integer(interval_ms) and interval_ms > 0 ->
+          max(monitoring.probe_interval_ms, interval_ms)
+
+        _default ->
+          monitoring.probe_interval_ms
+      end
+
+    %{
+      http: max(1, poll_interval_ms * 3),
+      ws: max(1, websocket.new_heads_timeout_ms)
     }
   end
 

--- a/test/integration/head_recovery_cluster_test.exs
+++ b/test/integration/head_recovery_cluster_test.exs
@@ -1,0 +1,64 @@
+defmodule Lasso.RPC.HeadRecoveryClusterTest do
+  use ExUnit.Case, async: false
+  alias Lasso.Test.HeadRecoveryPeer, as: Peer
+  @moduletag :integration
+  @moduletag timeout: 90_000
+
+  test "BEAM peers repair missed updates and recover after complete application state loss" do
+    {_output, 0} = System.cmd("epmd", ["-daemon"])
+    :ok = LocalCluster.start()
+
+    endpoint =
+      Application.get_env(:lasso, LassoWeb.Endpoint)
+      |> Keyword.put(:server, false)
+      |> Keyword.put(:http, ip: {127, 0, 0, 1}, port: 0)
+
+    {:ok, cluster} =
+      LocalCluster.start_link(2,
+        prefix: "headrecovery#{System.unique_integer([:positive])}",
+        applications: [:lasso],
+        environment: [
+          lasso: [
+            {LassoWeb.Endpoint, endpoint}
+          ]
+        ]
+      )
+
+    on_exit(fn -> if Process.alive?(cluster), do: GenServer.stop(cluster, :normal, 30_000) end)
+    {:ok, [a, b]} = LocalCluster.nodes(cluster)
+    key = {"public", 56}
+    for member <- [a, b], do: assert(:ok == :erpc.call(member, Peer, :configure, [key]))
+    :ok = :erpc.call(a, Peer, :seed, [key, 100])
+    eventually(fn -> match?(%{height: 100}, :erpc.call(b, Peer, :hint, [key])) end)
+    assert [] == :erpc.call(b, Peer, :floor, [key])
+
+    :ok = :erpc.call(b, Peer, :notifications, [false])
+    :ok = :erpc.call(a, Peer, :seed, [key, 101])
+    eventually(fn -> match?(%{height: 101}, :erpc.call(a, Peer, :hint, [key])) end)
+    assert %{height: 100} = :erpc.call(b, Peer, :hint, [key])
+    :ok = :erpc.call(b, Peer, :notifications, [true])
+    eventually(fn -> match?(%{height: 101}, :erpc.call(b, Peer, :hint, [key])) end)
+
+    assert true == :erpc.call(b, Peer, :restart_worker, [])
+    :ok = :erpc.call(b, Peer, :configure, [key])
+    assert %{height: 101} = :erpc.call(b, Peer, :hint, [key])
+    old_generation = :erpc.call(a, Peer, :generation, [])
+    :ok = :erpc.call(a, Application, :stop, [:lasso])
+    assert %{height: 101} = :erpc.call(b, Peer, :hint, [key])
+    assert {:ok, _} = :erpc.call(a, Application, :ensure_all_started, [:lasso])
+    :ok = :erpc.call(a, Peer, :configure, [key])
+    assert old_generation != :erpc.call(a, Peer, :generation, [])
+    assert [] == :erpc.call(a, Peer, :floor, [key])
+    eventually(fn -> match?(%{height: 101}, :erpc.call(a, Peer, :hint, [key])) end)
+  end
+
+  defp eventually(fun, attempts \\ 150)
+  defp eventually(fun, 0), do: assert(fun.())
+
+  defp eventually(fun, attempts) do
+    unless fun.() do
+      Process.sleep(40)
+      eventually(fun, attempts - 1)
+    end
+  end
+end

--- a/test/integration/request_pipeline_head_policy_test.exs
+++ b/test/integration/request_pipeline_head_policy_test.exs
@@ -7,7 +7,12 @@ defmodule Lasso.RPC.RequestPipelineHeadPolicyTest do
 
   setup %{chain: chain} do
     :ok = ConfigStore.register_chain_runtime("public", chain, %{head_policy: "local"})
-    on_exit(fn -> :ets.delete(:lasso_accepted_heads, {"public", chain}) end)
+
+    on_exit(fn ->
+      :ets.delete(:lasso_accepted_heads, {"public", chain})
+      :ets.delete(:lasso_recovered_heads, {"public", chain})
+    end)
+
     :ok
   end
 
@@ -176,7 +181,7 @@ defmodule Lasso.RPC.RequestPipelineHeadPolicyTest do
     assert_receive {"eth_blockNumber", []}
   end
 
-  test "a slower concurrent acquisition cannot commit below a completed acquisition", %{
+  test "overlapping responses may finish out of order while later requests retain the maximum", %{
     chain: chain
   } do
     setup_providers([
@@ -226,7 +231,125 @@ defmodule Lasso.RPC.RequestPipelineHeadPolicyTest do
 
     assert result(response) == "0x65"
     send(provider, :release_head)
-    assert {:error, %Error{data: %{reason: "head_regression"}}, _} = Task.await(slow)
+    assert {:ok, response, ctx} = Task.await(slow)
+    assert result(response) == "0x64"
+    assert ctx.execution_envelope.dispatch_count == 1
+    assert ctx.head_policy.evidence.block_number == "0x64"
+
+    serve("slow-head", header(100))
+    serve("fast-head", header(100))
+    assert {:error, %Error{data: %{minimum_height: 101}}, _} = request(chain)
+  end
+
+  test "a recovered height prefers observed providers without removing a lagging fallback", %{
+    chain: chain
+  } do
+    setup_providers([
+      %{id: "behind", priority: 1, behavior: :healthy},
+      %{id: "ahead", priority: 2, behavior: :healthy}
+    ])
+
+    for {id, height} <- [{"behind", 99}, {"ahead", 100}] do
+      instance_id = Lasso.Providers.Catalog.lookup_instance_id("public", chain, id)
+      Lasso.BlockSync.Registry.put_height(chain, instance_id, height, :http)
+      serve(id, header(height))
+    end
+
+    :ets.insert(:lasso_recovered_heads, {{"public", chain}, 100, header(100)["hash"], 0})
+    assert {:ok, response, ctx} = request(chain)
+    assert result(response) == "0x64"
+    assert ctx.selected_provider.id == "ahead"
+    assert ctx.head_policy.evidence.recovery_gap_blocks == 0
+    refute_received {:head_request, "behind", _}
+  end
+
+  test "an unreachable remote target cannot poison a single provider local floor", %{chain: chain} do
+    setup_providers([%{id: "head", priority: 1, behavior: :healthy}])
+    :ets.insert(:lasso_recovered_heads, {{"public", chain}, 1_000, header(1_000)["hash"], 0})
+    serve("head", header(100))
+    assert {:ok, response, ctx} = request(chain)
+    assert result(response) == "0x64"
+    assert ctx.execution_envelope.dispatch_count == 1
+    assert ctx.head_policy.evidence.recovery_gap_blocks == 900
+
+    serve("head", header(99))
+    assert {:error, %Error{data: %{minimum_height: 100}}, _} = request(chain)
+  end
+
+  test "a failed preferred provider retains a valid lower fallback", %{chain: chain} do
+    setup_providers([
+      %{id: "behind", priority: 1, behavior: :healthy},
+      %{id: "ahead", priority: 2, behavior: :healthy}
+    ])
+
+    for {id, height} <- [{"behind", 99}, {"ahead", 100}] do
+      instance = Lasso.Providers.Catalog.lookup_instance_id("public", chain, id)
+      Lasso.BlockSync.Registry.put_height(chain, instance, height, :http)
+    end
+
+    :ets.insert(:lasso_recovered_heads, {{"public", chain}, 100, header(100)["hash"], 0})
+    serve("ahead", nil)
+    serve("behind", header(99))
+    assert {:ok, response, ctx} = request(chain)
+    assert result(response) == "0x63"
+    assert ctx.execution_envelope.dispatch_count == 2
+    assert ctx.head_policy.evidence.recovery_gap_blocks == 1
+    assert_receive {:head_request, "ahead", ["latest", false]}
+    assert_receive {:head_request, "behind", ["latest", false]}
+  end
+
+  test "canceling enrollment preserves the remembered floor and hash", %{chain: chain} do
+    setup_providers([%{id: "head", priority: 1, behavior: :healthy}])
+    serve("head", header(100))
+    assert {:ok, _, _} = request(chain)
+
+    for publication <- [
+          nil,
+          %{"height" => 99, "hash" => header(99)["hash"]},
+          %{"height" => 100, "hash" => header(101)["hash"]}
+        ] do
+      assert 100 == Lasso.RPC.HeadPolicy.fence_local({"public", chain})
+      assert 100 == Lasso.RPC.HeadPolicy.fence_local({"public", chain})
+      Lasso.RPC.HeadPolicy.release_local({"public", chain}, publication)
+
+      serve("head", header(99))
+      assert {:error, %Error{data: %{minimum_height: 100}}, _} = request(chain)
+      serve("head", Map.put(header(100), "hash", header(101)["hash"]))
+      assert {:error, %Error{data: %{reason: "block_hash_changed"}}, _} = request(chain)
+      serve("head", header(100))
+      assert {:ok, _, _} = request(chain)
+    end
+  end
+
+  test "fencing and releasing invalidates an earlier local request snapshot", %{chain: chain} do
+    setup_providers([%{id: "head", priority: 1, behavior: :healthy}])
+    observer = self()
+
+    set_behavior(
+      "head",
+      {:conditional,
+       fn _, _, _ ->
+         send(observer, {:blocked_head, self()})
+
+         receive do
+           :release_head -> {:ok, header(100)}
+         after
+           2_000 -> {:error, :timeout}
+         end
+       end}
+    )
+
+    pending = Task.async(fn -> request(chain) end)
+    assert_receive {:blocked_head, provider}
+    assert nil == Lasso.RPC.HeadPolicy.fence_local({"public", chain})
+
+    Lasso.RPC.HeadPolicy.release_local({"public", chain}, %{
+      "height" => 101,
+      "hash" => header(101)["hash"]
+    })
+
+    send(provider, :release_head)
+    assert {:error, %Error{data: %{reason: "floor_unavailable"}}, _} = Task.await(pending)
   end
 
   defp request(chain, method \\ "eth_blockNumber", params \\ []) do

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -748,7 +748,7 @@ defmodule Lasso.RPC.SelectionTest do
           generation,
           now_us,
           latency,
-          "client_basic"
+          "client"
         )
 
         Lasso.BlockSync.Registry.put_height(

--- a/test/integration/selection_test.exs
+++ b/test/integration/selection_test.exs
@@ -727,6 +727,112 @@ defmodule Lasso.RPC.SelectionTest do
       assert :done = CandidateCursor.next(cursor)
     end
 
+    test "a higher recovered head bypasses a lagging fastest winner while retaining fallbacks", %{
+      chain: chain
+    } do
+      profile = "public"
+
+      setup_providers([
+        %{id: "winner", priority: 10, behavior: :healthy, profile: profile},
+        %{id: "ahead", priority: 20, behavior: :healthy, profile: profile}
+      ])
+
+      generation = Catalog.active_generation()
+      now_us = System.monotonic_time(:microsecond)
+
+      for {id, latency, height} <- [{"winner", 10_000, 99}, {"ahead", 20_000, 100}] do
+        record_selection_successes(
+          chain,
+          profile,
+          id,
+          generation,
+          now_us,
+          latency,
+          "client_basic"
+        )
+
+        Lasso.BlockSync.Registry.put_height(
+          chain,
+          Catalog.lookup_instance_id(profile, chain, id),
+          height,
+          :http
+        )
+      end
+
+      cursor =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http
+        )
+
+      assert {:ok, %{provider_id: "winner"}, _} = CandidateCursor.next(cursor)
+
+      recovered =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          preferred_head_height: 100
+        )
+
+      assert {:ok, %{provider_id: "ahead"}, recovered} = CandidateCursor.next(recovered)
+      assert {:ok, %{provider_id: "winner"}, recovered} = CandidateCursor.next(recovered)
+      assert :done = CandidateCursor.next(recovered)
+
+      ahead = Catalog.lookup_instance_id(profile, chain, "ahead")
+
+      assert :ok =
+               AttemptProjection.apply_control(
+                 selection_quota_event(chain, profile, "ahead", ahead, generation, now_us + 20)
+               )
+
+      limited =
+        Selection.select_channel_candidates(profile, chain, "eth_blockNumber",
+          strategy: :fastest,
+          transport: :http,
+          preferred_head_height: 100
+        )
+
+      assert {:ok, %{provider_id: "winner"}, _} = CandidateCursor.next(limited)
+    end
+
+    test "recovery preference honors the captured route freshness window", %{chain: chain} do
+      setup_providers([
+        %{id: "behind", priority: 1, behavior: :healthy},
+        %{id: "ahead", priority: 2, behavior: :healthy}
+      ])
+
+      snapshot = Catalog.snapshot()
+      {:ok, plan} = Catalog.get_routing_plan(snapshot, "public", chain)
+
+      plan = %{
+        plan
+        | providers:
+            Enum.map(
+              plan.providers,
+              &Map.put(&1, :head_freshness_ms, %{http: 90_000, ws: 90_000})
+            )
+      }
+
+      Lasso.BlockSync.Registry.clear_chain(chain)
+
+      for {id, height} <- [{"behind", 99}, {"ahead", 100}] do
+        :ets.insert(:block_sync_registry, {
+          {:height, chain, Catalog.lookup_instance_id("public", chain, id)},
+          {height, System.system_time(:millisecond) - 45_000, :http, %{}}
+        })
+      end
+
+      cursor =
+        CandidateCursor.new(snapshot, plan, "eth_blockNumber",
+          strategy: :priority,
+          transport: :http,
+          preferred_head_height: 100
+        )
+
+      assert {:ok, %{provider_id: "ahead"}, cursor} = CandidateCursor.next(cursor)
+      assert {:ok, %{provider_id: "behind"}, _} = CandidateCursor.next(cursor)
+    end
+
     test "fastest winner defers construction of fallback candidates", %{chain: chain} do
       profile = "public"
 

--- a/test/lasso/core/block_sync/observation_test.exs
+++ b/test/lasso/core/block_sync/observation_test.exs
@@ -42,6 +42,25 @@ defmodule Lasso.BlockSync.ObservationTest do
              Observation.read(chain_id, instance_id)
   end
 
+  test "route freshness requires matching transport evidence", %{chain_id: chain_id} do
+    instance_id = "route-freshness"
+    now_ms = System.system_time(:millisecond)
+
+    :ets.insert(:block_sync_registry, {
+      {:height, chain_id, instance_id},
+      {100, now_ms - 45_000, :http, %{}}
+    })
+
+    assert {:ok, %{height: 100}} =
+             Observation.read_transport(chain_id, instance_id, :http, now_ms, 90_000)
+
+    assert {:error, {:stale, _}} =
+             Observation.read_transport(chain_id, instance_id, :http, now_ms, 10_000)
+
+    assert {:error, :not_found} =
+             Observation.read_transport(chain_id, instance_id, :ws, now_ms, 90_000)
+  end
+
   test "rejects observations beyond their stored freshness contract", %{chain_id: chain_id} do
     instance_id = "stale-observation"
     observed_at_ms = System.system_time(:millisecond) - 90_001

--- a/test/lasso/rpc/head_recovery_test.exs
+++ b/test/lasso/rpc/head_recovery_test.exs
@@ -1,0 +1,195 @@
+defmodule Lasso.RPC.HeadRecoveryTest do
+  use ExUnit.Case, async: false
+
+  alias Lasso.RPC.HeadRecovery
+  @pubsub Lasso.Test.HeadRecoveryPubSub
+  @topic "local_head_recovery:v1"
+  @key {"recovery-test", 1}
+
+  setup do
+    start_supervised!({Phoenix.PubSub, name: @pubsub})
+
+    for table <- [
+          :recovery_floors_a,
+          :recovery_floors_b,
+          :recovery_floors_c,
+          :recovery_hints_a,
+          :recovery_hints_b,
+          :recovery_hints_c
+        ] do
+      :ets.new(table, [:named_table, :public, :set])
+    end
+
+    :ok
+  end
+
+  test "duplicate and delayed updates converge without advancing the hard floor" do
+    worker(:a)
+    worker(:b)
+    :ets.insert(:recovery_floors_a, {@key, 100, hash(100), make_ref()})
+
+    eventually(fn ->
+      HeadRecovery.read(@key, :recovery_hints_b) == %{height: 100, hash: hash(100)}
+    end)
+
+    Phoenix.PubSub.broadcast(
+      @pubsub,
+      @topic,
+      {:local_heads, [{@key, 99, hash(99)}, {@key, 100, hash(100)}]}
+    )
+
+    assert :ets.lookup(:recovery_floors_b, @key) == []
+    assert HeadRecovery.read(@key, :recovery_hints_b).height == 100
+  end
+
+  test "periodic repair recovers an update missed while the receiver was unsubscribed" do
+    worker(:a)
+    b = worker(:b)
+    :ets.insert(:recovery_floors_a, {@key, 100, hash(100), make_ref()})
+    eventually(fn -> match?(%{height: 100}, HeadRecovery.read(@key, :recovery_hints_b)) end)
+
+    :sys.replace_state(b, fn state ->
+      Phoenix.PubSub.unsubscribe(@pubsub, @topic)
+      state
+    end)
+
+    :ets.insert(:recovery_floors_a, {@key, 101, hash(101), make_ref()})
+    eventually(fn -> match?(%{height: 101}, HeadRecovery.read(@key, :recovery_hints_a)) end)
+    assert HeadRecovery.read(@key, :recovery_hints_b).height == 100
+
+    :sys.replace_state(b, fn state ->
+      Phoenix.PubSub.subscribe(@pubsub, @topic)
+      state
+    end)
+
+    eventually(fn -> match?(%{height: 101}, HeadRecovery.read(@key, :recovery_hints_b)) end)
+  end
+
+  test "a surviving peer repairs a replacement after the original source and its worker are gone" do
+    worker(:a)
+    worker(:b)
+    :ets.insert(:recovery_floors_a, {@key, 101, hash(101), make_ref()})
+    eventually(fn -> match?(%{height: 101}, HeadRecovery.read(@key, :recovery_hints_b)) end)
+    stop_supervised!(:recovery_worker_a)
+    stop_supervised!(:recovery_worker_b)
+    :ets.delete_all_objects(:recovery_floors_a)
+    :ets.delete_all_objects(:recovery_hints_a)
+    worker(:b)
+    worker(:c)
+
+    eventually(fn -> match?(%{height: 101}, HeadRecovery.read(@key, :recovery_hints_c)) end)
+    assert :ets.lookup(:recovery_floors_b, @key) == []
+    assert :ets.lookup(:recovery_floors_c, @key) == []
+  end
+
+  test "unknown scopes, malformed entries, and oversized batches do not create hints" do
+    b = worker(:b)
+
+    send(
+      b,
+      {:local_heads,
+       [{{"unknown", 1}, 100, hash(100)}, {@key, -1, hash(100)}, {@key, 100, "bad"}, :bad]}
+    )
+
+    send(b, {:local_heads, List.duplicate({@key, 100, hash(100)}, 65)})
+    :sys.get_state(b)
+    assert :ets.tab2list(:recovery_hints_b) == []
+  end
+
+  test "bounded pages eventually propagate more scopes than one batch" do
+    local? = fn {profile, chain} -> profile == "recovery-test" and chain in 1..200 end
+    worker(:a, local?)
+    worker(:b, local?)
+
+    for chain <- 1..200 do
+      :ets.insert(:recovery_floors_a, {{"recovery-test", chain}, 100, hash(100), make_ref()})
+    end
+
+    eventually(fn -> :ets.info(:recovery_hints_b, :size) == 200 end)
+    assert :ets.info(:recovery_floors_b, :size) == 0
+  end
+
+  test "same-height hash disagreement remains visible until a higher height arrives" do
+    b = worker(:b)
+    send(b, {:local_heads, [{@key, 100, hash(100)}, {@key, 100, hash(99)}]})
+    :sys.get_state(b)
+    assert HeadRecovery.read(@key, :recovery_hints_b) == %{height: 100, hash: nil}
+    send(b, {:local_heads, [{@key, 100, hash(100)}]})
+    :sys.get_state(b)
+    assert HeadRecovery.read(@key, :recovery_hints_b).hash == nil
+    send(b, {:local_heads, [{@key, 101, hash(101)}]})
+    :sys.get_state(b)
+    assert HeadRecovery.read(@key, :recovery_hints_b).hash == hash(101)
+  end
+
+  test "configuration churn and inactive floor rows cannot stop later repair" do
+    local? = fn {profile, chain} -> profile == "recovery-test" and chain in 1..200 end
+    a = worker(:a, local?)
+    worker(:b, local?)
+
+    for chain <- 1..300 do
+      :ets.insert(:recovery_floors_a, {{"recovery-test", chain}, nil, nil, make_ref()})
+      :ets.insert(:recovery_hints_a, {{"recovery-test", chain}, 100, hash(100), 0})
+    end
+
+    eventually(fn -> :ets.info(:recovery_hints_a, :size) == 200 end)
+    :ets.delete_all_objects(:recovery_floors_a)
+    :ets.insert(:recovery_floors_a, {@key, 101, hash(101), make_ref()})
+    eventually(fn -> match?(%{height: 101}, HeadRecovery.read(@key, :recovery_hints_b)) end)
+    assert Process.alive?(a)
+  end
+
+  test "repeated repair requests do not restart the scan ahead of later scopes" do
+    local? = fn {profile, chain} -> profile == "recovery-test" and chain in 1..200 end
+
+    for chain <- 1..200 do
+      :ets.insert(:recovery_hints_a, {{"recovery-test", chain}, 100, hash(100), 0})
+    end
+
+    a = worker(:a, local?, 100_000)
+    worker(:b, local?)
+
+    for _ <- 1..8 do
+      :sys.replace_state(a, &%{&1 | next_repair: System.monotonic_time(:millisecond) - 1})
+      send(a, :repair_local_heads)
+      send(a, :tick)
+      :sys.get_state(a)
+    end
+
+    eventually(fn -> :ets.info(:recovery_hints_b, :size) == 200 end)
+  end
+
+  defp worker(which, local? \\ fn key -> key == @key end, interval \\ 10) do
+    {name, floors, hints} =
+      case which do
+        :a -> {:recovery_worker_a, :recovery_floors_a, :recovery_hints_a}
+        :b -> {:recovery_worker_b, :recovery_floors_b, :recovery_hints_b}
+        :c -> {:recovery_worker_c, :recovery_floors_c, :recovery_hints_c}
+      end
+
+    start_supervised!(
+      Supervisor.child_spec(
+        {HeadRecovery,
+         name: name,
+         floors: floors,
+         table: hints,
+         pubsub: @pubsub,
+         local?: local?,
+         interval_ms: interval},
+        id: name
+      )
+    )
+  end
+
+  defp hash(height), do: "0x" <> String.pad_leading(Integer.to_string(height, 16), 64, "0")
+
+  defp eventually(fun, attempts \\ 150)
+  defp eventually(fun, 0), do: assert(fun.())
+
+  defp eventually(fun, attempts) do
+    unless fun.() do
+      Process.sleep(20)
+      eventually(fun, attempts - 1)
+    end
+  end
+end

--- a/test/support/head_recovery_peer.ex
+++ b/test/support/head_recovery_peer.ex
@@ -1,0 +1,49 @@
+defmodule Lasso.Test.HeadRecoveryPeer do
+  @moduledoc false
+  alias Lasso.RPC.HeadRecovery
+
+  def configure({profile, chain}) do
+    case Lasso.Config.ConfigStore.get_chain(profile, chain) do
+      {:ok, %{head_policy: "local"}} ->
+        :ok
+
+      {:error, :not_found} ->
+        Lasso.Config.ConfigStore.register_chain_runtime(profile, chain, %{
+          head_policy: "local",
+          providers: [],
+          block_time_ms: 250,
+          new_heads_monitoring: false
+        })
+    end
+  end
+
+  def seed(key, height) do
+    hash = "0x" <> String.pad_leading(Integer.to_string(height, 16), 64, "0")
+    :ets.insert(:lasso_accepted_heads, {key, height, hash, make_ref()})
+    :ok
+  end
+
+  def floor(key), do: :ets.lookup(:lasso_accepted_heads, key)
+  def hint(key), do: HeadRecovery.read(key)
+
+  def notifications(enabled) do
+    :sys.replace_state(HeadRecovery, fn state ->
+      if enabled,
+        do: Phoenix.PubSub.subscribe(Lasso.PubSub, "local_head_recovery:v1"),
+        else: Phoenix.PubSub.unsubscribe(Lasso.PubSub, "local_head_recovery:v1")
+
+      state
+    end)
+
+    :ok
+  end
+
+  def restart_worker do
+    old = Process.whereis(HeadRecovery)
+    :ok = Supervisor.terminate_child(Lasso.Supervisor, HeadRecovery)
+    {:ok, new} = Supervisor.restart_child(Lasso.Supervisor, HeadRecovery)
+    old != new
+  end
+
+  def generation, do: :ets.lookup_element(:lasso_accepted_heads, :generation, 2)
+end


### PR DESCRIPTION
Local block choices now capture their mandatory floor once per request and share accepted-height hints asynchronously. Sequential choices on one application generation cannot decrease; overlapping choices may complete out of order. Peer hints prefer suitable providers while retaining valid lower fallbacks, so local advancement adds no database or peer-acknowledgment hop.

This ports Cloud #1039 into RPC Core. The worker and local-floor algorithm match Cloud, including remembered height/hash through canceled global enrollment. Selection uses compiled route freshness. Core's older observation store retains one transport fact per instance; the compatibility reader requires that fact to match the candidate transport, preserving ordinary fallback when it does not. Existing global publication remains available.

Tests cover concurrency, fencing, provider preference/fallback, route freshness, bounded repair, worker restart and recovery between two complete BEAM applications. Exact-head CI passes all 1,748 hermetic tests, unit checks, Dialyzer, strict Credo and Docker build/boot. Independent source review found no remaining runtime or compatibility blocker after the Core configuration adaptation. `mix format` and `git diff --check` pass.

Cloud's 250 ms Anvil fixture passed 1,000 choices across ten concurrent readers. Staging comparison and production qualification remain pending; this source merge does not qualify a production release.

Wayfinder: jaxernst/lasso-cloud#989. This is source propagation of the comparison candidate; it does not publish or qualify v0.4.2.
