### PR TITLE
Clarify block protection and state reads for ordinary RPC clients

### DIFF
--- a/docs/BLOCK_CONTINUITY.md
+++ b/docs/BLOCK_CONTINUITY.md
@@ -1,129 +1,153 @@
-# Block continuity
+# Block regression protection
 
-Keep each query at one block, and keep later block choices from going backwards.
+RPC providers can disagree about the latest block. For example, a block-height
+poll might return 100 from one provider, then 99 from a provider that is behind.
+Block regression protection prevents that step backwards for sequential
+latest-block requests handled by the same running Lasso server.
 
-Set `head_policy: global` for a chain in your file profile after
-[configuring the publication journal and serving fleet](BLOCK_CONTINUITY_OPERATIONS.md). Choose a
-block once with `eth_getBlockByNumber("latest", false)` and pass its hash to
-every state read in your query. Your existing RPC endpoint and standard Ethereum
-methods stay the same.
+Use it when polling chain progress or fetching the latest block for your
+application. Your Ethereum JSON-RPC requests and responses stay the same.
 
-This works for queries that combine proxy resolution, storage and code reads,
-Multicall, and dependent `eth_call` rounds. Follow the
-[read at one block guide](READ_AT_ONE_BLOCK.md) to integrate it.
+The following sections describe `local` mode. See
+[strict fleet-wide coordination](#optional-strict-fleet-wide-coordination) for
+the separate durable `global` contract.
 
-## Local choices with peer recovery hints
+## Enable protection
 
-Set `head_policy: local` to preserve sequential nondecreasing block choices
-within each application generation. This mode needs no publication journal.
-Overlapping choices may complete out of order; each must meet the local floor
-captured when it starts. A lower provider response triggers bounded retry or an
-explicit error, and same-height hash conflicts remain errors.
+In an existing chain entry in your file profile, set `head_policy: local`:
 
-A background worker shares accepted heights with connected peers. A recovered
-height prefers providers with fresh observations at that height or higher while
-retaining valid lower fallbacks. Opt-in metadata reports `minimum_height`,
-`recovery_height` and `recovery_gap_blocks`. Remote hints never raise the mandatory
-local minimum or add a database hop to a request.
-
-Worker restart retains learned hints. Application or machine replacement starts
-a new generation and recovers asynchronously from surviving peers. Cross-instance
-regressions remain possible during cold startup, partitions, message loss or total
-memory loss. This is a soft recovery aid, not the global contract below. Hash-pinned
-queries retain their ordinary behavior in either mode. See the
-[design and qualification boundary](adr/0006-local-head-recovery.md).
-
-## What the global setting guarantees
-
-After a successful block choice returns height **N**, a later block choice
-returns **N or higher**, or an error. Returning the same height is allowed.
-
-The guarantee is shared by all callers and enrolled serving instances on the
-same profile and chain. Different profiles and chains have independent floors.
-It applies when the later request starts after the earlier response completes;
-overlapping requests can finish out of height order.
-
-| Request | Behavior with Block continuity enabled |
-| --- | --- |
-| `eth_blockNumber []` | Returns the retained block number. |
-| `eth_getBlockByNumber ["latest", false]` | Returns the retained block, including its number and hash. Use this to start a query. |
-| `eth_getBlockByNumber ["latest", true]` | Returns the selected block with full transactions, or an error if unavailable. |
-| State reads with an explicit number or hash | Keep the requested target through routing and retries, including targets below the latest floor. |
-| State reads using `latest` or an omitted selector | Use ordinary provider routing. Separate reads can observe different blocks. |
-
-The setting does not group requests into a query. Your application carries the
-chosen hash through discovery, independent calls, and dependent rounds. A
-JSON-RPC batch alone does not select a shared block. `safe`, `finalized`,
-`pending`, log ranges, and subscriptions retain their usual semantics.
-
-## One query, one block identity
-
-For state reads, use the standard
-[EIP-1898 selector](https://eips.ethereum.org/EIPS/eip-1898):
-
-```js
-{ blockHash: block.hash, requireCanonical: true }
+```yaml
+chains:
+  ethereum:
+    head_policy: local
+    # Keep the chain's existing providers and other settings.
 ```
 
-A number identifies a height; a hash identifies the particular block at that
-height. During a reorg, the same number can refer to a different block. If you
-start with a number, resolve it to a hash **once**, before the first state read.
+This is the behavior labeled **Block regression protection: On** in Lasso Cloud.
+`head_policy: off` is the default. Connected RPC Core instances automatically
+share progress to help preserve continuity when requests move between them.
+There is no additional peer-sharing switch and no publication database is
+required for this mode. Configure [clustering](DEPLOYMENT.md#multi-node-clustering) to connect
+self-hosted instances.
 
-Use providers that support the method, hash selector and required state history.
-Lasso keeps the hash during failover and returns an error if the read cannot be
-completed. Provider capability evidence guides routing; it does not certify that
-every backend behind an endpoint can execute the request.
-Your query can therefore finish at block 100 while a newer query reads block 101.
+For example, continue polling with your existing request:
 
-## Freshness and provider lag
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "eth_blockNumber",
+  "params": []
+}
+```
 
-Lasso retains its selected block even if providers subsequently report lower
-heights. It can return 101 again after observing 101, without accepting a later
-provider response of 100.
+If a protected response returns `"0x64"` (100), the next request on the same
+running Lasso server returns 100 or higher, or an error. Returning 100 again is
+allowed. You do not need to change your state reads or collect metadata to use
+this setting.
 
-That block expires after the greater of **60 seconds or four configured block
-intervals**, measured from its timestamp. Repeating it does not renew its age.
-If Lasso cannot provide a fresh block at or above the floor, it returns an error.
-This bounds staleness; it does not promise the newest block on the network.
-Executing state reads still requires a provider with the selected state.
+## Which requests are protected?
 
-Block choices normally use the retained block locally. During a publication
-change, a choice can wait up to one second within its request deadline before
-failing. Reads already pinned to a hash continue without that publication wait.
+The setting applies to these latest-block requests:
 
-A provider URL can sit in front of several nodes with different heads. Lasso
-keeps the hash on every attempt; a lagging node must serve that state or return
-an error. A successful head probe alone does not establish state availability.
+| Method | Parameters | Result |
+| --- | --- | --- |
+| `eth_blockNumber` | `[]` | A block number. |
+| `eth_getBlockByNumber` | `["latest", false]` | A block with transaction hashes. |
+| `eth_getBlockByNumber` | `["latest", true]` | A block with full transactions. |
 
-One provider is enough to enable the policy. It provides no provider failover or
-independent verification; reads fail if that provider cannot serve the chosen state.
+It protects the returned **block height**, not values such as balances or
+contract results. For example, `eth_getBalance(address, "latest")` and
+`eth_call(transaction, "latest")` still use ordinary provider routing, as do
+state reads with an omitted block selector. Separate state reads can observe
+different blocks.
 
-## Reorgs and failures
+Requests for an explicit number or hash keep that target through routing and
+retries, even if it is older than the latest protected height. This works with
+protection On or Off. Other requests, including `safe`, `finalized`, `pending`,
+log ranges and subscriptions, keep their existing semantics.
 
-With `requireCanonical: true`, a provider must reject a block it knows is no
-longer canonical. Lasso surfaces that conflict; it does not silently replace
-the query's hash. Discard the incomplete query and retry the whole operation
-within your deadline if a fresh result is still useful.
+## What the setting guarantees
 
-Detected replacements at the previous selected height appear in routing
-metadata as `anchor_hash_changed`. This does not detect every reorg, and missing
-state alone is not evidence of one. The height floor never resets downward,
-including during a reorg, so recovery can temporarily prevent new block choices.
+Protection applies to requests for the **same profile and chain on the same
+running Lasso server**. All API keys and callers using that profile and chain
+share the protected height; different profiles and chains are independent.
+Here, a Lasso server is the instance routing your request, not an upstream RPC
+provider. Changing providers within that instance preserves the protection.
 
-Canonicality reflects provider observations at the time of a read. A block can
-be reorganized later. Lasso does not cryptographically verify arbitrary
-`eth_call` results: a provider that silently ignores the selector can return
-incorrect data without revealing that in its response. Provider head checks
-and routing evidence do not prove execution correctness or finality.
+The next request must start after the previous response finishes. Concurrent
+requests can finish out of height order. The protected height is retained for
+the lifetime of the running application; it survives an internal recovery-worker
+restart, but not loss of the application itself. Calls made while protection is
+Off are outside the guarantee.
 
-## Return the block and routing evidence
+After a Lasso server switch or application restart, recovery is **best effort**:
+a lower height remains possible. Servers share progress in the background to
+help choose a suitable provider. Those updates do not impose a mandatory minimum
+on another server. There is no promised recovery time or block-gap bound, and
+disconnected servers or lost history can reduce continuity across the fleet.
 
-Add `?include_meta=headers` to collect Lasso's request ID and routing metadata
-without changing the JSON-RPC result. Return the chosen number, hash, and
-collected evidence alongside your application's query result. The
-[guide](READ_AT_ONE_BLOCK.md#3-return-results-with-evidence) shows what to retain.
+## Provider lag, errors and latency
 
-The continuity floor survives service restarts using the shared PostgreSQL journal.
-[Coordinated disabling](BLOCK_CONTINUITY_OPERATIONS.md#changing-or-disabling-the-policy) suspends
-protection; reenabling it retains the floor but cannot cover reads made while
-it was disabled.
+Lasso remembers a minimum accepted height, called the **floor**. Each protected
+request checks a provider response against the floor captured when that request
+starts. If the response is lower, Lasso can try another eligible provider within
+the request's deadline and retry budget. If none succeeds, the request fails
+rather than returning a lower height.
+
+Each protected request fetches a provider response. Advancing the floor adds no
+synchronous database lookup or wait for peer acknowledgments. Local processing,
+provider retries and cold connection setup can still add latency.
+
+A protected block must be no older than the greater of **60 seconds or four
+configured block intervals**, measured from its timestamp. Returning the same
+block again does not renew its age. This does not promise the newest block on
+the network. One provider is enough to enable protection, but it provides no
+fallback if that provider cannot serve an acceptable block.
+
+Protection also rejects a conflicting hash at the captured floor height. A
+chain reorganization can temporarily prevent new protected responses; the floor
+does not reset downwards. Protection does not detect every reorganization,
+establish finality or verify the correctness of a provider's execution results.
+
+## Read several values at the same block
+
+If a page needs a balance and transaction count from the same block, specify
+that block on both reads. Protection does not pin those calls automatically,
+and putting them in a JSON-RPC batch does not select a shared block.
+
+The separate [Read at one block](READ_AT_ONE_BLOCK.md) guide shows this standard
+Ethereum JSON-RPC pattern. It works with protection Off; turning protection On
+also protects the latest-block requests used to start later refreshes.
+
+## Optional: inspect protection metadata
+
+Add `?include_meta=headers` to inspect routing decisions without changing the
+JSON-RPC response body. Protected responses report `head_policy.policy=local`,
+the configuration name for protection with automatic fleet sharing.
+See [protection metadata](OBSERVABILITY.md#block-protection-metadata) for the
+accepted height, server identity and recovery fields. Metadata is diagnostic;
+collecting it is not required for protection.
+
+## Optional: strict fleet-wide coordination
+
+`head_policy: global` provides a different contract: sequential protected
+latest-block requests share a durable floor across all admitted serving
+instances for the same profile and chain. The floor survives application
+restarts. Configure its PostgreSQL journal and serving fleet before enabling it;
+follow the [operating guide](BLOCK_CONTINUITY_OPERATIONS.md).
+
+Global mode can return the retained block number or block with transaction
+hashes without an upstream request. Full-transaction responses still fetch the
+published hash from a provider. The same block-age limit applies. Advancement
+requires coordination, and requests can wait up to one second within their
+deadline during a publication change. Unavailable members or coordination can
+prevent advancement or cause errors. Explicit state reads keep their targets
+and do not wait for publication.
+
+Global publication can report a replacement at the previous selected height as
+`anchor_hash_changed`; this is a provider observation, not complete reorg
+detection or finality. Before changing away from an enrolled Global policy,
+complete coordinated shutdown and retain the journal and member configuration
+as described in the operating guide. A configuration edit alone cannot discard
+its durable contract.

--- a/docs/BLOCK_CONTINUITY_OPERATIONS.md
+++ b/docs/BLOCK_CONTINUITY_OPERATIONS.md
@@ -1,4 +1,34 @@
-# Operating block continuity
+# Operating block regression protection
+
+Use `head_policy: local` for protection with automatic peer sharing. It requires
+no publication database. Use `head_policy: global` only when you need a durable
+floor across every admitted serving instance and accept its coordination costs.
+See [Block regression protection](BLOCK_CONTINUITY.md) for the affected
+JSON-RPC methods and guarantees.
+
+## Protection with automatic peer recovery
+
+Set `head_policy: local` in each chain's file profile to enable protection with
+automatic progress sharing across connected peers.
+Local routing needs no PostgreSQL publication database. Each application retains
+its accepted floor in memory; connected BEAM peers exchange height hints in the
+background. Those hints prefer suitable providers without blocking requests or
+removing valid fallback providers.
+
+A worker restart retains application-owned state. A complete application restart,
+node switch, partition or loss of all copies can lose continuity. Recovery has no
+promised time or block-gap bound, and the total profile/chain inventory affects
+propagation. Qualify actual provider capacity: a protected latest-block request
+still fails
+when every eligible provider is unavailable. If your application also reads
+state at a chosen hash, qualify selector support and retained state for those
+methods separately.
+
+If this installation previously enrolled Global scopes, complete the coordinated
+disable procedure below before changing their contract. Retain its journal and
+member configuration so old durable history continues to be reconciled.
+
+## Strict fleet coordination
 
 `global` mode stores the monotonic floor, selected block and admitted instance
 boots in PostgreSQL. Serving requests read local ETS grants. Runtime publication writes transport committed journal snapshots over PubSub; background reconciliation recovers missed messages.
@@ -22,9 +52,11 @@ journal state and scope bounds. This changes neither the public continuity contr
 nor the one-second request wait; geographic availability still needs qualification
 on the intended serving fleet.
 
-Read the [builder contract](BLOCK_CONTINUITY.md) before enabling it. Global mode
-can return an availability error to preserve continuity. It does not choose one
+Read the [request behavior](BLOCK_CONTINUITY.md) before enabling Global mode.
+Global mode can return an availability error to preserve continuity. It does not choose one
 block automatically for unrelated state calls.
+
+The remaining procedures apply to Global mode.
 
 ## Install the journal
 
@@ -84,15 +116,16 @@ chains:
 
 Distribute/reload the file on every enrolled instance. First enrollment happens
 in the background; a successful config load is not proof that a grant is ready.
-Qualify the providers for the actual methods and EIP-1898 hash selectors across
-the freshness window plus your maximum query duration. A recent head probe alone
-does not prove state availability.
+Verify that your providers can serve protected latest-block requests within the
+freshness limit. If your application also reads state at a selected block hash,
+separately verify selector support and availability of that state.
 
 Request `eth_getBlockByNumber` with `["latest", false]` and
 `?include_meta=headers` through each instance's real ingress. Check the same
 profile/chain, `head_policy.policy=global`, `scope=profile_chain_fleet`, number,
-hash and serving instance. Decode the base64url `x-lasso-meta` header. Then run
-[the complete logical read](READ_AT_ONE_BLOCK.md) through multiple instances.
+hash and serving instance. Decode the base64url `x-lasso-meta` header. If your
+application also reads several values at one block, test
+[Read at one block](READ_AT_ONE_BLOCK.md) through multiple instances.
 Missing metadata means evidence is incomplete, not that a different block was
 selected. HTTP batch headers contain only one context.
 
@@ -184,7 +217,8 @@ publication resumes. Normal state requests retain their selectors and ordinary
 provider retry budgets.
 
 Before release, exercise journal interruption, worker restart, graceful and
-unfenced process replacement, disable/re-enable and actual hash-pinned queries.
+unfenced process replacement, and disable/re-enable. Include hash-pinned state
+reads if your application uses them.
 The repository CI runs PostgreSQL-backed three-BEAM tests and an Anvil/viem/SEL
 workflow with an actual branch replacement. It preserves correlated HTTP evidence.
 These tests do not certify your database provider's infrastructure failover.

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -98,3 +98,36 @@ interval; WebSocket observations remain direct evidence. Stale evidence is
 excluded, and consensus does not advance beyond an observed upstream height.
 See [Configuration](CONFIGURATION.md) for probe intervals, routing lag limits,
 and the dashboard lag status threshold.
+
+## Block protection metadata
+
+These optional fields help diagnose [Block regression protection](BLOCK_CONTINUITY.md).
+They are not required to enable protection or read several values at one block.
+When `head_policy.policy` is `local`, a protected latest-block response can include:
+
+| Field in `head_policy` | Meaning |
+| --- | --- |
+| `block_number`, `block_hash`, `block_age_ms` | The accepted block and its age. |
+| `instance`, `generation` | The serving Lasso instance and application lifetime. A replacement application starts a new generation. |
+| `minimum_height` | The local floor captured when the request started. |
+| `recovery_height` | A best-effort recovery height hint, or `null` if none was available. |
+| `recovery_gap_blocks` | The gap below the recovered height. A nonzero gap is allowed; hints are not mandatory minimums. |
+
+Compare nonoverlapping requests within the same service profile, chain, instance
+and generation to assess local protection. These fields do not prove that a
+particular number of peers received an update or predict recovery time.
+Global policies report `policy=global` and can include attributed
+chain-change observations. Their retained number/header responses have no
+executing upstream provider.
+
+Explicit-number/hash requests can legitimately have no `head_policy` object.
+State-read results do not independently attest which block the provider used
+to execute them. For correlation, use `x-lasso-request-id`, or `x-request-id`
+when no routing context was created. `service_profile_id` identifies the service profile and `profile_id` identifies
+the effective route. Core currently uses the same file-profile identity for
+both fields; treat them as opaque values.
+
+HTTP batch headers expose only one item's routing context. Oversized metadata
+can be omitted. If complete per-request diagnostics are required, use individual
+HTTP requests and record missing metadata explicitly; this is a diagnostics
+choice, not a requirement for consistent reads.

--- a/docs/READ_AT_ONE_BLOCK.md
+++ b/docs/READ_AT_ONE_BLOCK.md
@@ -1,149 +1,144 @@
 # Read at one block
 
-Choose a block before a query starts, reuse its hash for every state read, and
-return that identity with the result. This keeps proxy discovery, Multicall,
-and dependent calls on the same state as providers and regions change.
+Two RPC calls using `latest` can read different blocks if the chain advances
+between calls or their providers have different heads. For a consistent account
+view, such as a balance and transaction count from the same block, fetch a block
+once and pass its hash to both reads.
 
-Configure `head_policy: global` and its shared journal to also keep later
-block choices from returning a lower height. See
-[Block continuity](BLOCK_CONTINUITY.md) for the scope and freshness bound.
+This is standard Ethereum JSON-RPC. It works with **Block regression protection
+Off**, using your usual Lasso endpoint and authentication. Your providers must
+support the requested methods, block-hash selectors and state history.
 
 ## 1. Choose a block once
 
-Send this standard JSON-RPC request to your profile endpoint:
+The examples use your client's `request({ method, params })` function. It should
+return the JSON-RPC response's `result` and throw on errors. If your client's
+convenience methods do not expose block-hash selectors, use its raw JSON-RPC
+request method.
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "eth_getBlockByNumber",
-  "params": ["latest", false]
+```js
+const block = await request({
+  method: "eth_getBlockByNumber",
+  params: ["latest", false],
+});
+
+if (!block?.number || !block?.hash) {
+  throw new Error("No block is available");
 }
 ```
 
-Keep `result.number` and `result.hash`. A null result or error means the query
-cannot start. If you already have a target, select it as follows:
-
-| Starting point | Request |
-| --- | --- |
-| Latest state | `eth_getBlockByNumber ["latest", false]` |
-| A block number, such as 100 | `eth_getBlockByNumber ["0x64", false]` |
-| A block hash | Keep that hash. Use `eth_getBlockByHash [hash, false]` if you need its number. |
-
-Resolve a number only once per query. Resolving it separately for each read
-can select different hashes across a reorg. An explicit historical target
-remains valid even when it is below the profile's latest floor.
+Keep `block.number` and `block.hash`. A number identifies a height; a hash
+identifies the particular block at that height. A chain reorganization can
+replace a block with a different block at the same height, so use the hash
+when several reads must refer to the same block.
 
 ## 2. Reuse the hash for every read
 
-Pass this object in the method's existing block parameter:
+Replace `address` with the account you want to inspect. Pass the same block
+selector to both methods. `requireCanonical: true` asks the provider to reject
+a block it knows has been removed from the canonical chain:
 
 ```js
+const address = "0x1234567890123456789012345678901234567890";
 const at = { blockHash: block.hash, requireCanonical: true };
-```
 
-The example below uses your client's standard `request({ method, params })`
-operation. Addresses, calldata, and decoding functions belong to your
-application. `block` is the block object selected in step 1.
+const [balance, nonce] = await Promise.all([
+  request({ method: "eth_getBalance", params: [address, at] }),
+  request({ method: "eth_getTransactionCount", params: [address, at] }),
+]);
 
-```js
-// Resolve the proxy before building the calls that depend on it.
-const slot = await request({
-  method: "eth_getStorageAt", params: [proxy, implementationSlot, at]
-});
-const implementation = decodeImplementation(slot);
-const code = await request({
-  method: "eth_getCode", params: [implementation, at]
-});
-
-// Batch independent reads through your existing Multicall encoding.
-const firstRound = await request({
-  method: "eth_call",
-  params: [{ to: multicall, data: encodeIndependentCalls(code) }, at]
-});
-
-// Keep the same target for calls that depend on the first round.
-const result = await request({
-  method: "eth_call",
-  params: [{ to: proxy, data: encodeDependentCall(firstRound) }, at]
-});
-```
-
-Hash selectors are supported for `eth_call`, `eth_getBalance`, `eth_getCode`,
-`eth_getStorageAt`, `eth_getTransactionCount`, and `eth_getProof`. Storage and
-proof reads take the selector as their third parameter; the others take it
-as their second. See [EIP-1898](https://eips.ethereum.org/EIPS/eip-1898).
-
-Apply the selector before **any** discovery starts. Carry it into direct-call
-fallbacks, every Multicall chunk, and background workers. Scope cached state
-and proxy-resolution results to the chain and block hash. A JSON-RPC batch,
-connection, or shared API key cannot supply that query boundary for you.
-
-For a simpler account view, use the same selector for `eth_getBalance` and
-`eth_getCode`. For a historical query, use the hash resolved from your chosen
-number; the pool must include a provider with the required state history.
-
-## 3. Return results with evidence
-
-Use your usual profile URL with header metadata enabled:
-
-```text
-https://your-lasso-host/rpc/profile/<profile-slug>/fastest/1?include_meta=headers
-```
-
-Use any authentication required by your deployment. Core does not manage Cloud
-API keys. At your HTTP transport, capture the
-following for block selection and each state request:
-
-| Response header | Keep it for |
-| --- | --- |
-| `x-lasso-request-id` | Correlating the routed operation with Lasso; use `x-request-id` when no routing context was created. |
-| `x-lasso-meta` | Optional base64url JSON containing routing evidence, including the serving provider when one executed the request. |
-
-The block-selection record's `head_policy` includes the number, hash, age,
-scope, serving instance, and observed chain-change information. A retained
-block response has no executing upstream provider. State responses record
-routing evidence; their scalar results do not independently attest which
-block executed. See [routing evidence](OBSERVABILITY.md).
-
-Retain `service_profile_id` to check that responses belong to the same service
-profile. `profile_id` records the effective routing profile. Core currently uses the
-same file-profile identity for both fields. Both IDs are opaque.
-
-Aggregate the records in your application. For example, **your query API** can
-return this shape while each underlying Ethereum response stays standard:
-
-```js
-return {
-  result,
-  blockNumber: block.number, // Ethereum hex quantity
+console.log({
+  blockNumber: block.number,
   blockHash: block.hash,
-  routing: evidence         // Records collected by your HTTP transport
-};
+  balance,
+  nonce,
+});
 ```
 
-Use individual HTTP RPC responses or on-chain Multicall to collect evidence
-for every operation. One HTTP batch exposes only one item's routing metadata;
-oversized metadata can be omitted. Mark evidence incomplete when any record
-is missing, or fail the query if complete evidence is required.
+Both reads request the state at `block.hash`, even if a new block arrives between
+them. Lasso keeps that hash through routing and retries; it does not silently
+replace it with `latest` or a block number. If the requested state cannot be
+served, the read fails. Keeping the number and hash with the results helps you
+identify the state you read; it does not change the underlying RPC response.
 
-## Handle an interrupted query
+The balance is in wei and the nonce is the account's transaction count at the
+chosen block. Both are returned as hexadecimal quantities. This nonce excludes
+pending transactions; use the usual `pending` request when you need that
+different view.
 
-| Failure | Action |
+You can also send these reads in a JSON-RPC batch, with the same selector on
+**each item**. A batch alone does not give its items a shared block.
+
+## Other methods and block targets
+
+[EIP-1898](https://eips.ethereum.org/EIPS/eip-1898) defines block-hash selectors
+for the following state methods. Your upstream providers must support the
+method and selector; support for an ordinary `latest` call is not sufficient.
+
+| Method | Parameters using the selected block |
 | --- | --- |
-| No fresh block can be selected | Retry selection within a total deadline, or return an availability error. |
-| The chosen state is unavailable | Lasso attempts eligible providers at the same hash within its request budget. If exhausted, fail the query or restart the whole operation. |
-| The block is reported noncanonical or conflicting | Discard partial results. Choose a new block and rerun the complete query if your deadline permits. |
-| A contract call reverts | Handle the application error. A revert alone is not a reorg or a reason to change blocks. |
+| `eth_getBalance` | `[address, at]` |
+| `eth_getTransactionCount` | `[address, at]` |
+| `eth_getCode` | `[address, at]` |
+| `eth_getStorageAt` | `[address, slot, at]` |
+| `eth_call` | `[transaction, at]` |
+| `eth_getProof` | `[address, storageKeys, at]` |
 
-A restarted query must not reuse state-derived discovery or cached values
-from the abandoned block. Never combine partial results from different hashes.
-Applications that need finality should choose a finalized block before reading;
-a successful tip query can still be affected by a later reorg.
+For an older or finalized snapshot, change how you choose the block:
 
-## Executable example
+| Starting point | How to obtain the block hash |
+| --- | --- |
+| Latest block | `eth_getBlockByNumber` with `["latest", false]`. |
+| Finalized block | `eth_getBlockByNumber` with `["finalized", false]`, where the chain and provider support it. |
+| A block number, such as 100 | `eth_getBlockByNumber` with `["0x64", false]`. |
+| A known block hash | Reuse it. Call `eth_getBlockByHash` with `[hash, false]` if you also need the number. |
 
-The optional [logical-read example](../examples/logical-read/README.md) uses
-standard JSON-RPC, viem and SEL, with a shared deadline, hash propagation,
-bounded response evidence and worker handoff. It is an integration reference,
-not a required SDK. Never send credentials with captured evidence.
+Resolve a number to a hash once before reading, rather than separately for each
+call. Historical reads need providers that retain the required state. They can
+target an older block even after protection has accepted a newer height.
+
+## Handle errors and reorganizations
+
+`requireCanonical: true` asks the provider to return an error if it knows the
+block is no longer in its canonical chain. That is the provider's view at the
+time of the request, not a promise that the block can never be reorganized.
+Choose a finalized block when your application requires the chain's finality
+semantics.
+
+| Failure | What to do |
+| --- | --- |
+| Block lookup returns null or an error | Do not start the state reads. Retry within your application's deadline or report the failure. |
+| A provider cannot serve the hash or state | Lasso can try eligible providers at the same target within its request budget. If exhausted, report the failure or start a new snapshot. |
+| The block is reported noncanonical | Discard partial results. If a fresh snapshot is useful, choose a new block and repeat every read. |
+| A contract call reverts | Handle the contract error. A revert alone is not evidence of a reorganization. |
+
+If you start again at another block, do not combine old partial results with the
+new ones. Hash selectors express the requested state; they do not prove that an
+upstream executed it correctly. A provider that silently ignores the selector
+can return incorrect data without revealing the mismatch in a scalar result.
+
+## Optional: protect later refreshes
+
+Selecting one block keeps the reads in a refresh together. To also prevent a
+later latest-block request from returning a lower height on the same running
+Lasso server, enable [Block regression protection](BLOCK_CONTINUITY.md).
+With `head_policy: local`, server-switch and restart recovery is best effort;
+see the protection guide for the separate Global contract. Protection does not
+change explicit historical targets or pin ordinary `latest` state calls
+automatically.
+
+## Optional: inspect routing metadata
+
+Add `?include_meta=headers` to see request IDs, providers and retries while
+preserving the JSON-RPC body. See [routing metadata](OBSERVABILITY.md#response-metadata).
+Neither this recipe nor protection requires metadata collection.
+
+## Contract calls and larger workflows
+
+Use the same `at` selector for `eth_call`, including calls to a Multicall
+contract. If one read determines a later call, keep the hash for that later call
+too. This also applies to proxy discovery, multiple Multicall chunks and work
+sent to another process. Cache state-derived results by chain and block hash.
+
+The optional [logical-read integration example](https://github.com/jaxernst/lasso-rpc/tree/main/examples/logical-read)
+demonstrates a larger workflow with viem, SEL, shared deadlines and workers.


### PR DESCRIPTION
The guides currently present block regression protection and reading several values at one block as one integration, with proxy discovery and Multicall as the main example. An ordinary JSON-RPC user can infer that enabling protection also pins state reads, or that both features require a query engine and metadata collection.

The guides now explain two independent tasks: protecting sequential latest-block responses, and reading an account's balance and transaction count at one chosen hash. The latter explicitly works with protection Off. Examples use the client's standard JSON-RPC request function. Metadata is optional diagnostics, larger application workflows are an appendix, and strict fleet coordination is separate from standard peer sharing.

Two independent reviewers checked first-reader clarity and runtime accuracy, then reviewed the rewritten pages. Their findings are addressed, including exact protected methods, omitted selectors, provider support, pinned batch items, local versus Global recovery, and the provenance limits of recovery metadata. The hosted guides and Cloud/Core source documentation are synchronized.

Validation: Mintlify strict build and broken-link checks pass. All JSON examples parse, the four account examples match, and Markdown links/anchors resolve. The account snippet passes controlled success, missing-block and unavailable-state cases. Only documentation changes; runtime behavior and configuration values are unchanged.
