### PR TITLE
Trim block protection and state-read guides

### DIFF
--- a/docs/BLOCK_CONTINUITY.md
+++ b/docs/BLOCK_CONTINUITY.md
@@ -1,153 +1,37 @@
 # Block regression protection
 
-RPC providers can disagree about the latest block. For example, a block-height
-poll might return 100 from one provider, then 99 from a provider that is behind.
-Block regression protection prevents that step backwards for sequential
-latest-block requests handled by the same running Lasso server.
+Set `head_policy: local` in an existing chain's file-profile configuration.
+Lasso protects successive latest-block responses and shares progress across
+connected instances. `off` is the default; Local needs no publication database.
 
-Use it when polling chain progress or fetching the latest block for your
-application. Your Ethereum JSON-RPC requests and responses stay the same.
+Applies to:
 
-The following sections describe `local` mode. See
-[strict fleet-wide coordination](#optional-strict-fleet-wide-coordination) for
-the separate durable `global` contract.
+- `eth_blockNumber` with `[]`.
+- `eth_getBlockByNumber` with `["latest", false]` or `["latest", true]`.
 
-## Enable protection
+## What to expect
 
-In an existing chain entry in your file profile, set `head_policy: local`:
+After a protected response returns block 100, the next request on the same
+running Lasso server returns **100 or higher, or an error**, even if the upstream
+provider changes. The next request must start after the previous response
+finishes; overlapping requests can finish out of order.
 
-```yaml
-chains:
-  ethereum:
-    head_policy: local
-    # Keep the chain's existing providers and other settings.
-```
+All callers using the same profile and chain share this protection. After a
+server switch or restart, recovery is **best effort**: a lower height remains
+possible.
 
-This is the behavior labeled **Block regression protection: On** in Lasso Cloud.
-`head_policy: off` is the default. Connected RPC Core instances automatically
-share progress to help preserve continuity when requests move between them.
-There is no additional peer-sharing switch and no publication database is
-required for this mode. Configure [clustering](DEPLOYMENT.md#multi-node-clustering) to connect
-self-hosted instances.
+Provider lag, stale blocks or reorganizations can cause retries or errors.
+Retries and connection setup can add latency. Protected blocks must be within
+**60 seconds or four configured block intervals**, whichever is greater;
+protection does not promise the newest block or finality.
 
-For example, continue polling with your existing request:
+## Reading state
 
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "eth_blockNumber",
-  "params": []
-}
-```
+Ordinary `latest` balance and contract calls remain unpinned. Explicit block
+targets stay unchanged through retries, including older blocks. To read several
+values at one block, follow [Read at one block](READ_AT_ONE_BLOCK.md); that works
+with protection Off too.
 
-If a protected response returns `"0x64"` (100), the next request on the same
-running Lasso server returns 100 or higher, or an error. Returning 100 again is
-allowed. You do not need to change your state reads or collect metadata to use
-this setting.
-
-## Which requests are protected?
-
-The setting applies to these latest-block requests:
-
-| Method | Parameters | Result |
-| --- | --- | --- |
-| `eth_blockNumber` | `[]` | A block number. |
-| `eth_getBlockByNumber` | `["latest", false]` | A block with transaction hashes. |
-| `eth_getBlockByNumber` | `["latest", true]` | A block with full transactions. |
-
-It protects the returned **block height**, not values such as balances or
-contract results. For example, `eth_getBalance(address, "latest")` and
-`eth_call(transaction, "latest")` still use ordinary provider routing, as do
-state reads with an omitted block selector. Separate state reads can observe
-different blocks.
-
-Requests for an explicit number or hash keep that target through routing and
-retries, even if it is older than the latest protected height. This works with
-protection On or Off. Other requests, including `safe`, `finalized`, `pending`,
-log ranges and subscriptions, keep their existing semantics.
-
-## What the setting guarantees
-
-Protection applies to requests for the **same profile and chain on the same
-running Lasso server**. All API keys and callers using that profile and chain
-share the protected height; different profiles and chains are independent.
-Here, a Lasso server is the instance routing your request, not an upstream RPC
-provider. Changing providers within that instance preserves the protection.
-
-The next request must start after the previous response finishes. Concurrent
-requests can finish out of height order. The protected height is retained for
-the lifetime of the running application; it survives an internal recovery-worker
-restart, but not loss of the application itself. Calls made while protection is
-Off are outside the guarantee.
-
-After a Lasso server switch or application restart, recovery is **best effort**:
-a lower height remains possible. Servers share progress in the background to
-help choose a suitable provider. Those updates do not impose a mandatory minimum
-on another server. There is no promised recovery time or block-gap bound, and
-disconnected servers or lost history can reduce continuity across the fleet.
-
-## Provider lag, errors and latency
-
-Lasso remembers a minimum accepted height, called the **floor**. Each protected
-request checks a provider response against the floor captured when that request
-starts. If the response is lower, Lasso can try another eligible provider within
-the request's deadline and retry budget. If none succeeds, the request fails
-rather than returning a lower height.
-
-Each protected request fetches a provider response. Advancing the floor adds no
-synchronous database lookup or wait for peer acknowledgments. Local processing,
-provider retries and cold connection setup can still add latency.
-
-A protected block must be no older than the greater of **60 seconds or four
-configured block intervals**, measured from its timestamp. Returning the same
-block again does not renew its age. This does not promise the newest block on
-the network. One provider is enough to enable protection, but it provides no
-fallback if that provider cannot serve an acceptable block.
-
-Protection also rejects a conflicting hash at the captured floor height. A
-chain reorganization can temporarily prevent new protected responses; the floor
-does not reset downwards. Protection does not detect every reorganization,
-establish finality or verify the correctness of a provider's execution results.
-
-## Read several values at the same block
-
-If a page needs a balance and transaction count from the same block, specify
-that block on both reads. Protection does not pin those calls automatically,
-and putting them in a JSON-RPC batch does not select a shared block.
-
-The separate [Read at one block](READ_AT_ONE_BLOCK.md) guide shows this standard
-Ethereum JSON-RPC pattern. It works with protection Off; turning protection On
-also protects the latest-block requests used to start later refreshes.
-
-## Optional: inspect protection metadata
-
-Add `?include_meta=headers` to inspect routing decisions without changing the
-JSON-RPC response body. Protected responses report `head_policy.policy=local`,
-the configuration name for protection with automatic fleet sharing.
-See [protection metadata](OBSERVABILITY.md#block-protection-metadata) for the
-accepted height, server identity and recovery fields. Metadata is diagnostic;
-collecting it is not required for protection.
-
-## Optional: strict fleet-wide coordination
-
-`head_policy: global` provides a different contract: sequential protected
-latest-block requests share a durable floor across all admitted serving
-instances for the same profile and chain. The floor survives application
-restarts. Configure its PostgreSQL journal and serving fleet before enabling it;
-follow the [operating guide](BLOCK_CONTINUITY_OPERATIONS.md).
-
-Global mode can return the retained block number or block with transaction
-hashes without an upstream request. Full-transaction responses still fetch the
-published hash from a provider. The same block-age limit applies. Advancement
-requires coordination, and requests can wait up to one second within their
-deadline during a publication change. Unavailable members or coordination can
-prevent advancement or cause errors. Explicit state reads keep their targets
-and do not wait for publication.
-
-Global publication can report a replacement at the previous selected height as
-`anchor_hash_changed`; this is a provider observation, not complete reorg
-detection or finality. Before changing away from an enrolled Global policy,
-complete coordinated shutdown and retain the journal and member configuration
-as described in the operating guide. A configuration edit alone cannot discard
-its durable contract.
+[Routing metadata](OBSERVABILITY.md#block-protection-metadata) is optional.
+For the separate durable `global` contract, see [fleet operations](BLOCK_CONTINUITY_OPERATIONS.md).
+Enrolled Global scopes require coordinated disablement before changing modes.

--- a/docs/READ_AT_ONE_BLOCK.md
+++ b/docs/READ_AT_ONE_BLOCK.md
@@ -1,144 +1,46 @@
 # Read at one block
 
-Two RPC calls using `latest` can read different blocks if the chain advances
-between calls or their providers have different heads. For a consistent account
-view, such as a balance and transaction count from the same block, fetch a block
-once and pass its hash to both reads.
+Separate `latest` calls can read different blocks. Fetch one block, then reuse
+its hash for every related state read. This standard JSON-RPC pattern works
+with **Block regression protection Off**.
 
-This is standard Ethereum JSON-RPC. It works with **Block regression protection
-Off**, using your usual Lasso endpoint and authentication. Your providers must
-support the requested methods, block-hash selectors and state history.
-
-## 1. Choose a block once
-
-The examples use your client's `request({ method, params })` function. It should
-return the JSON-RPC response's `result` and throw on errors. If your client's
-convenience methods do not expose block-hash selectors, use its raw JSON-RPC
-request method.
+Use your client's `request()` helper, which returns `result` and throws on RPC
+errors. Set `address` to the account you want to read.
 
 ```js
 const block = await request({
   method: "eth_getBlockByNumber",
   params: ["latest", false],
 });
+if (!block?.hash) throw new Error("Block unavailable");
 
-if (!block?.number || !block?.hash) {
-  throw new Error("No block is available");
-}
-```
-
-Keep `block.number` and `block.hash`. A number identifies a height; a hash
-identifies the particular block at that height. A chain reorganization can
-replace a block with a different block at the same height, so use the hash
-when several reads must refer to the same block.
-
-## 2. Reuse the hash for every read
-
-Replace `address` with the account you want to inspect. Pass the same block
-selector to both methods. `requireCanonical: true` asks the provider to reject
-a block it knows has been removed from the canonical chain:
-
-```js
-const address = "0x1234567890123456789012345678901234567890";
 const at = { blockHash: block.hash, requireCanonical: true };
-
 const [balance, nonce] = await Promise.all([
   request({ method: "eth_getBalance", params: [address, at] }),
   request({ method: "eth_getTransactionCount", params: [address, at] }),
 ]);
 
-console.log({
-  blockNumber: block.number,
-  blockHash: block.hash,
-  balance,
-  nonce,
-});
+console.log({ blockHash: block.hash, balance, nonce });
 ```
 
-Both reads request the state at `block.hash`, even if a new block arrives between
-them. Lasso keeps that hash through routing and retries; it does not silently
-replace it with `latest` or a block number. If the requested state cannot be
-served, the read fails. Keeping the number and hash with the results helps you
-identify the state you read; it does not change the underlying RPC response.
+Both values describe the selected block; the nonce excludes pending
+transactions. Reuse `at` for contract calls and dependent reads too. In a
+JSON-RPC batch, put the selector on **every item**.
 
-The balance is in wei and the nonce is the account's transaction count at the
-chosen block. Both are returned as hexadecimal quantities. This nonce excludes
-pending transactions; use the usual `pending` request when you need that
-different view.
+## Essential limits
 
-You can also send these reads in a JSON-RPC batch, with the same selector on
-**each item**. A batch alone does not give its items a shared block.
+- Providers must support [block-hash selectors](https://eips.ethereum.org/EIPS/eip-1898)
+  and retain the requested state. Lasso preserves the hash through retries.
+- `requireCanonical: true` asks the provider to reject a block it knows was
+  removed from the canonical chain. It does not guarantee finality or prove
+  execution correctness.
+- If a read fails and you choose a new block, repeat all related reads. Do not
+  mix results from different hashes.
 
-## Other methods and block targets
+For historical reads, resolve a block number to a hash once. Use `"finalized"`
+instead of `"latest"` when you need the chain's finality semantics and your
+provider supports it.
 
-[EIP-1898](https://eips.ethereum.org/EIPS/eip-1898) defines block-hash selectors
-for the following state methods. Your upstream providers must support the
-method and selector; support for an ordinary `latest` call is not sufficient.
-
-| Method | Parameters using the selected block |
-| --- | --- |
-| `eth_getBalance` | `[address, at]` |
-| `eth_getTransactionCount` | `[address, at]` |
-| `eth_getCode` | `[address, at]` |
-| `eth_getStorageAt` | `[address, slot, at]` |
-| `eth_call` | `[transaction, at]` |
-| `eth_getProof` | `[address, storageKeys, at]` |
-
-For an older or finalized snapshot, change how you choose the block:
-
-| Starting point | How to obtain the block hash |
-| --- | --- |
-| Latest block | `eth_getBlockByNumber` with `["latest", false]`. |
-| Finalized block | `eth_getBlockByNumber` with `["finalized", false]`, where the chain and provider support it. |
-| A block number, such as 100 | `eth_getBlockByNumber` with `["0x64", false]`. |
-| A known block hash | Reuse it. Call `eth_getBlockByHash` with `[hash, false]` if you also need the number. |
-
-Resolve a number to a hash once before reading, rather than separately for each
-call. Historical reads need providers that retain the required state. They can
-target an older block even after protection has accepted a newer height.
-
-## Handle errors and reorganizations
-
-`requireCanonical: true` asks the provider to return an error if it knows the
-block is no longer in its canonical chain. That is the provider's view at the
-time of the request, not a promise that the block can never be reorganized.
-Choose a finalized block when your application requires the chain's finality
-semantics.
-
-| Failure | What to do |
-| --- | --- |
-| Block lookup returns null or an error | Do not start the state reads. Retry within your application's deadline or report the failure. |
-| A provider cannot serve the hash or state | Lasso can try eligible providers at the same target within its request budget. If exhausted, report the failure or start a new snapshot. |
-| The block is reported noncanonical | Discard partial results. If a fresh snapshot is useful, choose a new block and repeat every read. |
-| A contract call reverts | Handle the contract error. A revert alone is not evidence of a reorganization. |
-
-If you start again at another block, do not combine old partial results with the
-new ones. Hash selectors express the requested state; they do not prove that an
-upstream executed it correctly. A provider that silently ignores the selector
-can return incorrect data without revealing the mismatch in a scalar result.
-
-## Optional: protect later refreshes
-
-Selecting one block keeps the reads in a refresh together. To also prevent a
-later latest-block request from returning a lower height on the same running
-Lasso server, enable [Block regression protection](BLOCK_CONTINUITY.md).
-With `head_policy: local`, server-switch and restart recovery is best effort;
-see the protection guide for the separate Global contract. Protection does not
-change explicit historical targets or pin ordinary `latest` state calls
-automatically.
-
-## Optional: inspect routing metadata
-
-Add `?include_meta=headers` to see request IDs, providers and retries while
-preserving the JSON-RPC body. See [routing metadata](OBSERVABILITY.md#response-metadata).
-Neither this recipe nor protection requires metadata collection.
-
-## Contract calls and larger workflows
-
-Use the same `at` selector for `eth_call`, including calls to a Multicall
-contract. If one read determines a later call, keep the hash for that later call
-too. This also applies to proxy discovery, multiple Multicall chunks and work
-sent to another process. Cache state-derived results by chain and block hash.
-
-The optional [logical-read integration example](https://github.com/jaxernst/lasso-rpc/tree/main/examples/logical-read)
-demonstrates a larger workflow with viem, SEL, shared deadlines and workers.
+[Block regression protection](BLOCK_CONTINUITY.md) separately protects successive
+latest-block requests. [Routing metadata](OBSERVABILITY.md#response-metadata)
+is optional.


### PR DESCRIPTION
Cut the main guides by roughly 75% so users can find the setup, example and essential limits quickly. Block regression protection is about 230 words; Read at one block is about 260, including its example. Remove repeated explanations, extra tables and advanced-workflow sections. Existing metadata and fleet-operation references retain the deeper details.

Preserve the exact protected methods, sequential/profile/server scope, best-effort recovery, freshness/error limits, protection-Off independence of explicit reads, provider requirements and reorg handling. Runtime behavior is unchanged.

Validation: Mintlify strict build and broken-link checks pass. The four source/hosted account examples match and pass controlled success, missing-block and unavailable-state checks.
