### PR TITLE
Make the late-proof cutoff fixture independent of owner startup

### DIFF
--- a/test/lasso/core/request/request_owner_test.exs
+++ b/test/lasso/core/request/request_owner_test.exs
@@ -392,16 +392,17 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
 
   test "a negative proof after D cannot erase D-1 ambiguity" do
     test_pid = self()
-    deadline_us = deadline_after(50)
 
     owner =
       spawn(fn ->
+        deadline_us = deadline_after(1_000)
+
         outcome =
           RequestOwner.execute(identity(:unknown), deadline_us, fn ->
             context = AttemptProtocol.context()
             assert :ok = AttemptProtocol.send_started_at(context, deadline_us - 1)
-            send(test_pid, {:negative_transport_ready, self()})
-            assert_receive :report_late_negative
+            send(test_pid, {:negative_transport_ready, self(), deadline_us})
+            assert_receive :report_late_negative, 2_000
 
             assert :ok =
                      AttemptProtocol.observe_at(
@@ -417,7 +418,9 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
         send(test_pid, {:negative_owner_outcome, outcome})
       end)
 
-    assert_receive {:negative_transport_ready, task}
+    on_exit(fn -> if Process.alive?(owner), do: Process.exit(owner, :kill) end)
+
+    assert_receive {:negative_transport_ready, task, deadline_us}, 1_500
     assert :erlang.suspend_process(owner)
     wait_past(deadline_us)
 
@@ -426,6 +429,21 @@ defmodule Lasso.Core.Request.RequestOwnerTest do
     end)
 
     send(task, :report_late_negative)
+    late_proof_us = deadline_us + 1
+
+    await_mailbox(owner, fn messages ->
+      Enum.any?(messages, fn
+        {_ref,
+         %RequestOwner.AttemptCompletion{
+           terminal_candidate: {:ok, %{kind: :predispatch_failure, event_us: ^late_proof_us}}
+         }} ->
+          true
+
+        _ ->
+          false
+      end)
+    end)
+
     assert :erlang.resume_process(owner)
 
     assert_receive {:negative_owner_outcome, outcome}, 1_000


### PR DESCRIPTION
The negative-proof cutoff test could exhaust its50ms deadline before its spawned owner ran. Core release CI reproduced that path as an immediate, correctly classified not-dispatched deadline, so the test never exercised the intended late-proof ambiguity.

Create the deadline inside the scheduled owner, allow a one-second setup window, and pass that deadline back with the transport-ready handshake. It waits for the actual transport completion carrying the late negative proof while the owner remains suspended, preventing a vacuous pass where cutoff processing kills the task first. The test still waits for the real cutoff and asserts that a proof timestamped after D cannot erase dispatch ambiguity from D-1. Bound the transport handshake and clean up the owned process if the test fails. Runtime behavior is unchanged; the identical fixture correction is in Core release PR146.

Formatting and diff checks pass. Exact-head CI and review are required; no local full suite was run concurrently with the shared Mac's main-branch CI. This follows Wayfinder#989 qualification and is not a routing-runtime redesign.

Independent expert review of final Cloud56fd9918/Coref5d84b1a found no remaining issue after the completion handshake correction.
